### PR TITLE
initial support for Qt 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ if (TEXMACS_GUI MATCHES "Qt.*")
             Qt${QT_VERSION_MAJOR}::PrintSupport
             Qt${QT_VERSION_MAJOR}::Svg
             )
-    if (APPLE)
+    if (APPLE AND ${QT_VERSION_MAJOR} LESS_EQUAL 5)
       find_package (Qt5 COMPONENTS MacExtras REQUIRED)
       set (QT_LIBRARIES ${QT_LIBRARIES} Qt5::MacExtras)
     endif ()
@@ -758,7 +758,8 @@ option (BUILD_TESTS "Build unit tests" OFF)
 
 if (BUILD_TESTS)
   include (CTest)
-  find_package(Qt5Test REQUIRED)
+  find_package(QT NAMES Qt6 Qt5 COMPONENTS Test REQUIRED)
+  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
   enable_testing ()
   add_subdirectory (tests)
   # add_subdirectory (misc/benchmark)

--- a/src/Plugins/MacOS/mac_utilities.mm
+++ b/src/Plugins/MacOS/mac_utilities.mm
@@ -106,7 +106,7 @@ mac_handler_body (NSEvent *event) {
       unichar key = [nss characterAtIndex:0];
       if ((key == NSTabCharacter) || (key == NSBackTabCharacter) ) {
         NSUInteger nsmods = [event modifierFlags];
-        Qt::KeyboardModifiers modifs = 0;
+        Qt::KeyboardModifiers modifs = Qt::NoModifier;
         if (key == NSBackTabCharacter) modifs |= Qt::ShiftModifier;
         if (nsmods &  NSControlKeyMask) modifs |= Qt::MetaModifier;
         if (nsmods &  NSAlternateKeyMask) modifs |= Qt::AltModifier;

--- a/src/Plugins/MacOS/mac_utilities.mm
+++ b/src/Plugins/MacOS/mac_utilities.mm
@@ -130,7 +130,7 @@ mac_handler_body (NSEvent *event) {
       }
       if (key == 0x0051 || key == 0x0071) {
         NSUInteger nsmods = [event modifierFlags];
-        Qt::KeyboardModifiers modifs = 0;
+        Qt::KeyboardModifiers modifs = Qt::NoModifier;
         if (key == NSBackTabCharacter) modifs |= Qt::ShiftModifier;
         if (nsmods &  NSControlKeyMask) modifs |= Qt::MetaModifier;
         if (nsmods &  NSAlternateKeyMask) modifs |= Qt::AltModifier;

--- a/src/Plugins/Qt/QTMApplication.hpp
+++ b/src/Plugins/Qt/QTMApplication.hpp
@@ -24,7 +24,7 @@ void init_style_sheet (QApplication* app);
 void set_standard_style_sheet (QWidget *w);
 
 #ifdef Q_OS_MAC
-
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 #include <QMacPasteboardMime>
 
 // On MacOS we have to register appropriate mime types for PDF files
@@ -79,6 +79,7 @@ public:
   }
 };
 #endif
+#endif
 
 
 /*
@@ -108,7 +109,9 @@ class QTMApplication: public QApplication {
   Q_OBJECT
   
 #ifdef Q_OS_MAC
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   QMacPasteboardMimePDF mac_pasteboard_mime_pdf;
+#endif
 #endif
   
 public:

--- a/src/Plugins/Qt/QTMMenuHelper.cpp
+++ b/src/Plugins/Qt/QTMMenuHelper.cpp
@@ -1000,7 +1000,12 @@ QTMComboBox::addItemsAndResize (const QStringList& texts, string ww, string hh) 
   QComboBox::addItems (texts);
   
     ///// Calculate the minimal contents size:
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   calcSize = QApplication::globalStrut ();
+#else
+  // see https://doc.qt.io/qt-5/qapplication-obsolete.html#globalStrut-prop
+  // no replacement of QApplication::globalStrut
+#endif
   const QFontMetrics& fm = fontMetrics ();
   
   for (int i = 0; i < count(); ++i) {

--- a/src/Plugins/Qt/QTMMenuHelper.cpp
+++ b/src/Plugins/Qt/QTMMenuHelper.cpp
@@ -806,7 +806,10 @@ QTMRefreshWidget::QTMRefreshWidget (qt_widget _tmwid, string _strwid, string _ki
                    this, SLOT (doRefresh (string)));
   QVBoxLayout* l = new QVBoxLayout (this);
   l->setContentsMargins (0, 0, 0, 0);
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+  // https://doc.qt.io/qt-5/qlayout-obsolete.html#setMargin
   l->setMargin (0);
+#endif
   setLayout (l);
   
   doRefresh ("init");
@@ -894,7 +897,9 @@ QTMRefreshableWidget::QTMRefreshableWidget (qt_widget _tmwid, object _prom, stri
                    this, SLOT (doRefresh (string)));
   QVBoxLayout* l = new QVBoxLayout (this);
   l->setContentsMargins (0, 0, 0, 0);
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   l->setMargin (0);
+#endif
   setLayout (l);
   
   doRefresh ("init");

--- a/src/Plugins/Qt/QTMPrintDialog.hpp
+++ b/src/Plugins/Qt/QTMPrintDialog.hpp
@@ -25,7 +25,7 @@
 #include <QtGlobal>
 #include <QtCore/QLocale>
 #include <QtCore/QVariant>
-#include <QtWidgets/QAction>
+#include <QAction>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QButtonGroup>
 #include <QtWidgets/QCheckBox>

--- a/src/Plugins/Qt/QTMPrinterSettings.cpp
+++ b/src/Plugins/Qt/QTMPrinterSettings.cpp
@@ -153,19 +153,19 @@ QTMPrinterSettings::getChoices(DriverChoices _which, int& _default) {
   QStringList _ret;
   switch (_which) {
     case PageSize:
-      _ret = printerOptions["PageSize"].split(" ", Qt::SkipEmptyParts);
+      _ret = printerOptions["PageSize"].split(" ", QString::SkipEmptyParts);
       break;
     case Resolution:
-      _ret = printerOptions["Resolution"].split(" ", Qt::SkipEmptyParts);
+      _ret = printerOptions["Resolution"].split(" ", QString::SkipEmptyParts);
       break;
     case Duplex:
-      _ret = printerOptions["Duplex"].split(" ", Qt::SkipEmptyParts);
+      _ret = printerOptions["Duplex"].split(" ", QString::SkipEmptyParts);
       break;
     case ColorModel:
-      _ret = printerOptions["ColorModel"].split(" ", Qt::SkipEmptyParts);
+      _ret = printerOptions["ColorModel"].split(" ", QString::SkipEmptyParts);
       break;
     case Collate:
-      _ret = printerOptions["Collate"].split(" ", Qt::SkipEmptyParts);
+      _ret = printerOptions["Collate"].split(" ", QString::SkipEmptyParts);
       break;
   }
   

--- a/src/Plugins/Qt/QTMPrinterSettings.cpp
+++ b/src/Plugins/Qt/QTMPrinterSettings.cpp
@@ -150,19 +150,19 @@ QTMPrinterSettings::getChoices(DriverChoices _which, int& _default) {
   QStringList _ret;
   switch (_which) {
     case PageSize:
-      _ret = printerOptions["PageSize"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["PageSize"].split(" ", Qt::SkipEmptyParts);
       break;
     case Resolution:
-      _ret = printerOptions["Resolution"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["Resolution"].split(" ", Qt::SkipEmptyParts);
       break;
     case Duplex:
-      _ret = printerOptions["Duplex"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["Duplex"].split(" ", Qt::SkipEmptyParts);
       break;
     case ColorModel:
-      _ret = printerOptions["ColorModel"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["ColorModel"].split(" ", Qt::SkipEmptyParts);
       break;
     case Collate:
-      _ret = printerOptions["Collate"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["Collate"].split(" ", Qt::SkipEmptyParts);
       break;
   }
   

--- a/src/Plugins/Qt/QTMPrinterSettings.cpp
+++ b/src/Plugins/Qt/QTMPrinterSettings.cpp
@@ -151,21 +151,27 @@ QTMPrinterSettings::qStringToQtPaperSize(const QString& _size) {
 QStringList
 QTMPrinterSettings::getChoices(DriverChoices _which, int& _default) {
   QStringList _ret;
+
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+  QString::SplitBehavior behavior = QString::SkipEmptyParts;
+#else
+  Qt::SplitBehavior behavior = Qt::SkipEmptyParts;
+#endif
   switch (_which) {
     case PageSize:
-      _ret = printerOptions["PageSize"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["PageSize"].split(" ", behavior);
       break;
     case Resolution:
-      _ret = printerOptions["Resolution"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["Resolution"].split(" ", behavior);
       break;
     case Duplex:
-      _ret = printerOptions["Duplex"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["Duplex"].split(" ", behavior);
       break;
     case ColorModel:
-      _ret = printerOptions["ColorModel"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["ColorModel"].split(" ", behavior);
       break;
     case Collate:
-      _ret = printerOptions["Collate"].split(" ", QString::SkipEmptyParts);
+      _ret = printerOptions["Collate"].split(" ", behavior);
       break;
   }
   

--- a/src/Plugins/Qt/QTMPrinterSettings.hpp
+++ b/src/Plugins/Qt/QTMPrinterSettings.hpp
@@ -98,10 +98,13 @@ public:
    *  second the queue name.
    */
   virtual QList<QPair<QString,QString> > availablePrinters() = 0;
-  
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   static QString qtPaperSizeToQString(const QPrinter::PaperSize);
   static QPrinter::PaperSize qStringToQtPaperSize(const QString&);
-
+#else
+  static QString qtPaperSizeToQString(const QPageSize::PageSizeId);
+  static QPageSize::PageSizeId qStringToQtPaperSize(const QString&);
+#endif
 signals:
   void doneReading();
 

--- a/src/Plugins/Qt/QTMScrollView.cpp
+++ b/src/Plugins/Qt/QTMScrollView.cpp
@@ -68,8 +68,13 @@ QTMScrollView::QTMScrollView (QWidget *_parent):
 
   p_surface = new QTMSurface (_viewport, this);
   p_surface->setAttribute(Qt::WA_NoSystemBackground);
-  p_surface->setAttribute(Qt::WA_StaticContents); 
+  p_surface->setAttribute(Qt::WA_StaticContents);
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   p_surface->setAttribute(Qt::WA_MacNoClickThrough);
+#else
+  // This value is obsolete and has no effect.
+  // see https://doc.qt.io/qt-5/qt.html#WidgetAttribute-enum
+#endif
   p_surface->setAutoFillBackground(false);
   p_surface->setBackgroundRole(QPalette::NoRole);
   p_surface->setAttribute(Qt::WA_OpaquePaintEvent);

--- a/src/Plugins/Qt/QTMStyle.cpp
+++ b/src/Plugins/Qt/QTMStyle.cpp
@@ -281,8 +281,15 @@ void
 QTMStyle::drawPrimitive (PrimitiveElement element, const QStyleOption *opt, QPainter *p, const QWidget *widget) const {
   //  if (element == QStyle::PE_FrameStatusBarItem) return;
   switch (element) {
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
     case PE_FrameStatusBar : 
       return;
+#else
+    // Use PE_FrameStatusBarItem instead.
+    // see https://doc.qt.io/qt-5/qstyle.html
+    case PE_FrameStatusBarItem :
+      return;
+#endif
     case PE_PanelButtonTool:
       if ((opt->state & (State_Sunken | State_On))) {
         qtmDrawShadeRoundPanel(p, opt->rect,  QPalette(opt->palette.color(QPalette::Mid)),//opt->palette,

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -424,7 +424,7 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
 #if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
               ((mods & (Qt::MetaModifier + Qt::ControlModifier)) == 0)) {
 #else
-              ((mods & (int(Qt::MetaModifier) + int(Qt::ControlModifier))) == 0)) {
+              ((mods & (Qt::MetaModifier | Qt::ControlModifier)) == 0)) {
 #endif
             if ((mods & Qt::ShiftModifier) == 0 && key >= 65 && key <= 90)
               key += 32;

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -421,7 +421,11 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
                ((int) (unsigned char) r[0]) < 32 ||
                ((int) (unsigned char) r[0]) >= 128) &&
               key >= 32 && key < 128 &&
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
               ((mods & (Qt::MetaModifier + Qt::ControlModifier)) == 0)) {
+#else
+              ((mods & (int(Qt::MetaModifier) + int(Qt::ControlModifier))) == 0)) {
+#endif
             if ((mods & Qt::ShiftModifier) == 0 && key >= 65 && key <= 90)
               key += 32;
             qtcomposemap (key)= r;

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -573,7 +573,12 @@ QTMWidget::inputMethodEvent (QInputMethodEvent* event) {
 QVariant 
 QTMWidget::inputMethodQuery (Qt::InputMethodQuery query) const {
   switch (query) {
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+    // This query is obsolete. Use ImCursorRectangle instead.
     case Qt::ImMicroFocus : {
+#else
+    case Qt::ImCursorRectangle : {
+#endif
       const QPoint &topleft= cursor_pos - tm_widget()->backing_pos + surface()->geometry().topLeft();
       return QVariant (QRect (topleft, QSize (5, 5)));
     }

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -462,7 +462,11 @@ mouse_state (QMouseEvent* event, bool flag) {
   Qt::KeyboardModifiers kstate= event->modifiers ();
   if (flag) bstate= bstate | tstate;
   if ((bstate & Qt::LeftButton     ) != 0) i += 1;
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   if ((bstate & Qt::MidButton      ) != 0) i += 2;
+#else
+  if ((bstate & Qt::MiddleButton   ) != 0) i += 2;
+#endif
   if ((bstate & Qt::RightButton    ) != 0) i += 4;
   if ((bstate & Qt::XButton1       ) != 0) i += 8;
   if ((bstate & Qt::XButton2       ) != 0) i += 16;
@@ -621,7 +625,11 @@ tablet_state (QTabletEvent* event, bool flag) {
   Qt::MouseButton  tstate= event->button ();
   if (flag) bstate= bstate | tstate;
   if ((bstate & Qt::LeftButton     ) != 0) i += 1;
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   if ((bstate & Qt::MidButton      ) != 0) i += 2;
+#else
+  if ((bstate & Qt::MiddleButton   ) != 0) i += 2;
+#endif
   if ((bstate & Qt::RightButton    ) != 0) i += 4;
   if ((bstate & Qt::XButton1       ) != 0) i += 8;
   if ((bstate & Qt::XButton2       ) != 0) i += 16;

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -246,9 +246,14 @@ QTMWidget::resizeEventBis (QResizeEvent *event) {
 void
 QTMWidget::paintEvent (QPaintEvent* event) {
   QPainter p (surface());
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   QVector<QRect> rects = event->region().rects();
   for (int i = 0; i < rects.count(); ++i) {
     QRect qr = rects.at (i);
+#else
+  for (const QRect* it = event->region().begin(); it != event->region().end(); it++) {
+    QRect qr = *it;
+#endif
     p.drawPixmap (QRect (qr.x(), qr.y(), qr.width(), qr.height()),
                   tm_widget()->backingPixmap,
                   QRect (retina_factor * qr.x(),

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -830,7 +830,13 @@ QTMWidget::dropEvent (QDropEvent *event) {
 void
 QTMWidget::wheelEvent(QWheelEvent *event) {
   if (QApplication::keyboardModifiers() == Qt::ControlModifier) {
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+    // see https://doc.qt.io/qt-5/qwheelevent-obsolete.html#delta
     if (event->delta() > 0) {
+#else
+    QPoint numDegrees = event->angleDelta() / 8;
+    if (numDegrees.y() > 0) {
+#endif
       call ("zoom-in", object (sqrt (sqrt (2.0))));
     } else {
       call ("zoom-out", object (sqrt (sqrt (2.0))));

--- a/src/Plugins/Qt/qt_chooser_widget.cpp
+++ b/src/Plugins/Qt/qt_chooser_widget.cpp
@@ -207,7 +207,7 @@ void
 qt_chooser_widget_rep::perform_dialog () {
   QString caption = to_qstring (win_title);
   c_string tmp (directory * "/" * file);
-  QString path = QString::fromUtf8 (tmp);
+  QString path = QString::fromUtf8 (tmp, -1);
   
 #if (defined(Q_OS_MAC) )// || defined(Q_WS_WIN)) //at least windows Xp and 7 lack image preview, switch to custom dialog
   QFileDialog* dialog = new QFileDialog (NULL, caption, path);

--- a/src/Plugins/Qt/qt_font.cpp
+++ b/src/Plugins/Qt/qt_font.cpp
@@ -88,7 +88,11 @@ void
 qt_font_rep::get_extents (string s, metric& ex) {
   QString qs  = utf8_to_qstring (cork_to_utf8 (s));
   QRectF  rect= qfm.tightBoundingRect (qs);
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   qreal   w   = qfm.width (qs);
+#else
+  qreal   w   = qfm.horizontalAdvance (qs);
+#endif
   ex->x1= 0;
   ex->x2= ROUND (w);
   ex->y1= FLOOR (-rect.bottom ());

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -483,8 +483,12 @@ qt_gui_rep::show_wait_indicator (widget w, string message, string arg)  {
     waitWindow->close();
   }
   qApp->processEvents();
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+  // see https://doc.qt.io/qt-5/qcoreapplication-obsolete.html#flush
   QApplication::flush();
-  
+#else
+
+#endif
   wid->qwid->activateWindow ();
   send_keyboard_focus (wid);
     // next time we do update the dialog will disappear

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -191,11 +191,7 @@ qt_gui_rep::get_extents (SI& width, SI& height) {
   // see https://doc.qt.io/qt-5/qapplication-obsolete.html#desktop
   coord2 size = from_qsize (QApplication::desktop()->size());
 #else
-  QList<QScreen*> screens= QApplication::screens();
-  coord2 size(0, 0);
-  if (!screens.empty()) {
-    size= from_qsize(screens[0]->size());
-  }
+  coord2 size= from_qsize(QApplication::primaryScreen()->availableSize());
 #endif
   width  = size.x1;
   height = size.x2;

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -341,7 +341,7 @@ qt_gui_rep::set_selection (string key, tree t,
   cb->clear (mode);
   
   c_string selection (s);
-  cb->setText (QString::fromLatin1 (selection), mode);
+  cb->setText (QString::fromLatin1 (selection, -1), mode);
   QMimeData *md = new QMimeData;
   
   if (format == "verbatim" || format == "default") {
@@ -365,21 +365,21 @@ qt_gui_rep::set_selection (string key, tree t,
       enc = get_locale_charset ();
     
     if (enc == "utf-8" || enc == "UTF-8")
-      md->setText (QString::fromUtf8 (selection));
+      md->setText (QString::fromUtf8 (selection, -1));
     else if (enc == "iso-8859-1" || enc == "ISO-8859-1")
-      md->setText (QString::fromLatin1 (selection));
+      md->setText (QString::fromLatin1 (selection, -1));
     else
-      md->setText (QString::fromLatin1 (selection));
+      md->setText (QString::fromLatin1 (selection, -1));
   }
   else if (format == "latex") {
     string enc = get_preference ("texmacs->latex:encoding"); 
     if (enc == "utf-8" || enc == "UTF-8" || enc == "cork")
       md->setText (to_qstring (string (selection)));
     else
-      md->setText (QString::fromLatin1 (selection));
+      md->setText (QString::fromLatin1 (selection, -1));
   }
   else
-    md->setText (QString::fromLatin1 (selection));
+    md->setText (QString::fromLatin1 (selection, -1));
   cb->setMimeData (md, mode);
     // according to the docs, ownership of mimedata is transferred to clipboard
     // so no memory leak here

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -28,8 +28,10 @@
 #include "qt_renderer.hpp" // for the_qt_renderer
 #include "qt_simple_widget.hpp"
 #include "qt_window_widget.hpp"
-
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+// see https://doc.qt.io/qt-6/widgets-changes-qt6.html
 #include <QDesktopWidget>
+#endif
 #include <QClipboard>
 #include <QBuffer>
 #include <QFileOpenEvent>
@@ -45,7 +47,9 @@
 #include <QLibraryInfo>
 #include <QImage>
 #include <QUrl>
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 #include <QDesktopWidget>
+#endif
 #include <QApplication>
 
 #include "QTMGuiHelper.hpp"

--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -187,7 +187,16 @@ needing_update (false)
 /* important routines */
 void
 qt_gui_rep::get_extents (SI& width, SI& height) {
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+  // see https://doc.qt.io/qt-5/qapplication-obsolete.html#desktop
   coord2 size = from_qsize (QApplication::desktop()->size());
+#else
+  QList<QScreen*> screens= QApplication::screens();
+  coord2 size(0, 0);
+  if (!screens.empty()) {
+    size= from_qsize(screens[0]->size());
+  }
+#endif
   width  = size.x1;
   height = size.x2;
 }

--- a/src/Plugins/Qt/qt_pipe_link.cpp
+++ b/src/Plugins/Qt/qt_pipe_link.cpp
@@ -147,7 +147,12 @@ qt_pipe_link_rep::interrupt () {
   // Not implemented
   qt_error << "SIGINT not implemented on Windows\n";
 #else
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   Q_PID pid = PipeLink.pid ();
+#else
+  // see https://doc.qt.io/qt-5/qprocess-obsolete.html#pid
+  qint64 pid = PipeLink.processId();
+#endif
   
   // REMARK: previously there were here below a call to ::killpg which does not seems to work on MacOS
   // I (mgubi) replaced it with ::kill which does the job. But I do not undestand the difference.

--- a/src/Plugins/Qt/qt_renderer.cpp
+++ b/src/Plugins/Qt/qt_renderer.cpp
@@ -319,7 +319,11 @@ qt_renderer_rep::clear (SI x1, SI y1, SI x2, SI y2) {
   decode (x2, y2);
   if ((x1>=x2) || (y1<=y2)) return;
   QBrush br (to_qcolor (bg_brush->get_color ()));
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   painter->setRenderHints (0);
+#else
+  painter->setRenderHints(QPainter::Antialiasing);
+#endif
   painter->fillRect (x1, y2, x2-x1, y1-y2, br);       
 }
 
@@ -345,7 +349,11 @@ qt_renderer_rep::fill (SI x1, SI y1, SI x2, SI y2) {
   decode (x2, y2);
 
   QBrush br (to_qcolor (pen->get_color ()));
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   painter->setRenderHints (0);
+#else
+  painter->setRenderHints(QPainter::Antialiasing);
+#endif
   painter->fillRect (x1, y2, x2-x1, y1-y2, br);       
 }
 
@@ -444,7 +452,11 @@ qt_renderer_rep::draw_clipped (QImage *im, int w, int h, SI x, SI y) {
   decode (x2, y2);
   y--; // top-left origin to bottom-left origin conversion
        // clear(x1,y1,x2,y2);
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   painter->setRenderHints (0);
+#else
+  painter->setRenderHints(QPainter::Antialiasing);
+#endif
   painter->drawImage (x, y, *im);
 }
 
@@ -453,7 +465,11 @@ qt_renderer_rep::draw_clipped (QPixmap *im, int w, int h, SI x, SI y) {
   decode (x , y );
   y--; // top-left origin to bottom-left origin conversion
   // clear(x1,y1,x2,y2);
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   painter->setRenderHints (0);
+#else
+  painter->setRenderHints(QPainter::Antialiasing);
+#endif
   painter->drawPixmap (x, y, w, h, *im);
 }
 

--- a/src/Plugins/Qt/qt_simple_widget.cpp
+++ b/src/Plugins/Qt/qt_simple_widget.cpp
@@ -141,8 +141,11 @@ qt_simple_widget_rep::reapply_sent_slots () {
   t_slot_entry sorted_slots[slot_id__LAST];
   for (int i = 0; i < slot_id__LAST; ++i)
     sorted_slots[i] = sent_slots[i];
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   qSort (&sorted_slots[0], &sorted_slots[slot_id__LAST]);
-  
+#else
+  std::sort (&sorted_slots[0], &sorted_slots[slot_id__LAST]);
+#endif
   for (int i = 0; i < slot_id__LAST; ++i)
     if (sorted_slots[i].seq >= 0)
       this->send(sorted_slots[i].id, sorted_slots[i].val);

--- a/src/Plugins/Qt/qt_ui_element.hpp
+++ b/src/Plugins/Qt/qt_ui_element.hpp
@@ -179,7 +179,11 @@ public:
         l = "";
       
       if (filtered)
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
         cmd (list_object (l, from_qstring (qwid->filter()->filterRegExp().pattern())));
+#else
+        cmd (list_object (l, from_qstring (qwid->filter()->filterRegularExpression().pattern())));
+#endif
       else
         cmd (list_object (l));
     }

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -784,10 +784,17 @@ qt_pretty_time (int t) {
 }
 
 #ifndef _MBD_EXPERIMENTAL_PRINTER_WIDGET  // this is in qt_printer_widget
-
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 #define PAPER(fmt)  case QPrinter::fmt : return "fmt"
-static string 
+#else
+#define PAPER(fmt)  case QPageSize::fmt : return "fmt"
+#endif
+static string
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 qt_papersize_to_string (QPrinter::PaperSize sz) {
+#else
+qt_papersize_to_string (QPageSize::PageSizeId sz) {
+#endif
   switch (sz) {
       PAPER (A0) ;
       PAPER (A1) ;

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -481,7 +481,11 @@ qt_image_to_pdf (url image, url outfile, int w_pt, int h_pt, int dpi) {
 // or the actual dpi will be lower  
   if (DEBUG_CONVERT) debug_convert << "qt_image_to_eps_or_pdf " << image << " -> "<<outfile<<LF;
   QPrinter printer;
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   printer.setOrientation(QPrinter::Portrait);
+#else
+  printer.setPageOrientation(QPageLayout::Portrait);
+#endif
   if (suffix(outfile)=="eps") {
     //note that PostScriptFormat is gone in Qt5. a substitute?: http://soft.proindependent.com/eps/
     cout << "TeXmacs] warning: PostScript format no longer supported in Qt5\n";

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -836,8 +836,13 @@ qt_print (bool& to_file, bool& landscape, string& pname, url& filename,
     to_file = !(qprinter->outputFileName().isNull());
     pname = from_qstring( qprinter->printerName() );
     filename = from_qstring( qprinter->outputFileName() );
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
     landscape = (qprinter->orientation() == QPrinter::Landscape);
     paper_type = qt_papersize_to_string(qprinter->paperSize());
+#else
+    landscape = (qprinter->pageLayout().orientation() == QPageLayout::Landscape);
+    paper_type = qt_papersize_to_string(qprinter->pageLayout().pageSize().id());
+#endif
     if (qprinter->printRange() == QPrinter::PageRange) {
       first = qprinter->fromPage(); 
       last = qprinter->toPage(); 

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -774,7 +774,11 @@ qt_get_date (string lan, string fm) {
 
 string
 qt_pretty_time (int t) {
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
   QDateTime dt= QDateTime::fromTime_t (t);
+#else
+  QDateTime dt= QDateTime::fromSecsSinceEpoch(t);
+#endif
   QString s= dt.toString ();
   return from_qstring (s);
 }

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -508,8 +508,12 @@ qt_image_to_pdf (url image, url outfile, int w_pt, int h_pt, int dpi) {
   << "dpi set: " << printer.resolution() <<LF;
 */
     if (dpi > 0 && w_pt > 0 && h_pt > 0) {
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 	    printer.setPaperSize(QSizeF(w_pt, h_pt), QPrinter::Point); // in points
-
+#else
+      // see https://doc.qt.io/qt-5/qprinter-obsolete.html#setPaperSize
+      printer.setPageSize(QPageSize(QSizeF(w_pt, h_pt), QPageSize::Point));
+#endif
       // w_pt and h_pt are dimensions in points (and there are 72 points per inch)
       int ww = w_pt * dpi / 72;
       int hh = h_pt * dpi / 72;
@@ -519,7 +523,12 @@ qt_image_to_pdf (url image, url outfile, int w_pt, int h_pt, int dpi) {
         printer.setResolution((int) (dpi*im.width())/(double)ww);
       if (DEBUG_CONVERT) debug_convert << "dpi asked: "<< dpi <<" ; actual dpi set: " << printer.resolution() <<LF;
 	  }
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 	  else printer.setPaperSize(QSizeF(im.width (), im.height ()), QPrinter::DevicePixel);
+#else
+          // FIXME: how to set the unit QPrinter::DevicePixel
+          else printer.setPageSize(QPageSize(QSizeF(im.width(), im.height()), QPageSize::Point));
+#endif
     QPainter p;
     p.begin(&printer);
     p.drawImage(0, 0, im);

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -19,7 +19,9 @@
 #include <QCoreApplication>
 #include <QLocale>
 #include <QDateTime>
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
 #include <QTextCodec>
+#endif
 #include <QHash>
 #include <QStringList>
 #include <QKeySequence>

--- a/src/Plugins/Qt/qt_utilities.hpp
+++ b/src/Plugins/Qt/qt_utilities.hpp
@@ -21,8 +21,9 @@
 #include <QFont>
 #include <QUrl>
 
-
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 class QStringList;
+#endif
 class QKeySequence;
 
 typedef quartet<SI,SI,SI,SI> coord4;

--- a/src/Plugins/Qt/qt_window_widget.cpp
+++ b/src/Plugins/Qt/qt_window_widget.cpp
@@ -60,11 +60,20 @@ qt_window_widget_rep::qt_window_widget_rep (QWidget* _wid, string name,
 
   if (tm_style_sheet == "") {
     QPalette pal;
+#if QT_VERSION <  QT_VERSION_CHECK(6, 0, 0)
+    // QPalette::Background. This value is obsolete. Use Window instead.
     QColor winbg= pal.color (QPalette::Background);
     if (winbg.red() + winbg.green() + winbg.blue () < 255)
       pal.setColor (QPalette::Background, QColor (240, 240, 240));
     _wid->setPalette (pal);
   }
+#else
+    QColor winbg= pal.color (QPalette::Window);
+    if (winbg.red() + winbg.green() + winbg.blue () < 255)
+      pal.setColor (QPalette::Window, QColor (240, 240, 240));
+    _wid->setPalette (pal);
+  }
+#endif
 }
 
 /*!

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ foreach (_test_file ${TEST_SRC_FILES})
     texmacs_body
     ${TeXmacs_Libraries}
     ${CMAKE_DL_LIBS}
-    Qt5::Test
+    Qt${QT_VERSION_MAJOR}::Test
   )
   add_test (${_test_name} ${_test_name})
   set_tests_properties (${_test_name} PROPERTIES TIMEOUT 5)


### PR DESCRIPTION
Build TeXmacs with Qt6

maybe some bugs, we need more tests.

All changes do not affect the Qt5 version.

## How to test
set `CMAKE_PREFIX_PATH` to Qt6 cmake path

```
mkdir build
cd build
cmake -DCMAKE_PREFIX_PATH=/Users/pikachu/Qt/6.3.0/macos/lib/cmake ..
make -j4
```

## TODO

There are no equivalent replacements for the following changes.

- QPrinter::setPaperSize

no `QPrinter::DevicePixel` in QPageSize

on TeXmacs qt6 branch, it just print log
```
if (DEBUG_CONVERT) debug_convert << "no dpi or size informations!!" << LF;
```

- QWheelEvent::delta

- QApplication::globalStrut

on TeXmacs qt6 branch, a fixed value assigned
```
calcSize = QSize(2, 2);
```


## snapshot
After merge https://github.com/XmacsLabs/mogan/pull/135

We can see

![image](https://user-images.githubusercontent.com/18223871/161700962-5908717c-79f6-456e-a82d-b9dfd0e53576.png)
