### PR TITLE
Eliminate warnings caused by action of mingw setup.

### DIFF
--- a/.github/workflows/ci-xmake.yml
+++ b/.github/workflows/ci-xmake.yml
@@ -67,7 +67,7 @@ jobs:
             git 
             make 
       - name: Set up MinGW
-        uses: coffeebe4code/setup-mingw@v1-beta-2
+        uses: egor-tensin/setup-mingw@v2
         with:
           platform: x64
           version: 8.1.0


### PR DESCRIPTION
Main branch of action to set up mingw is egor-tensin/setup-mingw