### PR TITLE
Fix the icon in the Dock for Mac

### DIFF
--- a/src/Texmacs/Texmacs/texmacs.cpp
+++ b/src/Texmacs/Texmacs/texmacs.cpp
@@ -726,7 +726,7 @@ main (int argc, char **argv) {
 #endif
   TeXmacs_init_paths (argc, argv);
 #ifdef QTTEXMACS
-  qtmapp->set_window_icon ("/misc/images/new-mogan-512.png");
+  qtmapp->set_window_icon ("/misc/images/new-mogan-512.png"); // it this really necessary? Should be set in the metadata.
 #endif
   // cout << "Bench  ] Started TeXmacs\n";
   the_et     = tuple ();

--- a/src/Texmacs/Texmacs/texmacs.cpp
+++ b/src/Texmacs/Texmacs/texmacs.cpp
@@ -726,7 +726,7 @@ main (int argc, char **argv) {
 #endif
   TeXmacs_init_paths (argc, argv);
 #ifdef QTTEXMACS
-  qtmapp->set_window_icon ("/misc/images/xmacs-512.png");
+  qtmapp->set_window_icon ("/misc/images/new-mogan-512.png");
 #endif
   // cout << "Bench  ] Started TeXmacs\n";
   the_et     = tuple ();


### PR DESCRIPTION
There is a strange line in `texmacs.cpp` which reset the icon. I've now fixed it to point to the new icon. I do not understand why this is necessary. I guess we can remove that line since the application icon should be specified in the metadata and not in the code (unless one what to change it programmatically)