### PR TITLE
[143] bump qt version and emsdk version

### DIFF
--- a/.github/workflows/ci-xmake-wasm.yml
+++ b/.github/workflows/ci-xmake-wasm.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Qt wasm
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.4.3
+          version: 6.5.2
           arch: wasm_32
           host: 'linux'
           target: 'desktop'
@@ -62,7 +62,7 @@ jobs:
         uses: mymindstorm/setup-emsdk@v11
         with:
           # Make sure to set a version number!
-          version: 3.1.34
+          version: 3.1.25
           # This is the name of the cache folder.
           # The cache folder will be placed in the build directory,
           #  so make sure it doesn't conflict with anything!

--- a/.github/workflows/ci-xmake-wasm.yml
+++ b/.github/workflows/ci-xmake-wasm.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Qt wasm
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.5
+          version: 6.5.0
           arch: wasm_32
           host: 'linux'
           target: 'desktop'

--- a/.github/workflows/ci-xmake-wasm.yml
+++ b/.github/workflows/ci-xmake-wasm.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Qt wasm
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.5.2
+          version: 6.5
           arch: wasm_32
           host: 'linux'
           target: 'desktop'

--- a/.github/workflows/ci-xmake-wasm.yml
+++ b/.github/workflows/ci-xmake-wasm.yml
@@ -35,7 +35,7 @@ jobs:
         uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.0
-          arch: wasm_32
+          arch: wasm_singlethread
           host: 'linux'
           target: 'desktop'
           cache: 'true'

--- a/src/System/config.h.xmake
+++ b/src/System/config.h.xmake
@@ -84,6 +84,8 @@ ${define OS_MACOS}
 
 ${define OS_MINGW}
 
+${define OS_WASM}
+
 ${define PDFHUMMUS_NO_TIFF}
 
 /* Disable fast memory allocator */

--- a/xmake.lua
+++ b/xmake.lua
@@ -447,7 +447,6 @@ target("libmogan") do
 
     if is_plat("wasm") then
         add_cxxflags({"-Wall","-Wextra"})
-        add_ldflags({"--preload-file $(scriptdir)/TeXmacs@TeXmacs"})
     end
     add_mxflags("-fno-objc-arc")
     add_cxxflags("-include src/System/config.h")
@@ -478,6 +477,10 @@ target("mogan") do
 
     add_files("src/Texmacs/Texmacs/texmacs.cpp")
 
+    if is_plat("wasm") then
+        add_cxxflags({"-Wall","-Wextra"})
+        add_ldflags({"--preload-file $(scriptdir)/TeXmacs@TeXmacs"})
+    end
     set_installdir(INSTALL_DIR)
     after_install(function(target)
         local install_dir = path.join(target:installdir(), "/bin/")
@@ -645,6 +648,11 @@ for _, filepath in ipairs(os.files("tests/**_test.cpp")) do
             add_files("tests/Base/base.cpp")
             add_files(filepath) 
             add_files(filepath, {rules = "qt.moc"})
+
+            if is_plat("wasm") then
+                add_cxxflags({"-Wall","-Wextra"})
+                add_ldflags({"--preload-file $(scriptdir)/TeXmacs@TeXmacs"})
+            end
         end
     end
 end

--- a/xmake.lua
+++ b/xmake.lua
@@ -165,6 +165,7 @@ add_configfiles(
             OS_MACOS = is_plat("macosx"),
             MACOSX_EXTENSIONS = is_plat("macosx"),
             OS_MINGW = is_plat("mingw"),
+            OS_WASM = is_plat("wasm"),
             SIZEOF_VOID_P = 8,
             USE_JEAIII = true
             }})

--- a/xmake.lua
+++ b/xmake.lua
@@ -447,7 +447,7 @@ target("libmogan") do
 
     if is_plat("wasm") then
         add_cxxflags({"-Wall","-Wextra"})
-        add_ldflags({"SHELL:--preload-file $(scriptdir)/TeXmacs@TeXmacs"})
+        add_ldflags({"--preload-file $(scriptdir)/TeXmacs@TeXmacs"})
     end
     add_mxflags("-fno-objc-arc")
     add_cxxflags("-include src/System/config.h")

--- a/xmake.lua
+++ b/xmake.lua
@@ -447,7 +447,7 @@ target("libmogan") do
 
     if is_plat("wasm") then
         add_cxxflags({"-Wall","-Wextra"})
-        add_ldflags({"SHELL:--preload-file ${TEXMACS_SOURCE_DIR}/TeXmacs@TeXmacs","-qt-harfbuzz"})
+        add_ldflags({"SHELL:--preload-file $(scriptdir)/TeXmacs@TeXmacs"})
     end
     add_mxflags("-fno-objc-arc")
     add_cxxflags("-include src/System/config.h")

--- a/xmake.lua
+++ b/xmake.lua
@@ -41,7 +41,6 @@ if is_plat("linux") and (linuxos.name() == "debian" or linuxos.name() == "ubuntu
     add_requires("apt::libcurl4-openssl-dev", {alias="libcurl"})
     add_requires("apt::libsqlite3-dev", {alias="sqlite3"})
     add_requires("apt::libpng-dev", {alias="libpng"})
-    add_requires("apt::zlib1g-dev", {alias="zlib"})
     -- config package name for libjpeg on Ubuntu
     if linuxos.name() == "ubuntu" then
         add_requires("apt::libjpeg-turbo8-dev", {alias="libjpeg"})
@@ -60,7 +59,6 @@ else
         add_requires("libcurl 7.84.0", {system=false})
     end
     add_requires("libpng 1.6.37", {system=false})
-    add_requires("zlib 1.2.12", {system=false})
     add_requires("libjpeg v9e", {system=false})
     add_requires("freetype 2.12.1", {system=false})
     add_requires("sqlite3 3.39.0+200", {system=false})
@@ -269,7 +267,6 @@ target("libmogan") do
     end
 
     add_packages("libpng")
-    add_packages("zlib")
     add_packages("libjpeg")
     add_packages("freetype")
     add_packages("sqlite3")


### PR DESCRIPTION
https://doc.qt.io/qt-6/wasm.html#installing-emscripten

`mogan.js` should be patched as below:

```js

var createQtAppInstance = (() => {
  var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
  if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;
  return (
function(createQtAppInstance) {
  createQtAppInstance = createQtAppInstance || {};

/* content generated by emsdk */
  return createQtAppInstance.ready
}
);
})();
if (typeof exports === 'object' && typeof module === 'object')
  module.exports = createQtAppInstance;
else if (typeof define === 'function' && define['amd'])
  define([], function() { return createQtAppInstance; });
else if (typeof exports === 'object')
  exports["createQtAppInstance"] = createQtAppInstance;
```

after patching, errors occurs when starting:
```

TypeError: createQtAppInstance(...) is undefined
RuntimeError: Aborted(). Build with -sASSERTIONS for more info.
The qtContainerElements module property was not set or is invalid. Proceeding with no screens.
no screens available, assuming 24-bit color
Welcome to TeXmacs 2.1.2
------------------------------------------------------------------------------
Installation completed successfully !
I will now start up the editor
------------------------------------------------------------------------------
Benchmark 1
832040
Time: 45
Booting TeXmacs kernel functionality
------------------------------------------------------
Initialization done
------------------------------------------------------
Benchmark 2
832040
Time: 284
------------------------------------------------------
Forcing delayed loads
time: 1603
memory: 3131008 bytes
------------------------------------------------------
Cannot create window: no screens available
Aborted()
```