### PR TITLE
Use libcurl instead for invoke the curl command line

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake qtbase5-dev libqt5svg5-dev libfreetype6-dev libsqlite3-dev libjpeg-dev
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake qtbase5-dev libqt5svg5-dev libfreetype6-dev libsqlite3-dev libjpeg-dev libcurl4-openssl-dev
       - name: Create Build Dir
         run: mkdir -p ${{github.workspace}}/build
       - name: Build using CMake

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -21,7 +21,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install Dependencies
         run: |
-          brew install freetype libjpeg qt@5 cmake ccache
+          brew install freetype libjpeg qt@5 cmake ccache curl
           brew link qt@5
       - name: Create Build Dir
         run: mkdir -p ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ find_package (PNG)
 find_package (Iconv)
 find_package (ZLIB)
 find_package (JPEG)
+find_package (CURL)
 #FIND_PACKAGE(Axel)
 
 # Allow for selection of Scheme implementation
@@ -396,6 +397,7 @@ endif (WIN32)
 set (TeXmacs_Include_Dirs ${TeXmacs_Include_Dirs}
   ${FREETYPE_INCLUDE_DIRS} ${Cairo_INCLUDE_DIRS}
   ${IMLIB2_INCLUDE_DIR} ${GMP_INCLUDES}
+  ${CURL_INCLUDE_DIRS}
 )
 
 ### --------------------------------------------------------------------
@@ -434,6 +436,7 @@ file (GLOB_RECURSE TeXmacs_Std_Plugins_SRCS
   "${TEXMACS_SOURCE_DIR}/src/Plugins/Openssl/*.cpp"
   "${TEXMACS_SOURCE_DIR}/src/Plugins/Sqlite3/*.cpp"
   "${TEXMACS_SOURCE_DIR}/src/Plugins/Updater/*.cpp"
+  "${TEXMACS_SOURCE_DIR}/src/Plugins/Curl/*.cpp"
 )
 
 file (GLOB_RECURSE TeXmacs_Style_SRCS
@@ -494,6 +497,7 @@ set (TeXmacs_Libraries
   ${ZLIB_LIBRARIES}
   ${JPEG_LIBRARIES}
   ${PNG_LIBRARIES}
+  ${CURL_LIBRARIES}
   -lpthread
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ find_package (PNG)
 find_package (Iconv)
 find_package (ZLIB)
 find_package (JPEG)
-find_package (CURL)
+find_package (CURL REQUIRED)
 #FIND_PACKAGE(Axel)
 
 # Allow for selection of Scheme implementation

--- a/src/Plugins/Curl/curl.cpp
+++ b/src/Plugins/Curl/curl.cpp
@@ -1,0 +1,11 @@
+
+/******************************************************************************
+* MODULE     : curl.cpp
+* DESCRIPTION: interface with CURL
+* COPYRIGHT  : (C) 2022  Darcy Shen
+*******************************************************************************
+* This software falls under the GNU general public license version 3 or later.
+* It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+* in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+******************************************************************************/
+

--- a/src/Plugins/Curl/curl.cpp
+++ b/src/Plugins/Curl/curl.cpp
@@ -9,11 +9,11 @@
 * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ******************************************************************************/
 
-#include "curl.hpp"
+#include "Curl/curl.hpp"
 #include <curl/curl.h>
 
 static size_t write_data (void *ptr, size_t size, size_t nmemb, FILE *stream) {
-    size_t written = fwrite(ptr, size, nmemb, stream);
+    size_t written= fwrite (ptr, size, nmemb, stream);
     return written;
 }
 

--- a/src/Plugins/Curl/curl.cpp
+++ b/src/Plugins/Curl/curl.cpp
@@ -12,12 +12,12 @@
 #include "curl.hpp"
 #include <curl/curl.h>
 
-static size_t write_data(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+static size_t write_data (void *ptr, size_t size, size_t nmemb, FILE *stream) {
     size_t written = fwrite(ptr, size, nmemb, stream);
     return written;
 }
 
-void curl_download(string source, string target, string user_agent) {
+void curl_download (string source, string target, string user_agent) {
   debug_io << "curl --user-agent " << user_agent << " "
            << source << " --output " << target << LF;
   CURL *curl= curl_easy_init ();
@@ -28,9 +28,11 @@ void curl_download(string source, string target, string user_agent) {
     curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, write_data);
     curl_easy_setopt (curl, CURLOPT_WRITEDATA, fp);
     curl_easy_setopt (curl, CURLOPT_USERAGENT, as_charp (user_agent));
-    CURLcode res = curl_easy_perform (curl);
+    CURLcode res= curl_easy_perform (curl);
 
-    curl_easy_cleanup(curl);
-    fclose(fp);
+    curl_easy_cleanup (curl);
+    fclose (fp);
+  } else {
+    debug_io << "Failed to init the easy curl client" << LF;
   }
 }

--- a/src/Plugins/Curl/curl.cpp
+++ b/src/Plugins/Curl/curl.cpp
@@ -9,3 +9,28 @@
 * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ******************************************************************************/
 
+#include "curl.hpp"
+#include <curl/curl.h>
+
+static size_t write_data(void *ptr, size_t size, size_t nmemb, FILE *stream) {
+    size_t written = fwrite(ptr, size, nmemb, stream);
+    return written;
+}
+
+void curl_download(string source, string target, string user_agent) {
+  debug_io << "curl --user-agent " << user_agent << " "
+           << source << " --output " << target << LF;
+  CURL *curl= curl_easy_init ();
+  if (curl) {
+    FILE *fp= fopen (as_charp (target), "wb");
+
+    curl_easy_setopt (curl, CURLOPT_URL, as_charp (source));
+    curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, write_data);
+    curl_easy_setopt (curl, CURLOPT_WRITEDATA, fp);
+    curl_easy_setopt (curl, CURLOPT_USERAGENT, as_charp (user_agent));
+    CURLcode res = curl_easy_perform (curl);
+
+    curl_easy_cleanup(curl);
+    fclose(fp);
+  }
+}

--- a/src/Plugins/Curl/curl.hpp
+++ b/src/Plugins/Curl/curl.hpp
@@ -1,0 +1,11 @@
+
+/******************************************************************************
+* MODULE     : curl.hpp
+* DESCRIPTION: interface with CURL
+* COPYRIGHT  : (C) 2022  Darcy Shen
+*******************************************************************************
+* This software falls under the GNU general public license version 3 or later.
+* It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+* in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+******************************************************************************/
+

--- a/src/Plugins/Curl/curl.hpp
+++ b/src/Plugins/Curl/curl.hpp
@@ -14,6 +14,6 @@
 
 #include <string.hpp>
 
-void curl_download(string source, string target, string user_agent);
+void curl_download (string source, string target, string user_agent);
 
 #endif

--- a/src/Plugins/Curl/curl.hpp
+++ b/src/Plugins/Curl/curl.hpp
@@ -9,3 +9,11 @@
 * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 ******************************************************************************/
 
+#ifndef TM_CURL_H
+#define TM_CURL_H
+
+#include <string.hpp>
+
+void curl_download(string source, string target, string user_agent);
+
+#endif

--- a/src/System/Files/web_files.cpp
+++ b/src/System/Files/web_files.cpp
@@ -87,10 +87,6 @@ get_from_web (url name) {
     tmp_s,
     string("TeXmacs-") * TEXMACS_VERSION);
 
-  //cout << cmd << LF;
-  system (cmd);
-  //cout << "got " << name << " as " << tmp << LF;
-
   if (var_eval_system ("cat " * tmp_s * " 2> /dev/null") == "") {
     remove (tmp);
     return url_none ();

--- a/src/System/Files/web_files.cpp
+++ b/src/System/Files/web_files.cpp
@@ -79,10 +79,8 @@ get_from_web (url name) {
 
   url tmp= url_temp ();
   string tmp_s= escape_sh (concretize (tmp));
-  string cmd= "";
   
-  
-  curl_download(
+  curl_download (
     escape_sh (web_encode (as_string (name))),
     tmp_s,
     string("TeXmacs-") * TEXMACS_VERSION);

--- a/src/System/Files/web_files.cpp
+++ b/src/System/Files/web_files.cpp
@@ -15,6 +15,7 @@
 #include "analyze.hpp"
 #include "hashmap.hpp"
 #include "scheme.hpp"
+#include "Curl/curl.hpp"
 
 #define MAX_CACHED 25
 static int web_nr=0;
@@ -70,41 +71,21 @@ web_encode (string s) {
   return tm_decode (s);
 }
 
-static string
-fetch_tool () {
-  static bool done= false;
-  static string tool= "";
-  if (done) return tool;
-  if (tool == "" && exists_in_path ("wget")) tool= "wget";
-  if (tool == "" && exists_in_path ("curl")) tool= "curl";
-  done= true;
-  return tool;
-}
-
 url
 get_from_web (url name) {
   if (!is_rooted_web (name)) return url_none ();
   url res= get_cache (name);
   if (!is_none (res)) return res;
 
-  string tool= fetch_tool ();
-  if (tool == "") return url_none ();
-  
   url tmp= url_temp ();
   string tmp_s= escape_sh (concretize (tmp));
   string cmd= "";
   
-  if (tool == "wget") {
-    cmd= "wget --header='User-Agent: TeXmacs-" TEXMACS_VERSION "' -q";
-    cmd << " --no-check-certificate --tries=1";
-    cmd << " -O " << tmp_s << " " << escape_sh (web_encode (as_string (name)));
-  }
   
-  if (tool == "curl") {
-    cmd= "curl --user-agent TeXmacs-" TEXMACS_VERSION;
-    cmd << " " << escape_sh (web_encode (as_string (name)));
-    cmd << " --output " << tmp_s;
-  }
+  curl_download(
+    escape_sh (web_encode (as_string (name))),
+    tmp_s,
+    string("TeXmacs-") * TEXMACS_VERSION);
 
   //cout << cmd << LF;
   system (cmd);


### PR DESCRIPTION
## How to test it
Launch mogan via terminal, check on `Debug -> io`.

And then try to open a web file in `Help -> Mogan`. The following debugging meesage will be printed in the console.

```
TeXmacs] debug-io, curl --user-agent TeXmacs-2.1.1 https://gitee.com/XmacsLabs/mogan/raw/main/TeXmacs/doc/about/xmacs/2019年全国高中数学联合竞赛一试试题A卷.tm --output /home/sadhen/.Xmacs/system/tmp/93518/tmp_1951389520
```

## Why
The current impl actually work only on macOS and Linux. In this pull request, I decide only replace the curl command line invoke with libcurl. And later, I will submit the follow-up pull requests to:
+ make it work on Windows
+ correctly handle the exceptions
