### PR TITLE
[32_8] set minimal xmake version to 2.8.2

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -9,6 +9,8 @@
 -- It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
 -- in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
 
+set_xmakever("2.8.2")
+
 -- Check CXX Types/Includes/Funcs/Snippets
 includes("check_cxxtypes.lua")
 includes("check_cxxincludes.lua")


### PR DESCRIPTION
Because we are using `add_forceincludes`.
https://xmake.io/#/manual/project_target?id=targetadd_forceincludes