### PR TITLE
[7_8] fix crashing caused by missing gs binary on windows

### DIFF
--- a/src/Plugins/Ghostscript/gs_utilities.cpp
+++ b/src/Plugins/Ghostscript/gs_utilities.cpp
@@ -28,7 +28,12 @@ gs_system () {
   url gs= url_system ("C:\\") * url_wildcard ("Program Files*") *
           url_system ("gs") * url_wildcard ("gs*") * url_system ("bin") *
           url_wildcard ("gswin*c.exe");
-  return materialize (gs);
+  if (exists (gs)) {
+    return materialize (gs);
+  }
+  else {
+    return "gs.exe";
+  }
 #else
   return "gs";
 #endif


### PR DESCRIPTION
## Why you open this Pull Request?

Fix the first issue in https://gitee.com/XmacsLabs/mogan/issues/I8MZW1 , fix crashing when exporting given document to pdf. But export fails after this patch.

## What work have you done in the current Pull Request?

- [x] handle situation of missing ghostscript under default install position



