### PR TITLE
CMake: remove headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,9 +395,8 @@ else (WIN32)
 endif (WIN32)
 
 set (TeXmacs_Include_Dirs ${TeXmacs_Include_Dirs}
-  ${FREETYPE_INCLUDE_DIRS} ${Cairo_INCLUDE_DIRS}
+  ${Cairo_INCLUDE_DIRS}
   ${IMLIB2_INCLUDE_DIR} ${GMP_INCLUDES}
-  ${CURL_INCLUDE_DIRS}
 )
 
 ### --------------------------------------------------------------------


### PR DESCRIPTION
sub pr of https://github.com/XmacsLabs/mogan/pull/123

The target-based CMake style can manage headers and libraries automatically.