### PR TITLE
[23_27] Draw arc: fix bug when 3 points in one line

### DIFF
--- a/TeXmacs/progs/graphics/graphics-markup.scm
+++ b/TeXmacs/progs/graphics/graphics-markup.scm
@@ -97,7 +97,11 @@
                 (if (> (points-cross-product-k vec-c-p vec-c-q) 0)
                   (points-add (point-times (point-get-unit (points-sub mid-p-x c)) (- r)) c)
                   (if (= (points-cross-product-k vec-c-p vec-c-q) 0)
-                    x
+                    ;; If cross product == 0, then the angle between vec-c-p and vec-c-q is 0 or 180.
+                    ;; We should find out whether it's 0 or 180.
+                    (if (equal? (point-get-unit vec-c-p) (point-get-unit vec-c-q))
+                      x
+                      (point-rotate-90 vec-c-p))
                     (points-add (point-times (point-get-unit (points-sub mid-p-x c)) r) c))))))
     `(arc ,p ,m ,x)))
 

--- a/TeXmacs/progs/graphics/graphics-markup.scm
+++ b/TeXmacs/progs/graphics/graphics-markup.scm
@@ -101,7 +101,7 @@
                     ;; We should find out whether it's 0 or 180.
                     (if (equal? (point-get-unit vec-c-p) (point-get-unit vec-c-q))
                       x
-                      (point-rotate-90 vec-c-p))
+                      (point-rotate-90 (point-rotate-90 (point-rotate-90 vec-c-p))))
                     (points-add (point-times (point-get-unit (points-sub mid-p-x c)) r) c))))))
     `(arc ,p ,m ,x)))
 

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -759,6 +759,11 @@
   `(point ,(f2s (/ (point-get-x pt) f))
           ,(f2s (/ (point-get-y pt) f))))
 
+; Rotate 90 degrees. input (x,y) output (-y,x)
+(tm-define (point-rotate-90 pt)
+  `(point ,(f2s (- (point-get-y pt)))
+          ,(f2s (point-get-x pt))))
+
 (tm-define (points-mid P1 P2)
   (point-div (points-add P1 P2) 2))
 

--- a/TeXmacs/progs/graphics/graphics-utils.scm
+++ b/TeXmacs/progs/graphics/graphics-utils.scm
@@ -760,6 +760,7 @@
           ,(f2s (/ (point-get-y pt) f))))
 
 ; Rotate 90 degrees. input (x,y) output (-y,x)
+; anti-clockwise
 (tm-define (point-rotate-90 pt)
   `(point ,(f2s (- (point-get-y pt)))
           ,(f2s (point-get-x pt))))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why you open this Pull Request?

Fix a bug about drawing arc. 

Bug: if 3 points in one line, it could be a semi-circle. But in previous version, we can not get a semi-circle. The program will give a line. Now it's fixed. We can get a semi-circle.



## What work have you done in the current Pull Request?
- [x] change the logic in drawing arc




