### PR TITLE
Add package ci for windows 2h

### DIFF
--- a/.github/workflows/ci-xmake.yaml
+++ b/.github/workflows/ci-xmake.yaml
@@ -124,7 +124,6 @@ jobs:
         run: |
           ./inno-setup.exe /VERYSILENT /SP- /CURRENTUSER
           iscc .\package\Xmacs.iss
-            - name: Release
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/ci-xmake.yaml
+++ b/.github/workflows/ci-xmake.yaml
@@ -105,6 +105,30 @@ jobs:
           xmake run --yes --verbose --diagnosis --group=tests
         env:
           TEXMACS_PATH: .\TeXmacs
+  windowspackage:
+    runs-on: windows-latest
+    if: ${{ github.ref_type == 'tag' }}
+    steps:
+      - name: Download mogan binary
+        uses: actions/download-artifact@v3
+        with:
+          name: my-artifact
+          path: main
+      - name: Download binaries
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          repository: 'XmacsLabs/mogan-dependencies'
+          path: binary
+      - name: Generate Installer
+        run: |
+          ./inno-setup.exe /VERYSILENT /SP- /CURRENTUSER
+          iscc .\package\Xmacs.iss
+            - name: Release
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: Mogan-v*
   linuxbuild:
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/ci-xmake.yaml
+++ b/.github/workflows/ci-xmake.yaml
@@ -70,7 +70,7 @@ jobs:
           arch: win64_mingw81
           host: 'windows'
           target: 'desktop'
-          cache: 'false'
+          cache: 'true'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
@@ -91,6 +91,7 @@ jobs:
           xmake build --yes --verbose --diagnosis --jobs=8 --all
           windeployqt ./build/mingw/x86_64/release/
           xmake install mogan_install
+          windeployqt ./build/package/bin/
       - name: Upload 
         uses: actions/upload-artifact@v2
         with:

--- a/packages/windows/Xmacs.iss.in
+++ b/packages/windows/Xmacs.iss.in
@@ -34,14 +34,7 @@ Root: HKCR; Subkey: "tmfile\shell\open\command"; ValueType: string; ValueName: "
 
 [Files]
 Source: *; Excludes: "Xmacs.iss"; DestDir: {app}; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "C:\Program Files (x86)\TeXmacs\bin\gs.exe"; DestDir: {app}/bin/;
-Source: "C:\Program Files\Mogan\plugins\eukleides\bin\eukleides.exe"; DestDir: {app}/plugins/eukleides/bin; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "C:\Program Files (x86)\TeXmacs\plugins\aspell\bin\*"; DestDir: {app}/plugins/aspell/bin; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "C:\Program Files (x86)\TeXmacs\plugins\aspell\data\en*"; DestDir: {app}/plugins/aspell/data; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "C:\Program Files (x86)\TeXmacs\plugins\aspell\data\iso*"; DestDir: {app}/plugins/aspell/data; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "C:\Program Files (x86)\TeXmacs\plugins\aspell\data\standard*"; DestDir: {app}/plugins/aspell/data; Flags: recursesubdirs createallsubdirs ignoreversion
-Source: "C:\Program Files (x86)\TeXmacs\plugins\aspell\dict\en*"; DestDir: {app}/plugins/aspell/dict; Flags: recursesubdirs createallsubdirs ignoreversion
-
+Source: "..\binary\*"; Excludes: "\.git\*,\inno-setup.exe"; DestDir: {app}; Flags: recursesubdirs createallsubdirs ignoreversion
 [Icons]
 Name: "{group}\Mogan"; Filename: "{app}\bin\Mogan.exe"; IconFilename: "{app}\Xmacs.ico"
 Name: "{group}\Uninstall Mogan"; Filename: "{uninstallexe}"

--- a/xmake.lua
+++ b/xmake.lua
@@ -409,11 +409,6 @@ target("mogan") do
     after_install(function(target)
         local install_dir = path.join(target:installdir(), "/bin/")
         os.cp(target:targetfile(), install_dir)
-        local bin_dir = path.directory(target:targetfile())
-        os.cp(
-            path.join(bin_dir,"**.dll"),
-            install_dir, {rootdir=bin_dir}
-        )
     end)
 end 
 


### PR DESCRIPTION
This ci will be triggered by pushing tag. Cache qt environment to accelerate ci execution. Use windeploy twice to avoid `Qt5Test` appears in installer.

Binary dependencies is stored in [XmacsLabs/mogan-dependencies](https://github.com/XmacsLabs/mogan-dependencies)

# see also

* #116 
* #127 
* #128 
* #129 