### PR TITLE
[47_5] Fix bug: Inserting "include" macro does not work from keyboard

### DIFF
--- a/src/Edit/Modify/edit_dynamic.cpp
+++ b/src/Edit/Modify/edit_dynamic.cpp
@@ -133,7 +133,8 @@ edit_dynamic_rep::make_compound (tree_label l, int n= -1) {
       insert_tree (t, p);
       return;
     }
-    if ((block_macro && (!table_macro)) ||
+    if ((block_macro && (!table_macro) &&
+         l != INCLUDE && l != VAR_INCLUDE) ||
         (l == make_tree_label ("footnote")) ||
         (l == make_tree_label ("footnote-anchor")) ||
         (l == make_tree_label ("note-footnote")) ||


### PR DESCRIPTION
…

## Why you open this Pull Request?

Importing revision 14129, fixes broken `include` macro inserted from slash command.


## What work have you done in the current Pull Request?

- [x]  tweaking editor interface



