### PR TITLE
option for TM format with UTF8 support

### DIFF
--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -14,7 +14,9 @@
 #include "path.hpp"
 #include "vars.hpp"
 #include "drd_std.hpp"
+#ifdef QTTEXMACS
 #include "Qt/qt_utilities.hpp"
+#endif
 
 /******************************************************************************
 * Conversion of TeXmacs strings of the present format to TeXmacs trees
@@ -95,16 +97,21 @@ tm_reader::read_char () {
   }
   if (pos >= N(buf)) return "";
 
-  string guess_unicode= buf(pos, pos+4);
-  QChar qch= utf8_to_qstring (guess_unicode).front();
-  int size = QString(qch).toUtf8().length();
+#ifdef QTTEXMACS
+  string guess_unicode= buf (pos, pos+4);
+  QChar qch= utf8_to_qstring (guess_unicode).front ();
+  int size= QString(qch).toUtf8().length();
   if (size > 1) {
     pos+= size;
-    return from_qstring(QString(qch));
+    return from_qstring (QString(qch));
   } else {
-    pos+= 1;
-    return buf(pos-1, pos);
+    pos++;
+    return buf (pos-1, pos);
   }
+#else
+  pos+= 1;
+  return buf(pos-1, pos);
+#endif
 }
 
 string

--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -99,7 +99,7 @@ tm_reader::read_char () {
 
 #ifdef QTTEXMACS
   string guess_unicode= buf (pos, pos+4);
-  QChar qch= utf8_to_qstring (guess_unicode).front ();
+  QChar qch= utf8_to_qstring (guess_unicode).at (0);
   int size= QString(qch).toUtf8().length();
   if (size > 1) {
     pos+= size;

--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -14,6 +14,7 @@
 #include "path.hpp"
 #include "vars.hpp"
 #include "drd_std.hpp"
+#include "Qt/qt_utilities.hpp"
 
 /******************************************************************************
 * Conversion of TeXmacs strings of the present format to TeXmacs trees
@@ -93,8 +94,17 @@ tm_reader::read_char () {
     skip_spaces (buf, pos);
   }
   if (pos >= N(buf)) return "";
-  pos++;
-  return buf (pos-1, pos);
+
+  string guess_unicode= buf(pos, pos+4);
+  QChar qch= utf8_to_qstring (guess_unicode).front();
+  int size = QString(qch).toUtf8().length();
+  if (size > 1) {
+    pos+= size;
+    return from_qstring(QString(qch));
+  } else {
+    pos+= 1;
+    return buf(pos-1, pos);
+  }
 }
 
 string
@@ -102,6 +112,8 @@ tm_reader::read_next () {
   int old_pos= pos;
   string c= read_char ();
   if (c == "") return c;
+  if (N(c) > 1) return "\\<" * c(1, N(c)-1) * "\\>";
+
   switch (c[0]) {
   case '\t':
   case '\n':

--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -109,7 +109,7 @@ tm_reader::read_next () {
   int old_pos= pos;
   string c= read_char ();
   if (c == "") return c;
-  if (N(c) == 9) return c; // \<#FFFF\>
+  if (N(c) == 9) return c; // c is like \<#FFFF\>
 
   switch (c[0]) {
   case '\t':

--- a/src/Data/Convert/Texmacs/totm.cpp
+++ b/src/Data/Convert/Texmacs/totm.cpp
@@ -144,6 +144,12 @@ tm_writer::write (string s, bool flag, bool encode_space) {
     for (i=0; i<n; i++) {
       char c= s[i];
       if ((c == ' ') && (!encode_space)) write_space ();
+      else if (c == '<' && i+6 < n && s[i+1] == '#' && s[i+6] == '>') {
+        tmp << cork_to_utf8 (s(i, i+6));
+        i+= 6;
+        spc_flag= false;
+        ret_flag= false;
+      }
       else {
         if (c == ' ') tmp << "\\ ";
         else if (c == '\n') tmp << "\\n";

--- a/src/Data/Convert/Texmacs/totm.cpp
+++ b/src/Data/Convert/Texmacs/totm.cpp
@@ -11,6 +11,7 @@
 
 #include "convert.hpp"
 #include "drd_std.hpp"
+#include "scheme.hpp"
 
 /******************************************************************************
 * Conversion of TeXmacs trees to the present TeXmacs string format
@@ -144,7 +145,8 @@ tm_writer::write (string s, bool flag, bool encode_space) {
     for (i=0; i<n; i++) {
       char c= s[i];
       if ((c == ' ') && (!encode_space)) write_space ();
-      else if (c == '<' && i+6 < n && s[i+1] == '#' && s[i+6] == '>') {
+      else if (get_preference ("tm format with utf8", "on") == "on" &&
+               (c == '<' && i+6 < n && s[i+1] == '#' && s[i+6] == '>')) {
         tmp << cork_to_utf8 (s(i, i+6));
         i+= 6;
         spc_flag= false;


### PR DESCRIPTION
The reader is compatible with the previous reader.

For the writer, we provide the option `tm format with utf8`, it will be default to off for GNU TeXmacs.