### PR TITLE
[11_17] Use local font_rev_table to speedup tt_font_exists

### DIFF
--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -254,6 +254,7 @@ array<string> font_database_search (string fam, string var, string series,
                                     string shape);
 array<string> font_database_characteristics (string family, string style);
 tree          font_database_substitutions (string family);
+bool          font_database_rev_contains (string font_file_name);
 
 // Font selection
 tree          array_as_tuple (array<string> a);

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -14,6 +14,7 @@
 #include "analyze.hpp"
 #include "data_cache.hpp"
 #include "file.hpp"
+#include "font.hpp"
 #include "hashmap.hpp"
 #include "preferences.hpp"
 #include "scheme.hpp"
@@ -136,6 +137,22 @@ tt_font_find_sub (string name) {
   // cout << "tt_font_find " << name << "\n";
   url u= tt_unpack (name);
   if (!is_none (u)) return u;
+
+  if (font_database_rev_contains (name * ".ttf")) {
+    u= tt_locate (name * ".ttf");
+    if (!is_none (u)) return u;
+  }
+
+  if (font_database_rev_contains (name * ".ttc")) {
+    u= tt_locate (name * ".ttc");
+    if (!is_none (u)) return u;
+  }
+
+  if (font_database_rev_contains (name * ".otf")) {
+    u= tt_locate (name * ".otf");
+    if (!is_none (u)) return u;
+  }
+
   u= tt_locate (name * ".pfb");
   // if (!is_none (u)) cout << name << " -> " << u << "\n";
   if (!is_none (u)) return u;


### PR DESCRIPTION
Before
```
TeXmacs] std-bench, Task 'tt_locate Songti.pfb' took 1057 ms
TeXmacs] std-bench, Task 'tt_locate Songti.ttf' took 23 ms
TeXmacs] std-bench, Task 'tt_locate Songti.ttc' took 19 ms
TeXmacs] std-bench, Task 'tt_font_exists Songti' took 1099 ms
```
Now
```
TeXmacs] std-bench, Task 'tt_locate Songti.ttc' took 16 ms
TeXmacs] std-bench, Task 'tt_font_exists Songti' took 270 ms
```
or
```
TeXmacs] std-bench, Task 'tt_locate Songti.ttc' took 17 ms
TeXmacs] std-bench, Task 'tt_font_exists Songti' took 36 ms
```