### PR TITLE
[48_1] Improve Xmake

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------------------
 --
 -- MODULE      : xmake.lua
--- DESCRIPTION : Xmake config file for Mogan Editor
+-- DESCRIPTION : Xmake config file for Mogan Applications
 -- COPYRIGHT   : (C) 2022-2023  jingkaimori
 --                   2022-2023  Darcy Shen
 --
@@ -36,9 +36,9 @@ configvar_check_cxxsnippets(
 
 
 ---
---- Project: Mogan Editor
+--- Project: Mogan Applications
 ---
-set_project("Mogan Editor")
+set_project("Mogan Applications")
 
 set_allowedplats(
     -- these plat should be guaranteed
@@ -558,7 +558,7 @@ target("research") do
 
     set_configdir(INSTALL_DIR)
     set_configvar("DEVEL_VERSION", DEVEL_VERSION)
-    set_configvar("PACKAGE", "Mogan Editor")
+    set_configvar("PACKAGE", "Mogan Research")
     set_configvar("XMACS_VERSION", XMACS_VERSION)
 
     -- install man.1 manual file
@@ -820,7 +820,7 @@ add_configfiles(
         filename = "doxyfile",
         pattern = "@(.-)@",
         variables = {
-            PACKAGE = "Mogan Editor",
+            PACKAGE = "Mogan Applications",
             DOXYGEN_DIR = get_config("buildir"),
             DEVEL_VERSION = DEVEL_VERSION,
         }


### PR DESCRIPTION
Besides, by now, the executable file for **Mogan Research** is still `mogan.exe`. Should we change it to `mogan_research.exe`?

Some code about this:
```lua
target("research") do 
    set_version(XMACS_VERSION)
    set_installdir(INSTALL_DIR)

    if is_plat("macosx") then
        set_filename("Mogan")
    elseif is_plat("mingw") then
        set_filename("mogan.exe")
    else
        set_filename("mogan")
    ende
```