### PR TITLE
focus tag first letter doesn't need to be upper case

### DIFF
--- a/TeXmacs/progs/check/check-master.scm
+++ b/TeXmacs/progs/check/check-master.scm
@@ -24,7 +24,8 @@
         (convert tools environment-test)
         (convert mathml mathtm-test)
         (convert tmml tmmltm-test)
-        (prog prog-format-test)))
+        (prog prog-format-test)
+        (generic generic-test)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test LaTeX export
@@ -96,4 +97,5 @@
   (regtest-tm-define)
   (regtest-tm-dialogue)
   (regtest-tm-convert)
+  (regtest-generic)
 )

--- a/TeXmacs/progs/generic/generic-menu.scm
+++ b/TeXmacs/progs/generic/generic-menu.scm
@@ -35,7 +35,7 @@
           (focus-tag-name (string->symbol ns)))
         (if (symbol-unnumbered? l)
             (focus-tag-name (symbol-drop-right l 1))
-            (with r (upcase-first (tree-name (tree l)))
+            (with r (tree-name (tree l))
               (string-replace r "-" " "))))))
 
 (tm-menu (focus-variant-menu t)

--- a/TeXmacs/progs/generic/generic-test.scm
+++ b/TeXmacs/progs/generic/generic-test.scm
@@ -1,0 +1,32 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : generic-test.scm
+;; DESCRIPTION : Test suite for generic
+;; COPYRIGHT   : (C) 2022  Yufeng Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (generic generic-test)
+  (:use (generic generic-menu) ))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; generic menu functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (regtest-focus-tag-name)
+  (regression-test-group
+   "focus-tag-name" "string"
+   focus-tag-name :none
+   (test "bmatrix" 'bmatrix "bmatrix")
+   (test "Bmatrix" 'Bmatrix "Bmatrix")
+  ))
+
+  (tm-define (regtest-generic)
+  (let ((n (+ (regtest-focus-tag-name)
+              )))
+    (display* "Total: " (object->string n) " tests.\n")
+    (display "Test suite of generic: ok\n")))


### PR DESCRIPTION
removed upcase-first from focus-tag-name, a unit test added for this function