### PR TITLE
[24_3] fix str2num bug

### DIFF
--- a/plugins/html/progs/convert/html/tmhtml.scm
+++ b/plugins/html/progs/convert/html/tmhtml.scm
@@ -921,9 +921,26 @@
 (define (tmhtml-with-color val arg)
   `((h:font (@ (color ,(tmcolor->htmlcolor val))) ,@(tmhtml arg))))
 
+(define (my-string->number str)
+  (let ((result (string->number-helper str 0 0)))
+    (if (positive? result)
+        result
+        (if (negative? result)
+            result
+            0))))
+
+(define (string->number-helper str index acc)
+  (if (>= index (string-length str))
+      acc
+      (let ((char (string-ref str index)))
+        (if (char-numeric? char)
+            (string->number-helper str (+ index 1) (+ (* acc 10) (- (char->integer char) (char->integer #\0))))
+            #f))))
+
 (define (tmhtml-with-font-size val arg)
   (ahash-with tmhtml-env :mag val
-    (let* ((x (* (string->number val) 100))
+  ;(display* " [DEBUG]" val "end")
+    (let* ((x (* (my-string->number val) 100))
            (c (string-append "font-size: " (number->string x) "%"))
 	   (s (cond ((< x 1) "-4") ((< x 55) "-4") ((< x 65) "-3")
 		    ((< x 75) "-2") ((< x 95) "-1") ((< x 115) "0")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why you open this Pull Request?

Close: https://github.com/XmacsLabs/mogan/issues/1030
<!-- For example: "Closes #1234" -->

<!-- Please give a short summary of the change and the problem this solves. -->
内置的`string->number`函数接受空字符串会返回#f，使用自定义的`my-string->number`函数就解决了这个问题


## What work have you done in the current Pull Request?

<!-- Briefly describe what you have completed and what you have yet to complete -->

- [x] 重写了 string->number 函数




