### PR TITLE
[49_1] add compilation switch to toggle experimental feature

### DIFF
--- a/src/System/config.h.xmake
+++ b/src/System/config.h.xmake
@@ -1,6 +1,5 @@
 /* L1 Kernel */
 ${define QTTEXMACS}
-${define SANITY_CHECKS}
 ${define OS_MINGW}
 
 /* Define to 1 if the system has the type `intptr_t'. */
@@ -112,6 +111,8 @@ ${define USE_QT_PRINTER}
 
 ${define USE_CURL}
 
+${define SANITY_CHECKS}
+
 #define SIZEOF_VOID_P ${SIZEOF_VOID_P} 
 
 /* Define to 1 if you have the ANSI C header files. */
@@ -120,6 +121,8 @@ ${define STDC_HEADERS}
 #define TEXMACS_REVISION "${VERSION}"
 
 ${define TM_DYNAMIC_LINKING}
+
+${define USE_EXCEPTIONS}
 
 /* Use freetype library */
 ${define USE_FREETYPE}

--- a/xmake.lua
+++ b/xmake.lua
@@ -89,6 +89,34 @@ add_requires_of_mogan()
 
 
 --
+-- Experimental options of Mogan
+--
+option("experimental")
+    set_description("Enable experimental style rewriting code")
+    set_default(false)
+    set_values(false, true)
+option_end()
+if has_config("experimental") then
+    set_configvar("EXPERIMENTAL", true)
+end
+option("sanity-checks")
+    set_description("Enable sanity checks")
+    set_default(false)
+    set_values(false, true)
+option_end()
+if has_config("sanity-checks") then
+    set_configvar("SANITY_CHECKS", true)
+end
+option("use-exceptions")
+    set_description("Use C++ exception mechanism")
+    set_default(false)
+    set_values(false, true)
+option_end()
+if has_config("use-exceptions") then
+    set_configvar("USE_EXCEPTIONS", true)
+end
+
+--
 -- Library: L3 Kernel
 --
 set_configvar("QTTEXMACS", 1)


### PR DESCRIPTION
This add compilation switch to toggle experimental feature described in #936 , added switch is listed below:

* `experimental`: `EXPERIMENTAL`
* `sanity-checks`: `SANITY_CHECKS`
* `use-exceptions`: `USE_EXCEPTIONS`

## Example
```
xmake config --experimental=y --sanity-checks=y --use-exceptions=y
```

## Known issues
- [ ] check whether `USE_EXCEPTIONS` define take effect in objective-c++ `mm` file
- [ ] add `sanity-checks` option to lolly
- [ ] check whether definition of `USE_EXCEPTIONS` in lolly affects mogan code
- [ ] add integrated test for experimental style expansion

