### PR TITLE
[29_7] remove dead code

### DIFF
--- a/TeXmacs/plugins/pdf/progs/init-pdf.scm
+++ b/TeXmacs/plugins/pdf/progs/init-pdf.scm
@@ -12,29 +12,6 @@
 (texmacs-module (pdf-format))
 
 
-(define (texmacs->pdf x . opts)
-  (let* ((tem-dir (url-temp-dir))
-          (tem-pdf (url-append tem-dir "tem.pdf"))
-          (tem-tm (url-append tem-dir "tem.tm"))
-          (url-list (pdf-get-linked-file-paths x buffer-get)))
-  (string-save (serialize-texmacs (pdf-replace-linked-path x buffer-get)) tem-tm)
-  
-  (let* ((cur (current-buffer))
-          (buf (buffer-new)))
-    (buffer-set-master buf cur)
-    (switch-to-buffer buf)
-    (load-buffer tem-tm)
-    (set-drd cur)
-    (dynamic-make-slides)
-    (print-to-file tem-pdf)
-    (switch-to-buffer cur)
-    (buffer-close buf))
-  (if (pdf-make-attachments tem-pdf url-list tem-pdf)
-    (string-load tem-pdf)
-    (begin
-      (notify-now "Can not make attachments to pdf normally")
-      (texmacs-error "pdf" "Can not make attachments to pdf normally")))))
-
 (define (pdf->texmacs x . opts)
   (let* ((tem-dir (url-temp-dir))
           (tem-pdf (url-append tem-dir "tem.pdf"))
@@ -48,8 +25,6 @@
           (notify-now "Can not extract attachments from PDF")
           (texmacs-error "pdf" "Can not extract attachments from PDF")))))
 
-(converter texmacs-tree pdf-document
-  (:function texmacs->pdf))
 
 (converter pdf-document texmacs-tree
   (:function pdf->texmacs))


### PR DESCRIPTION
In project 29, it is necessary to add conversion methods for pdf format and tm format, but the conversion method from tm to pdf is actually a pdf export method, so the method implemented here is useless