### PR TITLE
[29_7] refactor replace_with_relative_path

### DIFF
--- a/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
@@ -275,7 +275,9 @@ get_linked_file_paths (tree t, url path) {
   return tm_and_linked_file;
 }
 
-tree
+//Pass in an image or include tree and a path.
+//change the url in tree to a url with the same path as the path.
+static tree
 replace_url_image_or_include_tree (tree t, url path) {
   if (get_label (t) != "image" && get_label (t) != "include") {
     debug_convert << get_label (t) << " is not image or include" << LF;
@@ -304,7 +306,10 @@ replace_url_image_or_include_tree (tree t, url path) {
   }
   return t;
 }
-tree
+
+//Pass in an tree with style label and a path.
+//change the label to a url with the same path as the path.
+static tree
 repalce_url_style (tree t, url path) {
   if (!is_atomic (t)) {
     debug_convert << get_label (t) << " is not atomic" << LF;
@@ -328,7 +333,10 @@ repalce_url_style (tree t, url path) {
   }
   return t;
 }
-tree
+
+//Pass in an style tree and a path.
+//change the urls in style tree to a url with the same path as the path.
+static tree
 replace_url_style_tree (tree t, url path) {
   if (get_label (t) != "style") {
     debug_convert << get_label (t) << " is not style" << LF;

--- a/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_extract_attachment.cpp
@@ -275,8 +275,8 @@ get_linked_file_paths (tree t, url path) {
   return tm_and_linked_file;
 }
 
-//Pass in an image or include tree and a path.
-//change the url in tree to a url with the same path as the path.
+// Pass in an image or include tree and a path.
+// change the url in tree to a url with the same path as the path.
 static tree
 replace_url_image_or_include_tree (tree t, url path) {
   if (get_label (t) != "image" && get_label (t) != "include") {
@@ -307,8 +307,8 @@ replace_url_image_or_include_tree (tree t, url path) {
   return t;
 }
 
-//Pass in an tree with style label and a path.
-//change the label to a url with the same path as the path.
+// Pass in an tree with style label and a path.
+// change the label to a url with the same path as the path.
 static tree
 repalce_url_style (tree t, url path) {
   if (!is_atomic (t)) {
@@ -334,8 +334,8 @@ repalce_url_style (tree t, url path) {
   return t;
 }
 
-//Pass in an style tree and a path.
-//change the urls in style tree to a url with the same path as the path.
+// Pass in an style tree and a path.
+// change the urls in style tree to a url with the same path as the path.
 static tree
 replace_url_style_tree (tree t, url path) {
   if (get_label (t) != "style") {


### PR DESCRIPTION
Change the traversal method of tm_tree from loop to recursion, and split the style tree and image tree processing into small functions to improve code readability and neatness