### PR TITLE
Add support for macOS M1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,9 +612,14 @@ if (TEXMACS_GUI MATCHES "Qt.*")
   if (TEXMACS_GUI STREQUAL "Qt4")
     message (FATAL_ERROR "Qt 4.x is not supported")
   else (TEXMACS_GUI STREQUAL "Qt4")
-    # Homebrew installs Qt5 in /usr/local/opt/qt5
-    if (APPLE AND EXISTS /usr/local/opt/qt5)
-      list (APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+    if (APPLE)
+      if (EXISTS /usr/local/opt/qt@5)
+        # Homebrew installs Qt 5 in /usr/local/opt/qt@5 in x86-64 macOS
+        list (APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt@5")
+        # Homebrew installs Qt 5 in /opt/homebrew/opt/qt@5 in macOS on M1
+      elseif (EXISTS /opt/homebrew/opt/qt@5)
+        list (APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/qt@5")
+      endif ()
     endif ()
     # compat with Qt6
     if (TEXMACS_GUI STREQUAL "Qt6")

--- a/packages/macos/package.sh
+++ b/packages/macos/package.sh
@@ -44,6 +44,7 @@ copy_assets() (
 
 deploy_app() {
     macdeployqt Mogan.app -verbose=1 -dmg
+    codesign --force --sign - --deep Mogan.app
 }
 
 build_mogan_base


### PR DESCRIPTION
- Add the Homebrew Qt path of macOS M1.
- Sign `Mogan.app` after `macdeployqt` as this is a mandatory requirement for M1.

CI: <https://github.com/pan93412/mogan/actions/runs/3626346588> (passed)