### PR TITLE
Change version format on Windows

### DIFF
--- a/packages/windows/Xmacs.iss.in
+++ b/packages/windows/Xmacs.iss.in
@@ -9,7 +9,7 @@ DefaultGroupName=Mogan
 VersionInfoTextVersion=v@XMACS_VERSION@
 AppPublisher=XmacsLabs
 AppPublisherURL=http://github.com/XmacsLabs/mogan
-AppVersion=v@XMACS_VERSION@
+AppVersion=@XMACS_VERSION@
 LicenseFile=LICENSE
 
 UninstallDisplayIcon={app}\TeXmacs.ico


### PR DESCRIPTION
This PR changes the format of the version that the Windows installer writes to the uninstall registry key from `v1.1.2` to `1.1.2`, so it will align with the version string on Windows prior to 1.1.0 and other platforms (macOS, etc.). This will not affect current users.
![image](https://user-images.githubusercontent.com/56779163/210151314-d673f4de-c631-4160-a52b-e662eb8e7b36.png)

By the way, the `VersionInfoTextVersion` property has been deprecated after Windows 98. It can be replaced by `VersionInfoVersion`.
https://jrsoftware.org/ishelp/index.php?topic=setup_versioninfotextversion