### PR TITLE
copy image to current folder when pasting image from the clipboard

### DIFF
--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -305,7 +305,7 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
   }
   if (input_format == "picture") {
     tree t (IMAGE);
-    auto img = qvariant_cast<QImage>(md->imageData());
+    QImage img = qvariant_cast<QImage>(md->imageData());
     QSize size= img.size ();
     int ww= size.width (), hh= size.height ();
 #ifdef OS_MACOS

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -316,8 +316,8 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
     qt_pretty_image_size (ww, hh, w, h);
     if (get_preference("copy image to current folder") == "on") {
       string doc_path = as_string(get_current_buffer());
-      // e.g. 20220402114852693Sat
-      QString cur_time_str = QDateTime::currentDateTime().toString("yyyyMMddhhmmsszzzddd");
+      // e.g. 20220402114852693
+      QString cur_time_str = QDateTime::currentDateTime().toString("yyyyMMddhhmmsszzz");
       QString tmp_image_name = QString("img_%1.png").arg(cur_time_str);
       QString tmp_image_dir = QFileInfo(to_qstring(doc_path)).absolutePath();
       QString tmp_image_path = QString("%1/%2").arg(tmp_image_dir).arg(tmp_image_name);

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -323,10 +323,12 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
       QString tmp_image_path= QString ("%1/%2").arg (tmp_image_dir)
                                    .arg (tmp_image_name);
       bool ok= img.save (tmp_image_path);
+      debug_io << "save tmp image to: " << from_qstring(tmp_image_path) << LF;
       if (ok) {
         t= tree (IMAGE, from_qstring (tmp_image_name), w, h, "", "");
       } else {
         // insert raw data if fail
+        debug_io << "save tmp image fail, insert raw data" << LF;
         t << tuple (tree (RAW_DATA, s), "png") << w << h << "" << "";
       }
     } else {

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -305,7 +305,7 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
   }
   if (input_format == "picture") {
     tree t (IMAGE);
-    QImage img= qvariant_cast<QImage>(md->imageData());
+    QImage img= qvariant_cast<QImage>(md->imageData ());
     QSize size= img.size ();
     int ww= size.width (), hh= size.height ();
 #ifdef OS_MACOS
@@ -315,15 +315,16 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
     string w, h;
     qt_pretty_image_size (ww, hh, w, h);
     if (get_preference("copy image to current folder") == "on") {
-      string doc_path= as_string(get_current_buffer());
+      string doc_path= as_string (get_current_buffer ());
       // e.g. 20220402114852693
-      QString cur_time_str= QDateTime::currentDateTime().toString("yyyyMMddhhmmsszzz");
-      QString tmp_image_name= QString("img_%1.png").arg(cur_time_str);
-      QString tmp_image_dir= QFileInfo(to_qstring(doc_path)).absolutePath();
-      QString tmp_image_path= QString("%1/%2").arg(tmp_image_dir).arg(tmp_image_name);
-      bool ok= img.save(tmp_image_path);
+      QString cur_time_str= QDateTime::currentDateTime().toString ("yyyyMMddhhmmsszzz");
+      QString tmp_image_name= QString ("img_%1.png").arg (cur_time_str);
+      QString tmp_image_dir= QFileInfo (to_qstring (doc_path)).absolutePath ();
+      QString tmp_image_path= QString ("%1/%2").arg (tmp_image_dir)
+                                   .arg (tmp_image_name);
+      bool ok= img.save (tmp_image_path);
       if (ok) {
-        t= tree(IMAGE, from_qstring(tmp_image_name), w, h, "", "");
+        t= tree (IMAGE, from_qstring (tmp_image_name), w, h, "", "");
       } else {
         // insert raw data if fail
         t << tuple (tree (RAW_DATA, s), "png") << w << h << "" << "";

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -319,7 +319,7 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
     if ((get_preference ("copy image to current folder") == "on")
         && !is_rooted_web (doc_url)
         && !is_rooted_tmfs (doc_url)
-        && descends (doc_url, url_system ("$TEXMACS_PATH"))) {
+        && !descends (doc_url, url_system ("$TEXMACS_PATH"))) {
       // e.g. 20220402114852693
       QString cur_time_str= QDateTime::currentDateTime().toString ("yyyyMMddhhmmsszzz");
       QString tmp_image_name= QString ("img_%1.png").arg (cur_time_str);

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -314,8 +314,15 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
 #endif
     string w, h;
     qt_pretty_image_size (ww, hh, w, h);
-    if (get_preference("copy image to current folder") == "on") {
-      string doc_path= as_string (get_current_buffer ());
+    bool need_save_img= (get_preference("copy image to current folder") == "on");
+    string doc_path= as_string (get_current_buffer ());
+    // only local document save image
+    if (starts (doc_path, "tmfs://")
+        || starts (doc_path, "http://")
+        || starts (doc_path, "https://")) {
+      need_save_img= false;
+    }
+    if (need_save_img) {
       // e.g. 20220402114852693
       QString cur_time_str= QDateTime::currentDateTime().toString ("yyyyMMddhhmmsszzz");
       QString tmp_image_name= QString ("img_%1.png").arg (cur_time_str);

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -314,19 +314,16 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
 #endif
     string w, h;
     qt_pretty_image_size (ww, hh, w, h);
-    bool need_save_img= (get_preference("copy image to current folder") == "on");
-    string doc_path= as_string (get_current_buffer ());
+    url doc_url= get_current_buffer ();
     // only local document save image
-    if (starts (doc_path, "tmfs://")
-        || starts (doc_path, "http://")
-        || starts (doc_path, "https://")) {
-      need_save_img= false;
-    }
-    if (need_save_img) {
+    if ((get_preference ("copy image to current folder") == "on")
+        && !is_rooted_web (doc_url)
+        && !is_rooted_tmfs (doc_url)
+        && descends (doc_url, url_system ("$TEXMACS_PATH"))) {
       // e.g. 20220402114852693
       QString cur_time_str= QDateTime::currentDateTime().toString ("yyyyMMddhhmmsszzz");
       QString tmp_image_name= QString ("img_%1.png").arg (cur_time_str);
-      QString tmp_image_dir= QFileInfo (to_qstring (doc_path)).absolutePath ();
+      QString tmp_image_dir= QFileInfo (to_qstring (as_string (doc_url))).absolutePath ();
       QString tmp_image_path= QString ("%1/%2").arg (tmp_image_dir)
                                    .arg (tmp_image_name);
       bool ok= img.save (tmp_image_path);

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -305,7 +305,7 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
   }
   if (input_format == "picture") {
     tree t (IMAGE);
-    QImage img = qvariant_cast<QImage>(md->imageData());
+    QImage img= qvariant_cast<QImage>(md->imageData());
     QSize size= img.size ();
     int ww= size.width (), hh= size.height ();
 #ifdef OS_MACOS
@@ -315,15 +315,15 @@ qt_gui_rep::get_selection (string key, tree& t, string& s, string format) {
     string w, h;
     qt_pretty_image_size (ww, hh, w, h);
     if (get_preference("copy image to current folder") == "on") {
-      string doc_path = as_string(get_current_buffer());
+      string doc_path= as_string(get_current_buffer());
       // e.g. 20220402114852693
-      QString cur_time_str = QDateTime::currentDateTime().toString("yyyyMMddhhmmsszzz");
-      QString tmp_image_name = QString("img_%1.png").arg(cur_time_str);
-      QString tmp_image_dir = QFileInfo(to_qstring(doc_path)).absolutePath();
-      QString tmp_image_path = QString("%1/%2").arg(tmp_image_dir).arg(tmp_image_name);
-      bool ok = img.save(tmp_image_path);
+      QString cur_time_str= QDateTime::currentDateTime().toString("yyyyMMddhhmmsszzz");
+      QString tmp_image_name= QString("img_%1.png").arg(cur_time_str);
+      QString tmp_image_dir= QFileInfo(to_qstring(doc_path)).absolutePath();
+      QString tmp_image_path= QString("%1/%2").arg(tmp_image_dir).arg(tmp_image_name);
+      bool ok= img.save(tmp_image_path);
       if (ok) {
-        t = tree(IMAGE, from_qstring(tmp_image_name), w, h, "", "");
+        t= tree(IMAGE, from_qstring(tmp_image_name), w, h, "", "");
       } else {
         // insert raw data if fail
         t << tuple (tree (RAW_DATA, s), "png") << w << h << "" << "";


### PR DESCRIPTION
## Overview

Give an option like Typora,

![image](https://user-images.githubusercontent.com/18223871/161365467-d6f97015-ea93-483f-a5d4-5a463be77f01.png)

But now, only support `copy image to current folder`.


## How to test
add the following scheme code to your `init-buffer.scm`

```scm
(define (notify-julia-syntax2 var val)
  ())

(define-preferences
  ("copy image to current folder" "on" notify-julia-syntax2))
```
Is there a more elegant way to change user preferences? 😭

## Why

I just want to provide an option
separate binary data and plain text.

## snapshot

![image](https://user-images.githubusercontent.com/18223871/161365829-5d3f5686-3da0-41a0-814e-12dd1a0d6eb3.png)
