### PR TITLE
[no ci] backport: fix 61659

### DIFF
--- a/src/Texmacs/Texmacs/texmacs.cpp
+++ b/src/Texmacs/Texmacs/texmacs.cpp
@@ -476,7 +476,7 @@ TeXmacs_main (int argc, char** argv) {
              (s == "-x") || (s == "-execute") ||
              (s == "-log-file") ||
              (s == "-build-manual") ||
-             (s == "-reference-suite") || (s == "-test-suite")) {}
+             (s == "-reference-suite") || (s == "-test-suite")) {i++;}
   }
   if (install_status == 1) {
     if (DEBUG_STD) debug_boot << "Loading welcome message...\n";


### PR DESCRIPTION
Fix https://savannah.gnu.org/bugs/?61659 by Philippe Joyez