### PR TITLE
[53_7] draw: init_tbox

### DIFF
--- a/src/Mogan/Draw/draw.cpp
+++ b/src/Mogan/Draw/draw.cpp
@@ -498,6 +498,7 @@ immediate_options (int argc, char** argv) {
 
 int
 main (int argc, char** argv) {
+  lolly::init_tbox ();
 
 #ifdef STACK_SIZE
   struct rlimit limit;


### PR DESCRIPTION
https://github.com/XmacsLabs/mogan/commit/7ebc87ff6518103ca5705c39ad398edea1c929e6 breaks the mogan draw app.
This pr will fix it.