### PR TITLE
Re-impl read_directory using Qt

### DIFF
--- a/src/Plugins/Qt/qt_file.cpp
+++ b/src/Plugins/Qt/qt_file.cpp
@@ -1,0 +1,35 @@
+
+/******************************************************************************
+* MODULE     : qt_file.cpp
+* DESCRIPTION: File handling using Qt
+* COPYRIGHT  : (C) 2022  Darcy Shen
+*******************************************************************************
+* This software falls under the GNU general public license version 3 or later.
+* It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+* in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+******************************************************************************/
+
+#include "string.hpp"
+#include "Qt/qt_utilities.hpp"
+#include "Qt/qt_file.hpp"
+
+#include <QDir>
+#include <QFileInfoList>
+#include <QFileInfo>
+
+array<string>
+qt_read_directory (string name, bool& error_flag) {
+  QDir dir= QDir (to_qstring (name));
+  if (!dir.exists ()) {
+    error_flag= true;
+    return array<string>();
+  }
+
+  QFileInfoList list = dir.entryInfoList();
+  array<string> dirs;
+  for (int i = 0; i < list.size(); ++i) {
+    QFileInfo fileInfo = list.at(i);
+    dirs << from_qstring(fileInfo.fileName());
+  }
+  return dirs;
+}

--- a/src/Plugins/Qt/qt_file.hpp
+++ b/src/Plugins/Qt/qt_file.hpp
@@ -1,0 +1,19 @@
+
+/******************************************************************************
+* MODULE     : qt_file.hpp
+* DESCRIPTION: File handling using Qt
+* COPYRIGHT  : (C) 2022  Darcy Shen
+*******************************************************************************
+* This software falls under the GNU general public license version 3 or later.
+* It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+* in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+******************************************************************************/
+
+#ifndef QT_FILE_H
+#define QT_FILE_H
+#include "array.hpp"
+
+array<string>
+qt_read_directory (string name, bool& error_flag);
+
+#endif

--- a/src/System/Files/file.cpp
+++ b/src/System/Files/file.cpp
@@ -40,6 +40,10 @@
 #include "MacOS/mac_images.h"
 #endif
 
+#ifdef QTTEXMACS
+#include "Qt/qt_file.hpp"
+#endif
+
 /******************************************************************************
 * New style loading and saving
 ******************************************************************************/
@@ -527,27 +531,13 @@ read_directory (url u, bool& error_flag) {
   bench_start ("read directory");
   // End caching
 
-  DIR* dp;
-  c_string temp (name);
-  dp= opendir (temp);
-  error_flag= (dp==NULL);
-  if (error_flag) return array<string> ();
-
   array<string> dir;
-  #ifdef OS_MINGW
-  while (true) {
-    const char* nextname =  nowide::readir_entry (dp);
-    if (nextname==NULL) break;
-    dir << string (nextname);
-  #else
-  struct dirent* ep;
-  while (true) {
-    ep= readdir (dp);
-    if (ep==NULL) break;
-    dir << string (ep->d_name);
-  #endif
-  }
-  (void) closedir (dp);
+#ifdef QTTEXMACS
+  dir= qt_read_directory(name, error_flag);
+#else
+  FAILED("Implementation of list directories is not provided");
+#endif
+
   merge_sort (dir);
 
   // Caching of directory contents

--- a/tests/System/Files/file_test.cpp
+++ b/tests/System/Files/file_test.cpp
@@ -1,0 +1,33 @@
+
+/******************************************************************************
+* MODULE     : file_test.cpp
+* COPYRIGHT  : (C) 2022  Darcy Shen
+*******************************************************************************
+* This software falls under the GNU general public license version 3 or later.
+* It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+* in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+******************************************************************************/
+
+#include <QtTest/QtTest>
+#include "file.hpp"
+
+
+class TestFile: public QObject {
+  Q_OBJECT
+
+private slots:
+  void test_read_directory ();
+};
+
+void TestFile::test_read_directory () {
+  auto misc= url ("$TEXMACS_PATH/styles/");
+  bool err= false;
+  auto dirs= read_directory(misc, err);
+  QCOMPARE (N(dirs), 17);
+
+  auto no_dirs= read_directory (url ("/not_exist"), err);
+  QCOMPARE (N(no_dirs), 0);
+}
+
+QTEST_MAIN(TestFile)
+#include "file_test.moc"


### PR DESCRIPTION
IO code in https://github.com/XmacsLabs/mogan/blob/main/src/System/Files/file.cpp is not in a good quality. We should replace it using Qt.

Without it crashes on Windows because `read_directory` on Windows returns messy code.