### PR TITLE
fix(package/macos): Don't break on `copy_assets`

### DIFF
--- a/packages/macos/package.sh
+++ b/packages/macos/package.sh
@@ -47,5 +47,10 @@ deploy_app() {
 }
 
 build_mogan_base
-copy_assets
+
+# “Copy Assets” is a optional step, and should not break
+# the subsequent commands. `|| true` indicates `bash` to
+# not stop at this command.
+copy_assets || true
+
 deploy_app


### PR DESCRIPTION
“Copy Assets” is a optional step, and should not break the subsequent commands. `|| true` indicates `bash` to not stop at this command.

This fixes #395

## Other Information

- Proof CI: <https://github.com/pan93412/mogan/actions/runs/3597383535> (passed)
- The CI of this commit: <https://github.com/pan93412/mogan/actions/runs/3597549087> **Passed!**