### PR TITLE
Use math font in math mode

### DIFF
--- a/src/Typeset/Env/env_semantics.cpp
+++ b/src/Typeset/Env/env_semantics.cpp
@@ -560,7 +560,7 @@ edit_env_rep::update_font () {
   case 2:
     fn= smart_font (get_string (MATH_FONT), get_string (MATH_FONT_FAMILY),
                     get_string (MATH_FONT_SERIES), get_string (MATH_FONT_SHAPE),
-                    get_string (FONT), get_string (FONT_FAMILY),
+                    get_string (MATH_FONT), get_string (FONT_FAMILY),
                     get_string (FONT_SERIES), "mathitalic",
                     get_script_size (fn_size, index_level), (int) (magn*dpi));
     break;


### PR DESCRIPTION
Fixes the choice typesetting bug, here is the demo doc:

```
<TeXmacs|2.1.1>

<style|<tuple|generic|chinese>>

<\body>
  <math|<choice|<tformat|<table|<row|<cell|>>|<row|<cell|>>>>>>
</body>

<\initial>
  <\collection>
    <associate|page-medium|paper>
  </collection>
</initial>
```
closes #110 