### PR TITLE
[23_20] Fix a bug that would cause an infinite loop

### DIFF
--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -856,9 +856,8 @@
 
 (tm-define (graphics-set-mode val)
   (:check-mark "v" graphics-mode-has-value?)
-  (if (and
-        (equal? (graphics-mode) val)
-        (not (equal? (graphics-mode) '(group-edit edit-props))))
+  (if (and (equal? (graphics-mode) val)
+           (not (equal? (graphics-mode) '(group-edit edit-props))))
     (graphics-set-mode '(group-edit edit-props))
     (begin
       (if (== val '(group-edit move))

--- a/TeXmacs/progs/graphics/graphics-main.scm
+++ b/TeXmacs/progs/graphics/graphics-main.scm
@@ -856,7 +856,9 @@
 
 (tm-define (graphics-set-mode val)
   (:check-mark "v" graphics-mode-has-value?)
-  (if (equal? (graphics-mode) val)
+  (if (and
+        (equal? (graphics-mode) val)
+        (not (equal? (graphics-mode) '(group-edit edit-props))))
     (graphics-set-mode '(group-edit edit-props))
     (begin
       (if (== val '(group-edit move))


### PR DESCRIPTION
In addition, there are still some issues with the functionality of 23_20. I have browsed the code repository, but I couldn't figure out why the menu button sometimes doesn't change to a dark color. Given the work schedule of OSPP, I will temporarily suspend this task.

Currently, as long as users follow the normal procedure, there won't be any inconsistencies. However, if a user is in the circle drawing mode and clicks the circle button again, it will enter the mode for setting properties. At this point, if the user clicks the circle button again, it will return to the circle drawing mode. The mode switching works fine. However, the circle button does not change to a dark color.