### PR TITLE
[56_1] Use get-tm-cache-path instead hard coded path

### DIFF
--- a/TeXmacs/progs/doc/apidoc-collect.scm
+++ b/TeXmacs/progs/doc/apidoc-collect.scm
@@ -78,7 +78,7 @@
     (if (and (!= pref "default") (url-exists? (system->url pref)))
         (system->url pref)
         (with new (persistent-file-name
-                   (unix->url "$TEXMACS_HOME_PATH/system/cache/")
+                   (get-tm-cache-path)
                    "api")
           (set-preference "doc:doc-scm-cache" (url->system new))
           new))))
@@ -89,7 +89,7 @@
     (if (and (!= pref "default") (url-exists? (system->url pref)))
         (system->url pref)
         (with new (persistent-file-name 
-                   (unix->url "$TEXMACS_HOME_PATH/system/cache/")
+                   (get-tm-cache-path)
                    "api")
           (set-preference "doc:doc-macro-cache" (url->system new))
           new))))

--- a/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-plugins.scm
@@ -333,7 +333,7 @@
 
 (define-public reconfigure-flag? #t)
 (define plugin-loaded-setup? #f)
-(define plugin-cache "$TEXMACS_HOME_PATH/system/cache/plugin_cache.scm")
+(define plugin-cache (url->string (url-append (get-tm-cache-path) "plugin_cache.scm")))
 
 (define plugin-check-path "")
 (define check-dir-table (make-ahash-table))

--- a/TeXmacs/progs/texmacs/texmacs/tm-tools.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-tools.scm
@@ -81,9 +81,9 @@
 
 (tm-define (clear-font-cache)
   (:synopsis "Clear font cache under TEXMACS_HOME_PATH.")
+  (system-remove (url-append (get-tm-cache-path) (string->url "font_cache.scm")))
   (map system-remove
     (list
-      "$TEXMACS_HOME_PATH/system/cache/font_cache.scm"
       "$TEXMACS_HOME_PATH/fonts/font-database.scm"
       "$TEXMACS_HOME_PATH/fonts/font-features.scm"
       "$TEXMACS_HOME_PATH/fonts/font-characteristics.scm")))

--- a/src/Data/Document/new_style.cpp
+++ b/src/Data/Document/new_style.cpp
@@ -108,7 +108,7 @@ style_invalidate_cache () {
     sd= NULL;
   }
   init_style_data ();
-  remove ("$TEXMACS_HOME_PATH/system/cache" * url_wildcard ("__*"));
+  remove (get_tm_cache_path() * url_wildcard ("__*"));
 }
 
 void
@@ -117,7 +117,7 @@ style_set_cache (tree style, hashmap<string,tree> H, tree t) {
   // cout << "set cache " << style << LF;
   sd->style_cache (copy (style))= H;
   sd->style_drd   (copy (style))= t;
-  url name ("$TEXMACS_HOME_PATH/system/cache", cache_file_name (style));
+  url name= get_tm_cache_path () * url (cache_file_name (style));
   if (!exists (name)) {
     save_string (name, tree_to_scheme (tuple (as_tree (H), t)));
     // cout << "saved " << name << LF;
@@ -136,7 +136,7 @@ style_get_cache (tree style, hashmap<string,tree>& H, tree& t, bool& f) {
   }
   else {
     string s;
-    url name ("$TEXMACS_HOME_PATH/system/cache", cache_file_name (style));
+    url name= get_tm_cache_path () * url (cache_file_name (style));
     if (exists (name) && (!load_string (name, s, false))) {
       //cout << "loaded " << name << LF;
       tree p= scheme_to_tree (s);

--- a/src/Graphics/Fonts/font_database.cpp
+++ b/src/Graphics/Fonts/font_database.cpp
@@ -155,7 +155,7 @@ font_database_save_database (url u) {
   string s= scheme_tree_to_block (tree (TUPLE, r));
   save_string (u, s);
   // FIXME: this should not be necessary
-  remove ("$TEXMACS_PATH/system/cache/file_cache");
+  remove (get_tm_cache_path () * url ("file_cache"));
   cache_refresh ();
 }
 
@@ -173,7 +173,7 @@ font_database_save_features (url u) {
   string s= scheme_tree_to_block (tree (TUPLE, r));
   save_string (u, s);
   // FIXME: this should not be necessary
-  remove ("$TEXMACS_PATH/system/cache/file_cache");
+  remove (get_tm_cache_path () * url ("file_cache"));
   cache_refresh ();
 }
 
@@ -189,7 +189,7 @@ font_database_save_characteristics (url u) {
   string s= scheme_tree_to_block (tree (TUPLE, r));
   save_string (u, s);
   // FIXME: this should not be necessary
-  remove ("$TEXMACS_PATH/system/cache/file_cache");
+  remove (get_tm_cache_path () * url ("file_cache"));
   cache_refresh ();
 }
 

--- a/src/Mogan/Code/code.cpp
+++ b/src/Mogan/Code/code.cpp
@@ -448,36 +448,36 @@ immediate_options (int argc, char** argv) {
     if ((s == "-S") || (s == "-setup")) {
       remove (url ("$TEXMACS_HOME_PATH/system/settings.scm"));
       remove (url ("$TEXMACS_HOME_PATH/system/setup.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+      remove (get_tm_cache_path () * url_wildcard ("*"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
     }
     else if (s == "-delete-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+      remove (get_tm_cache_path () * url_wildcard ("*"));
     else if (s == "-delete-style-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("__*"));
+      remove (get_tm_cache_path () * url_wildcard ("__*"));
     else if (s == "-delete-font-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/font_cache.scm"));
+      remove (get_tm_cache_path () * url ("font_cache.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
     }
     else if (s == "-delete-doc-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+      remove (get_tm_cache_path () * url ("doc_cache"));
+      remove (get_tm_cache_path () * url ("dir_cache.scm"));
+      remove (get_tm_cache_path () * url ("stat_cache.scm"));
     }
     else if (s == "-delete-file-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/file_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+      remove (get_tm_cache_path () * url ("file_cache"));
+      remove (get_tm_cache_path () * url ("doc_cache"));
+      remove (get_tm_cache_path () * url ("dir_cache.scm"));
+      remove (get_tm_cache_path () * url ("stat_cache.scm"));
     }
     else if (s == "-delete-plugin-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/plugin_cache.scm"));
+      remove (get_tm_cache_path () * url ("plugin_cache.scm"));
     else if (s == "-delete-server-data")
       system ("rm -rf", url ("$TEXMACS_HOME_PATH/server"));
     else if (s == "-delete-databases") {

--- a/src/Mogan/Draw/draw.cpp
+++ b/src/Mogan/Draw/draw.cpp
@@ -448,36 +448,36 @@ immediate_options (int argc, char** argv) {
     if ((s == "-S") || (s == "-setup")) {
       remove (url ("$TEXMACS_HOME_PATH/system/settings.scm"));
       remove (url ("$TEXMACS_HOME_PATH/system/setup.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+      remove (get_tm_cache_path () * url_wildcard ("*"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
     }
     else if (s == "-delete-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+      remove (get_tm_cache_path () * url_wildcard ("*"));
     else if (s == "-delete-style-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("__*"));
+      remove (get_tm_cache_path () * url_wildcard ("__*"));
     else if (s == "-delete-font-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/font_cache.scm"));
+      remove (get_tm_cache_path () * url ("font_cache.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
     }
     else if (s == "-delete-doc-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+      remove (get_tm_cache_path () * url ("doc_cache"));
+      remove (get_tm_cache_path () * url ("dir_cache.scm"));
+      remove (get_tm_cache_path () * url ("stat_cache.scm"));
     }
     else if (s == "-delete-file-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/file_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+      remove (get_tm_cache_path () * url ("file_cache"));
+      remove (get_tm_cache_path () * url ("doc_cache"));
+      remove (get_tm_cache_path () * url ("dir_cache.scm"));
+      remove (get_tm_cache_path () * url ("stat_cache.scm"));
     }
     else if (s == "-delete-plugin-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/plugin_cache.scm"));
+      remove (get_tm_cache_path () * url ("plugin_cache.scm"));
     else if (s == "-delete-server-data")
       system ("rm -rf", url ("$TEXMACS_HOME_PATH/server"));
     else if (s == "-delete-databases") {

--- a/src/Mogan/Research/research.cpp
+++ b/src/Mogan/Research/research.cpp
@@ -619,36 +619,36 @@ immediate_options (int argc, char** argv) {
     if ((s == "-S") || (s == "-setup")) {
       remove (url ("$TEXMACS_HOME_PATH/system/settings.scm"));
       remove (url ("$TEXMACS_HOME_PATH/system/setup.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+      remove (get_tm_cache_path () * url_wildcard ("*"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
     }
     else if (s == "-delete-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+      remove (get_tm_cache_path () * url_wildcard ("*"));
     else if (s == "-delete-style-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("__*"));
+      remove (get_tm_cache_path () * url_wildcard ("__*"));
     else if (s == "-delete-font-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/font_cache.scm"));
+      remove (get_tm_cache_path () * url ("font_cache.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));
       remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
     }
     else if (s == "-delete-doc-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+      remove (get_tm_cache_path () * url ("doc_cache"));
+      remove (get_tm_cache_path () * url ("dir_cache.scm"));
+      remove (get_tm_cache_path () * url ("stat_cache.scm"));
     }
     else if (s == "-delete-file-cache") {
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/file_cache"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+      remove (get_tm_cache_path () * url ("file_cache"));
+      remove (get_tm_cache_path () * url ("doc_cache"));
+      remove (get_tm_cache_path () * url ("dir_cache.scm"));
+      remove (get_tm_cache_path () * url ("stat_cache.scm"));
     }
     else if (s == "-delete-plugin-cache")
-      remove (url ("$TEXMACS_HOME_PATH/system/cache/plugin_cache.scm"));
+      remove (get_tm_cache_path () * url ("plugin_cache.scm"));
     else if (s == "-delete-server-data")
       system ("rm -rf", url ("$TEXMACS_HOME_PATH/server"));
     else if (s == "-delete-databases") {
@@ -721,7 +721,7 @@ main (int argc, char** argv) {
     cout << "TeXmacs] Performing setup (Alt on startup)" << LF;
     remove (url ("$TEXMACS_HOME_PATH/system/settings.scm"));
     remove (url ("$TEXMACS_HOME_PATH/system/setup.scm"));
-    remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+    remove (get_tm_cache_path () * url_wildcard ("*"));
     remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));
   }
 #endif

--- a/src/Scheme/L2/glue_misc.lua
+++ b/src/Scheme/L2/glue_misc.lua
@@ -107,6 +107,11 @@ function main()
                 ret_type = "url"
             },
             {
+                scm_name = "get-tm-cache-path",
+                cpp_name = "get_tm_cache_path",
+                ret_type = "url"
+            },
+            {
                 scm_name = "default-look-and-feel",
                 cpp_name = "default_look_and_feel",
                 ret_type = "string"

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -168,7 +168,7 @@ init_user_dirs () {
   make_dir ("$TEXMACS_HOME_PATH/styles");
   make_dir ("$TEXMACS_HOME_PATH/system");
   make_dir ("$TEXMACS_HOME_PATH/system/bib");
-  make_dir ("$TEXMACS_HOME_PATH/system/cache");
+  make_dir (get_tm_cache_path ());
   make_dir ("$TEXMACS_HOME_PATH/system/database");
   make_dir ("$TEXMACS_HOME_PATH/system/database/bib");
   make_dir ("$TEXMACS_HOME_PATH/system/make");
@@ -189,7 +189,7 @@ acquire_boot_lock () {
   if (exists (lock_file)) {
     remove (url ("$TEXMACS_HOME_PATH/system/settings.scm"));
     remove (url ("$TEXMACS_HOME_PATH/system/setup.scm"));
-    remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("*"));
+    remove (get_tm_cache_path () * url_wildcard ("*"));
     remove (url ("$TEXMACS_HOME_PATH/fonts/error") * url_wildcard ("*"));    
   }
   else save_string (lock_file, "", false);

--- a/src/System/Boot/init_upgrade.cpp
+++ b/src/System/Boot/init_upgrade.cpp
@@ -116,11 +116,11 @@ init_upgrade () {
   init_upgrade_doc (install_version);
 
   remove (url ("$TEXMACS_HOME_PATH/system/setup.scm"));
-  remove (url ("$TEXMACS_HOME_PATH/system/cache") * url_wildcard ("__*"));
-  remove (url ("$TEXMACS_HOME_PATH/system/cache/dir_cache.scm"));
-  remove (url ("$TEXMACS_HOME_PATH/system/cache/doc_cache"));
-  remove (url ("$TEXMACS_HOME_PATH/system/cache/file_cache"));
-  remove (url ("$TEXMACS_HOME_PATH/system/cache/stat_cache.scm"));
+  remove (get_tm_cache_path () * url_wildcard ("__*"));
+  remove (get_tm_cache_path () * url ("dir_cache.scm"));
+  remove (get_tm_cache_path () * url ("doc_cache"));
+  remove (get_tm_cache_path () * url ("file_cache"));
+  remove (get_tm_cache_path () * url ("stat_cache.scm"));
   remove (url ("$TEXMACS_HOME_PATH/fonts/font-database.scm"));
   remove (url ("$TEXMACS_HOME_PATH/fonts/font-features.scm"));
   remove (url ("$TEXMACS_HOME_PATH/fonts/font-characteristics.scm"));

--- a/src/System/Misc/data_cache.cpp
+++ b/src/System/Misc/data_cache.cpp
@@ -161,7 +161,7 @@ do_cache_doc (string name) {
 void
 cache_save (string buffer) {
   if (cache_changed->contains (buffer)) {
-    url cache_file= texmacs_home_path * url ("system/cache/" * buffer);
+    url cache_file= get_tm_cache_path () * url (buffer);
     string cached;
     iterator<tree> it= iterate (cache_data);
     if (buffer == "file_cache" || buffer == "doc_cache") {
@@ -193,7 +193,7 @@ cache_save (string buffer) {
 void
 cache_load (string buffer) {
   if (!cache_loaded->contains (buffer)) {
-    url cache_file = texmacs_home_path * url ("system/cache/" * buffer);
+    url cache_file= get_tm_cache_path () * url (buffer);
     //cout << "cache_file "<< cache_file << LF;
     string cached;
     if (!load_string (cache_file, cached, false)) {

--- a/src/System/Misc/tm_sys_utils.cpp
+++ b/src/System/Misc/tm_sys_utils.cpp
@@ -97,6 +97,10 @@ get_texmacs_home_path () {
   return path;
 }
 
+url
+get_tm_cache_path () {
+  return url ("$TEXMACS_HOME_PATH/system/cache");
+}
 
 string 
 get_printing_default () {

--- a/src/System/Misc/tm_sys_utils.hpp
+++ b/src/System/Misc/tm_sys_utils.hpp
@@ -30,6 +30,7 @@ string var_eval_system (string s);
 
 url get_texmacs_path ();
 url get_texmacs_home_path ();
+url get_tm_cache_path ();
 
 string get_printing_default ();
 bool has_printing_cmd (void);


### PR DESCRIPTION
## Why you open this Pull Request?
Use `(get-tm-cache-path)` instead of `(string->url "$TEXMACS_HOME_PATH/system/cache")` to simplify the change of the TeXmacs cache directory.


## What work have you done in the current Pull Request?
- [x] Replace all usages in cpp
- [x] Replace all usages in scheme



