### PR TITLE
[49_5] use qt.console instead of -mconsole

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -804,10 +804,10 @@ function add_target_research_on_others()
         set_optimize("smallest");
     end
 
-    if is_plat("macosx", "linux", "windows") then
-        add_rules("qt.widgetapp")
+    if is_mode("debug", "releasedbg") and is_plat("mingw", "windows") then
+        add_rules("qt.console")
     else
-        add_rules("qt.widgetapp_static")
+        add_rules("qt.widgetapp")
     end
 
     add_frameworks("QtGui", "QtWidgets", "QtCore", "QtPrintSupport", "QtSvg")
@@ -818,11 +818,6 @@ function add_target_research_on_others()
     add_packages("lolly")
     if is_plat("mingw", "windows") then
         add_packages("qt5widgets")
-    end
-
-    if is_plat("mingw") and is_mode("releasedbg") then
-        set_policy("check.auto_ignore_flags", false)
-        add_ldflags("-mconsole")
     end
 
     add_deps("libmogan")
@@ -1127,19 +1122,14 @@ function add_target_tm2html()
         set_optimize("smallest");
     end
 
-    if is_plat("macosx", "linux", "windows") then
-        add_rules("qt.widgetapp")
+    if is_mode("debug", "releasedbg") and is_plat("mingw", "windows") then
+        add_rules("qt.console")
     else
-        add_rules("qt.widgetapp_static")
+        add_rules("qt.widgetapp")
     end
 
     if is_plat("macosx") then
         add_frameworks("QtMacExtras")
-    end
-
-    if is_plat("mingw") and is_mode("releasedbg") then
-        set_policy("check.auto_ignore_flags", false)
-        add_ldflags("-mconsole")
     end
 
     if is_plat("linux") then


### PR DESCRIPTION
## Why you open this Pull Request?

Simplify xmake.lua and avoid setting linker flag manually.

see also https://github.com/xmake-io/xmake/discussions/3910

## What work have you done in the current Pull Request?

- [x] Remove link option `-mconsole`
- [x] Simplify checking for console display, now checking on windows also.



