### PR TITLE
[no ci] add copy cut paste to context menu

### DIFF
--- a/TeXmacs/progs/generic/generic-menu.scm
+++ b/TeXmacs/progs/generic/generic-menu.scm
@@ -648,6 +648,16 @@
   (dynamic (focus-label-menu t)))
 
 (tm-menu (focus-menu)
+  (when (or (selection-active-any?)
+  	    (and (in-graphics?)
+  		 (graphics-selection-active?)))
+  ("Copy" (kbd-copy))
+  ("Cut" (kbd-cut)))
+  ("Paste" (kbd-paste))
+  (when (selection-active-any?)
+      (=> "Export selection as image"
+          (link export-as-image-menu)))
+  ---
   (dynamic (standard-focus-menu (focus-tree))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/TeXmacs/progs/generic/generic-menu.scm
+++ b/TeXmacs/progs/generic/generic-menu.scm
@@ -651,8 +651,8 @@
   (when (or (selection-active-any?)
   	    (and (in-graphics?)
   		 (graphics-selection-active?)))
-  ("Copy" (kbd-copy))
-  ("Cut" (kbd-cut)))
+    ("Copy" (kbd-copy))
+    ("Cut" (kbd-cut)))
   ("Paste" (kbd-paste))
   (when (selection-active-any?)
       (=> "Export selection as image"


### PR DESCRIPTION
before

![image](https://user-images.githubusercontent.com/18223871/161671813-4c66bcfe-2d90-4bf6-9007-7788079010b3.png)

after 

![image](https://user-images.githubusercontent.com/18223871/161672422-223ad35c-d93f-4a61-8e78-3d98664ea705.png)



the code from `edit-menu.scm`


why do the following codes cause crashes when removing them?


```
  (when (or (selection-active-any?)
  	    (and (in-graphics?)
  		 (graphics-selection-active?)))
```


