### PR TITLE
[11_20] Improved junctions for virtual \in, \subset ...

### DIFF
--- a/TeXmacs/fonts/virtual/emu-setrels.vfn
+++ b/TeXmacs/fonts/virtual/emu-setrels.vfn
@@ -12,8 +12,9 @@
 
   (prein (with w (width ohalf)
            (join (align* ohalf (w 0 sheqset*) 1 * 0 *)
-                 (w 0 sheqset*))))
-  (preni (pretend (join sheqset* (align* halfo sheqset* 0 * 1 *)) prein))
+                 (w 0 (junc-left sheqset* 0.1)))))
+  (preni (pretend (join (junc-right sheqset* 0.1)
+                        (align* halfo sheqset* 0 * 1 *)) prein))
   (minus-in (or (font minus Carlito)
                 (scale* minus prein 1 0)))
   (minus-ni (or (font (scale* minus preni 0.5 0) Carlito)
@@ -26,9 +27,10 @@
   (subset (bitmap
             (with w (width ohalf)
               (join (align* ohalf (w 0 sheqset) 1 * 0 *)
-                    (w 0 sheqset)))))
+                    (w 0 (junc-left sheqset 0.1))))))
   (supset (bitmap
-            (pretend (join sheqset (align* halfo sheqset 0 * 1 *)) subset)))
+            (pretend (join (junc-right sheqset 0.1)
+                           (align* halfo sheqset 0 * 1 *)) subset)))
   (subseteq (stack-less subset (hor-scale minus subset)))
   (supseteq (stack-less supset (hor-scale minus supset)))
   (subseteqq (stack-less subset (hor-scale = subset)))

--- a/src/Graphics/Bitmap_fonts/bitmap_font.hpp
+++ b/src/Graphics/Bitmap_fonts/bitmap_font.hpp
@@ -104,6 +104,8 @@ glyph move        (glyph gl, SI x, SI y);
 glyph bar_right   (glyph gl1, glyph gl2);
 glyph bar_bottom  (glyph gl1, glyph gl2);
 glyph copy        (glyph gl);
+glyph junc_left   (glyph gl, int jw);
+glyph junc_right  (glyph gl, int jw);
 glyph simplify    (glyph gl);
 glyph padded      (glyph gl, int l, int t, int r, int b);
 glyph clip        (glyph gl, SI x1, SI y1, SI x2, SI y3);

--- a/src/Graphics/Bitmap_fonts/glyph_ops.cpp
+++ b/src/Graphics/Bitmap_fonts/glyph_ops.cpp
@@ -258,6 +258,44 @@ copy (glyph gl) {
 }
 
 glyph
+junc_left (glyph gl, int jw) {
+  int i, j, k;
+  int ww= gl->width, hh= gl->height;
+  glyph bmr (ww, hh, gl->xoff, gl->yoff, gl->depth);
+  jw= min (jw, ww);
+  for (j=0; j<hh; j++) {
+    for (i=0; i<ww; i++)
+      bmr->set_x (i, j, gl->get_x (i, j));
+    for (i=0; i<jw; i++)
+      if (gl->get_x (i, j) != 0) {
+        for (k=0; k<i; k++)
+          bmr->set_x (k, j, gl->get_x (i, j));
+        break;
+      }
+  }
+  return bmr;
+}
+
+glyph
+junc_right (glyph gl, int jw) {
+  int i, j, k;
+  int ww= gl->width, hh= gl->height;
+  glyph bmr (ww, hh, gl->xoff, gl->yoff, gl->depth);
+  jw= min (jw, ww);
+  for (j=0; j<hh; j++) {
+    for (i=0; i<ww; i++)
+      bmr->set_x (i, j, gl->get_x (i, j));
+    for (i=ww-1; i>=ww-jw; i--)
+      if (gl->get_x (i, j) != 0) {
+        for (k=i+1; k<ww; k++)
+          bmr->set_x (k, j, gl->get_x (i, j));
+        break;
+      }
+  }
+  return bmr;
+}
+
+glyph
 simplify (glyph gl) {
   int i, j;
   int ww= gl->width, hh= gl->height;

--- a/src/Graphics/Fonts/virtual_font.cpp
+++ b/src/Graphics/Fonts/virtual_font.cpp
@@ -322,6 +322,8 @@ virtual_font_rep::supported (scheme_tree t, bool svg) {
       is_tuple (t, "ver-crop", 1) || is_tuple (t, "top-crop", 1) ||
       is_tuple (t, "bottom-crop", 1) || is_tuple (t, "clip") ||
       is_tuple (t, "part") || is_tuple (t, "copy", 1) ||
+      (is_tuple (t, "junc-left", 2) && is_double (t[2]) && !svg) ||
+      (is_tuple (t, "junc-right", 2) && is_double (t[2]) && !svg) ||
       is_tuple (t, "hor-flip", 1) || is_tuple (t, "ver-flip", 1) ||
       is_tuple (t, "rot-left", 1) || is_tuple (t, "rot-right", 1) ||
       (is_tuple (t, "rotate") && N (t) >= 3) ||
@@ -782,6 +784,20 @@ virtual_font_rep::compile_bis (scheme_tree t, metric& ex) {
   }
 
   if (is_tuple (t, "copy", 1)) return copy (compile (t[1], ex));
+
+  if (is_tuple (t, "junc-left", 2) && is_double (t[2])) {
+    glyph gl1= compile (t[1], ex);
+    SI  w = (SI) (as_double (t[2]) * (ex->x2 - ex->x1));
+    int jw= max (w / PIXEL, 0);
+    return junc_left (compile (t[1], ex), jw);
+  }
+
+  if (is_tuple (t, "junc-right", 2) && is_double (t[2])) {
+    glyph gl1= compile (t[1], ex);
+    SI  w = (SI) (as_double (t[2]) * (ex->x2 - ex->x1));
+    int jw= max (w / PIXEL, 0);
+    return junc_right (compile (t[1], ex), jw);
+  }
 
   if (is_tuple (t, "hor-flip", 1)) return hor_flip (compile (t[1], ex));
 


### PR DESCRIPTION
## Why you open this Pull Request?

import 14126 revision from texmacs to mogan, which tweaks display of in, ni, subset and supset. Image below shows result of these change, with Carlito font. Font of four line is `italic-bold`, `italic-regular`, `regular`, and `bold` from top to bottom.

Rendering before this PR:

<img width="250" alt="改前" src="https://github.com/XmacsLabs/mogan/assets/36156959/8d30b7d2-936d-4219-a291-00b6eb191de7">

Rendering after this PR:

<img width="669" alt="改后" src="https://github.com/XmacsLabs/mogan/assets/36156959/a492bf30-ba74-4061-9279-2c3b1f486b3d">

## What work have you done in the current Pull Request?

- [x] tweaking virtual font define of those four characters.
- [x] add `junc-left` and `junc-right` rules for virtual font.


Co-authored-by: Joris van der Hoeven <vdhoeven@lix.polytechnique.fr>
