### PR TITLE
[no ci] Open links in remote files as in local files

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -530,8 +530,8 @@
 (tm-define (load-browse-buffer name)
   (:synopsis "Load a buffer or switch to it if already open")
   (cond ((buffer-exists? name) (switch-to-buffer name))
-        ((url-rooted-web? (current-buffer)) (load-buffer name))
         ((buffer-external? name) (load-external name))
+        ((url-rooted-web? (current-buffer)) (load-buffer name))
         (else (load-buffer name))))
 
 (tm-define (open-buffer)


### PR DESCRIPTION
Links open rules:
1. If it is a http/https/ftp/... link
   + if it ends with tm, open it in Mogan Editor
   + else just open it in web browser
2. If it is a local file, open it in Mogan Editor

Before, the rules work fine when we are in a local file buffer but it failed to work in a remote file buffer.
With the PR merged, the rules is the same for both local and remote files.

Fixes #234 