### PR TITLE
Qt: fix QTMLineEdit crash when using Input Method

### DIFF
--- a/src/Plugins/Qt/QTMMenuHelper.cpp
+++ b/src/Plugins/Qt/QTMMenuHelper.cpp
@@ -721,8 +721,11 @@ QTMLineEdit::keyPressEvent (QKeyEvent* ev)
 void
 QTMLineEdit::inputMethodEvent (QInputMethodEvent* ev) {
   QLineEdit::inputMethodEvent (ev);
-  if (!ev->commitString().isEmpty() && ev->preeditString().isEmpty()) {
-    string str = from_qstring(ev->commitString());
+
+  if (!ev->commitString().isEmpty() &&
+      ev->preeditString().isEmpty() &&
+      continuous()) {
+    string str= from_qstring(ev->commitString());
     cmd (list_object (list_object (object (str), object (str))));
   }
 }


### PR DESCRIPTION
Fixes #222 

It fixes the crash issue, and we still need to click twice to open the document searching window.