### PR TITLE
[71_23] Open file defaults to home path when current dir is root

### DIFF
--- a/src/Plugins/Qt/qt_chooser_widget.cpp
+++ b/src/Plugins/Qt/qt_chooser_widget.cpp
@@ -249,10 +249,12 @@ qt_chooser_widget_rep::perform_dialog () {
   dialog->setLabelText (QFileDialog::LookIn,
                         to_qstring (translate ("Directory")));
 
+#ifdef OS_MACOS
   // If the current directory is root, we should reset it to home
   if ((dialog->directory ()).isRoot ()) {
     dialog->setDirectory (QDir::home ());
   }
+#endif
 
   dialog->updateGeometry ();
   QSize  sz = dialog->sizeHint ();

--- a/src/Plugins/Qt/qt_chooser_widget.cpp
+++ b/src/Plugins/Qt/qt_chooser_widget.cpp
@@ -249,6 +249,11 @@ qt_chooser_widget_rep::perform_dialog () {
   dialog->setLabelText (QFileDialog::LookIn,
                         to_qstring (translate ("Directory")));
 
+  // If the current directory is root, we should reset it to home
+  if ((dialog->directory ()).isRoot ()) {
+    dialog->setDirectory (QDir::home ());
+  }
+
   dialog->updateGeometry ();
   QSize  sz = dialog->sizeHint ();
   QPoint pos= to_qpoint (position);


### PR DESCRIPTION
On macOS, `File -> Open` when the current-buffer is scratch, the current dir will be root directory. It should be set to homedir.