### PR TITLE
[29_7] remove dead code

### DIFF
--- a/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
@@ -198,71 +198,78 @@ is_internal_style (string style) {
   return internal_styles->contains (style);
 }
 
-array<url>
-get_linked_file_paths (tree t, url path) {
-  list<tree> st (t);
-  array<url> tm_and_linked_file;
-  while (N (st) != 0) {
-    auto la= last_item (st);
-    st     = suppress_last (st);
-    for (int i= 0; i < arity (la); i++) {
-      if (is_compound (la[i])) {
-        string label= get_label (la[i]);
-        if (label == "image" || label == "include") {
-          if (is_atomic (la[i][0])) {
-            url pre_url= url (get_label (la[i][0]));
-            if (!exists (pre_url)) {
-              pre_url= relative (path, pre_url);
-              if (!exists (pre_url)) {
-                debug_convert << pre_url << "do not exist" << LF;
-              }
-            }
-            tm_and_linked_file= append (pre_url, tm_and_linked_file);
-          }
-        }
-        else if (label == "style") {
-          if (get_label (la[i][0]) == "tuple") {
-            for (int j= 0; j < N (la[i][0]); j++) {
-              string style_name= get_label (la[i][0][j]);
-              if (!is_internal_style (style_name)) {
-                url style_url= url (style_name);
-                style_url    = glue (style_url, ".ts");
-                if (!exists (style_url)) {
-                  style_url= relative (path, style_url);
-                  if (!exists (style_url)) {
-                    debug_convert << style_url << "do not exist" << LF;
-                    continue;
-                  }
-                }
-                tm_and_linked_file= append (style_url, tm_and_linked_file);
-              }
-            }
-          }
-          else {
-            if (!is_atomic (la[i][0])) {
-              debug_convert << get_label (la[i][0]) << "is not atomic tree"
-                            << LF;
-            }
-            string style_name= get_label (la[i][0]);
-            if (!is_internal_style (style_name)) {
-              url style_url= url (style_name);
-              style_url    = glue (style_url, ".ts");
-              if (!exists (style_url)) {
-                style_url= relative (path, style_url);
-                if (!exists (style_url)) {
-                  debug_convert << style_url << "do not exist" << LF;
-                  continue;
-                }
-              }
-              tm_and_linked_file= append (style_url, tm_and_linked_file);
-            }
-          }
-        }
-        else st= st * la[i];
+url image_and_include_tree_operate(tree t, url path){
+  if (is_atomic (t[0])) {
+    url pre_url= url (get_label (t[0]));
+    if (!exists (pre_url)) {
+      pre_url= relative (path, pre_url);
+      if (!exists (pre_url)) {
+        debug_convert << pre_url << " do not exist\n" << LF;
+      }
+    }
+    return pre_url;
+  }else{
+    debug_convert << t << " image or include tree format wrong\n" << LF;
+    return url();
+  }
+}
+url get_actural_style_url(string style_name, url path){
+  url style_file;
+  if (!is_internal_style (style_name)) {
+    style_file    = glue (url (style_name), ".ts");
+    if (!exists (style_file)) {
+      style_file= relative (path, style_file);
+      if (!exists (style_file)) {
+        debug_convert << style_file << "do not exist" << LF;
+        style_file = url();
       }
     }
   }
+  return style_file;
+}
+array<url> style_tree_operate(tree t, url path){
+  //cout << "style_tree_operate t -> " << t << " path -> " << path << LF;
+  array<url> style_file;
+  //print_tree(t);
+  if(N(t) == 0)
+    return style_file;
+  if (get_label (t[0]) == "tuple") {
+    for (int i= 0; i < N (t[0]); i++) {
+      url style_url = get_actural_style_url(get_label (t[0][i]), path);
+      if(style_url != url())
+        style_file << style_url;
+    }
+  }
+  else {
+    if (!is_atomic (t[0])) {
+      debug_convert << get_label (t[0]) << "is not atomic tree"
+                    << LF;
+      return style_file;
+    }
+    url style_url = get_actural_style_url(get_label (t[0]), path);
+    if(style_url != url())
+      style_file << style_url;
+  }
+  return style_file;
+}
 
+array<url>
+get_linked_file_paths (tree t, url path){
+  //print_tree(t);
+  array<url> tm_and_linked_file;
+  string label= get_label (t);
+  // cout << "label -> " << label << LF;
+  // cout << "N(t) -> " << N(t) << LF;
+  if(label == "image" || label == "include"){
+    tm_and_linked_file << image_and_include_tree_operate(t, path);
+    return tm_and_linked_file;
+  }
+  if(label == "style")
+    return style_tree_operate(t, path);
+  if(!is_atomic (t))
+    for(int i = 0; i < N(t); i ++){
+      tm_and_linked_file << get_linked_file_paths(t[i], path);
+    }
   return tm_and_linked_file;
 }
 

--- a/tests/Plugins/Pdf/pdf_make_attachment_test.cpp
+++ b/tests/Plugins/Pdf/pdf_make_attachment_test.cpp
@@ -171,9 +171,9 @@ TestHummusPdfMakeAttachment::test_get_linked_file_paths () {
       texmacs_tree_2, url ("$TEXMACS_PATH/tests/29_4_2multiple-files/main.tm"));
   QVERIFY (N (linked) == 2);
   QVERIFY (is_regular (linked[0]));
-  QVERIFY (tail (linked[0]) == url ("logo.pdf"));
+  QVERIFY (tail (linked[0]) == url ("myslides.ts"));
   QVERIFY (is_regular (linked[1]));
-  QVERIFY (tail (linked[1]) == url ("myslides.ts"));
+  QVERIFY (tail (linked[1]) == url ("logo.pdf"));
 }
 void
 TestHummusPdfMakeAttachment::test_replace_with_relative_path () {


### PR DESCRIPTION

In project 29, it is necessary to add conversion methods for pdf format and tm format, but the conversion method from tm to pdf is actually a pdf export method, so the method implemented here is useless


