### PR TITLE
[63_2] Merge contiguous indices for sorted bib items

### DIFF
--- a/TeXmacs/progs/check/check-master.scm
+++ b/TeXmacs/progs/check/check-master.scm
@@ -25,7 +25,8 @@
         (convert tmml tmmltm-test)
         (prog prog-format-test)
         (fonts fonts-test)
-        (graphics graphics-group-test)))
+        (graphics graphics-group-test)
+        (utils cite cite-sort-test)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test LaTeX export
@@ -99,4 +100,5 @@
   (regtest-fonts)
   (regtest-tm-tools)
   (regtest-graphics-group)
+  (regtest-cite-sort)
 )

--- a/TeXmacs/progs/utils/cite/cite-sort-test.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort-test.scm
@@ -14,17 +14,57 @@
 (texmacs-module (utils cite cite-sort-test)
   (:use (utils cite cite-sort)))
 
-(tm-define (regtest-cite-sort)
-  (define (math->tree x) (htmltm-as-serial (cons 'math x)))
+(define (regtest-indice-sort)
   (regression-test-group
-   "mathtm" "mathtm"
-   math->tree :none 
-   (test "identifier" '((mi "x")) "x")
-   (test "operator" '((mi "x") (mo "+") (mi "y")) "x+y")
-   (test "numeral" '((mn "2") (mo "+") (mi "x")) "2+x")
-   ;; (test "exponent" '(msup (mi "x") (mn "2")) '(concat "x" (rsup "2")))
-   ;; (test "special ops"
-   ;;   '(mrow (mn "3") (mo "&InvisibleTimes;") (mi "x")
-   ;;      (mo "*") (msup (mi "y") (mn "4")))
-   ;;   '(concat "3*x<ast>y" (rsup "4")))   
+   "test indice sorting and merging" "indice-sort"
+   indice-sort :none 
+   (test "unmerged two element"
+     '(("1" (reference "bib1"))
+       ("2" (reference "bib2"))
+       ("4" (reference "bib4"))
+       ("5" (reference "bib5")))
+     '((reference "bib1")
+       (reference "bib2")
+       (reference "bib4")
+       (reference "bib5")))
+   (test "unmerged one element"
+     '(("1" (reference "bib1"))
+       ("3" (reference "bib3")))
+     '((reference "bib1")
+       (reference "bib3")))
+   (test "discontinue merge"
+     '(("1" (reference "bib1"))
+       ("3" (reference "bib3"))
+       ("4" (reference "bib4"))
+       ("5" (reference "bib5"))
+       ("7" (reference "bib7")))
+     '((reference "bib1")
+       (concat
+         (reference "bib3")
+         "-"
+         (reference "bib5"))
+       (reference "bib7")))
+   (test "merge at lease three elements"
+     '(("1" (reference "bib1"))
+       ("2" (reference "bib2"))
+       ("3" (reference "bib3")))
+     '((concat
+         (reference "bib1")
+         "-"
+         (reference "bib3"))))
+   (test "merge five elements"
+     '(("1" (reference "bib1"))
+       ("3" (reference "bib3"))
+       ("4" (reference "bib4"))
+       ("2" (reference "bib2"))
+       ("5" (reference "bib5")))
+     '((concat
+         (reference "bib1")
+         "-"
+         (reference "bib5"))))
 ))
+
+(tm-define (regtest-cite-sort)
+  (let ((n (+ (regtest-indice-sort))))
+    (display* "Total: " (object->string n) " tests.\n")
+    (display "Test suite of cite-sort: ok\n")))

--- a/TeXmacs/progs/utils/cite/cite-sort-test.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort-test.scm
@@ -1,0 +1,30 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : cite-sort-test.scm
+;; DESCRIPTION : Test suite for cite-sort package
+;; COPYRIGHT   : (C) 2023  jingkaimori
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (utils cite cite-sort-test)
+  (:use (utils cite cite-sort)))
+
+(tm-define (regtest-cite-sort)
+  (define (math->tree x) (htmltm-as-serial (cons 'math x)))
+  (regression-test-group
+   "mathtm" "mathtm"
+   math->tree :none 
+   (test "identifier" '((mi "x")) "x")
+   (test "operator" '((mi "x") (mo "+") (mi "y")) "x+y")
+   (test "numeral" '((mn "2") (mo "+") (mi "x")) "2+x")
+   ;; (test "exponent" '(msup (mi "x") (mn "2")) '(concat "x" (rsup "2")))
+   ;; (test "special ops"
+   ;;   '(mrow (mn "3") (mo "&InvisibleTimes;") (mi "x")
+   ;;      (mo "*") (msup (mi "y") (mn "4")))
+   ;;   '(concat "3*x<ast>y" (rsup "4")))   
+))

--- a/TeXmacs/progs/utils/cite/cite-sort.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort.scm
@@ -50,8 +50,7 @@
             (merge-contiguous new (cdr old) (list (car old)))
             (if (compare-cite-keys (cAr present) (car old) compare-string-inc?)
                 (merge-contiguous new (cdr old) (append present (list (car old))))
-                (merge-contiguous (append new (flush)) (cdr old) (list (car old)))
-                )))))
+                (merge-contiguous (append new (flush)) (cdr old) (list (car old))))))))
 
 (tm-define (indice-sort tup)
   (let* ((sorted-tup 

--- a/TeXmacs/progs/utils/cite/cite-sort.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort.scm
@@ -18,18 +18,39 @@
     (< (string->number s1) (string->number s2))
     (string<? s1 s2)))
 
-(define (compare-cite-keys t1 t2)
+(define (compare-string-inc? s1 s2)
+  (if (and (string->number s1) (string->number s2))
+    (== 1 (- (string->number s2) (string->number s1)))
+    #f))
+
+(define (compare-cite-keys t1 t2 comparator)
   (let*
     ((t1 (car t1))
      (t2 (car t2))
      (s1 (if (string? t1) t1 (convert t1 "stm-snippet" "verbatim-snippet")))
      (s2 (if (string? t2) t2 (convert t2 "stm-snippet" "verbatim-snippet"))))
-    (compare-string s1 s2)))
+    (comparator s1 s2)))
 
 (define (expand-references k)
   (with key (stree->tree `(get-binding ,(cadr k)))
     (with ret (tree->stree (texmacs-exec key))
       (if (!= ret '(uninit)) ret ""))))
+(define (merge-contiguous new old present)
+  (let ((flush
+        (lambda ()
+          (if (> (length present) 2)
+              (list (list (caar present) `(concat ,@(cdar present) "-" ,@(cdAr present))))
+              present))))
+    (if (null? old)
+        (if (null? present)
+            new
+            (append new (flush)))
+        (if (null? present)
+            (merge-contiguous new (cdr old) (list (car old)))
+            (if (compare-cite-keys (cAr present) (car old) compare-string-inc?)
+                (merge-contiguous new (cdr old) (append present (list (car old))))
+                (merge-contiguous (append new (flush)) (cdr old) (list (car old)))
+                )))))
 
 (tm-define (cite-sort args)
   ;; get a (tuple (tuple key_1 value_1) ... (tuple key_n value_n))
@@ -38,8 +59,9 @@
   (let* ((args (map tree->stree (tree-children args)))
          (keys (map expand-references (map caddr args)))
          (tup (map list keys args))
-         (sorted-tup (list-sort tup compare-cite-keys))
-         ;; we should merge contiguous number series here...
-         (sorted-args (map cadr sorted-tup))
-         (ret `(concat ,@(list-intersperse sorted-args '(cite-sep)))))
+         (sorted-tup 
+           (list-sort tup (lambda (s1 s2) (compare-cite-keys s1 s2 compare-string))))
+         (merged-tup (merge-contiguous '() sorted-tup '()))
+         (merged-args (map cadr merged-tup))
+         (ret `(concat ,@(list-intersperse merged-args '(cite-sep)))))
     ret))

--- a/TeXmacs/progs/utils/cite/cite-sort.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort.scm
@@ -33,8 +33,6 @@
 
 (define (expand-references k)
   (with key (stree->tree `(get-binding ,(cadr k)))
-    (display* "key:" (object->string (tree->stree key)))
-    (newline)
     (with ret (tree->stree (texmacs-exec key))
       (if (!= ret '(uninit)) ret ""))))
 
@@ -55,6 +53,13 @@
                 (merge-contiguous (append new (flush)) (cdr old) (list (car old)))
                 )))))
 
+(tm-define (indice-sort tup)
+  (let* ((sorted-tup 
+           (list-sort tup (lambda (s1 s2) (compare-cite-keys s1 s2 compare-string))))
+         (merged-tup (merge-contiguous '() sorted-tup '()))
+         (merged-args (map cadr merged-tup)))
+    merged-args))
+
 (tm-define (cite-sort args)
   ;; get a (tuple (tuple key_1 value_1) ... (tuple key_n value_n))
   ;; and sort it according to values.
@@ -63,9 +68,6 @@
   (let* ((args (map tree->stree (tree-children args)))
          (keys (map expand-references (map caddr args)))
          (tup (map list keys args))
-         (sorted-tup 
-           (list-sort tup (lambda (s1 s2) (compare-cite-keys s1 s2 compare-string))))
-         (merged-tup (merge-contiguous '() sorted-tup '()))
-         (merged-args (map cadr merged-tup))
+         (merged-args (indice-sort tup))
          (ret `(concat ,@(list-intersperse merged-args '(cite-sep)))))
     ret))

--- a/TeXmacs/progs/utils/cite/cite-sort.scm
+++ b/TeXmacs/progs/utils/cite/cite-sort.scm
@@ -33,8 +33,11 @@
 
 (define (expand-references k)
   (with key (stree->tree `(get-binding ,(cadr k)))
+    (display* "key:" (object->string (tree->stree key)))
+    (newline)
     (with ret (tree->stree (texmacs-exec key))
       (if (!= ret '(uninit)) ret ""))))
+
 (define (merge-contiguous new old present)
   (let ((flush
         (lambda ()
@@ -56,6 +59,7 @@
   ;; get a (tuple (tuple key_1 value_1) ... (tuple key_n value_n))
   ;; and sort it according to values.
   (:secure #t)
+  ; (display "args: " (tree->stree args))
   (let* ((args (map tree->stree (tree-children args)))
          (keys (map expand-references (map caddr args)))
          (tup (map list keys args))


### PR DESCRIPTION
## Why you open this Pull Request?

Merge continuous citing indices, close #166 :
| Origin | Merged |
|--------|--------|
| [1, 2, 3] | [1-3] |
| [1, 2, 3, 4, 5] | [1-5] |
| [1, 3, 4, 5, 7] | [1, 3-5, 7] |
| [1, 2, 4, 5] | [1, 2, 4, 5] | 

Users should add `cite-sort` style package explicitly to enable this feature.

[Origin patch is provided by Zhengfei Hu(hammer)](https://savannah.gnu.org/patch/?10339) @hammerfunctor 

## What work have you done in the current Pull Request?

- [x] import Zhengfei Hu's work
- [x] improve origin patch slightly



