### PR TITLE
[7_2] Revert: Use long array instead of long list to avoid stackoverflow

### DIFF
--- a/src/Kernel/Types/rectangles.cpp
+++ b/src/Kernel/Types/rectangles.cpp
@@ -271,20 +271,6 @@ least_upper_bound (rectangles l) {
   return r1;
 }
 
-rectangle
-least_upper_bound (array<rectangle> l) {
-  ASSERT (N (l) != 0, "no rectangles in list");
-  rectangle r1= l[0];
-  for (int i=1; i<N(l); i++) {
-    rectangle r2= l[i];
-    r1->x1= min (r1->x1, r2->x1);
-    r1->y1= min (r1->y1, r2->y1);
-    r1->x2= max (r1->x2, r2->x2);
-    r1->y2= max (r1->y2, r2->y2);
-  }
-  return r1;
-}
-
 double
 area (rectangles r) {
   double sum= 0.0;

--- a/src/Kernel/Types/rectangles.hpp
+++ b/src/Kernel/Types/rectangles.hpp
@@ -60,7 +60,6 @@ rectangles outlines (rectangles l, SI pixel);
 rectangles correct (rectangles l);
 rectangles simplify (rectangles l);
 rectangle  least_upper_bound (rectangles l);
-rectangle  least_upper_bound (array<rectangle> l);
 double area (rectangles r);
 
 #endif // defined RECTANGLES_H

--- a/src/Typeset/Boxes/Basic/boxes.cpp
+++ b/src/Typeset/Boxes/Basic/boxes.cpp
@@ -861,7 +861,7 @@ box_rep::display_links (renderer ren) {
 }
 
 void
-box_rep::position_at (SI x, SI y, array<rectangle>& change_log) {
+box_rep::position_at (SI x, SI y, rectangles& change_log) {
   int i, n= subnr ();
   x += x0; y += y0;
   for (i=0; i<n; i++) subbox (i)->position_at (x, y, change_log);

--- a/src/Typeset/Boxes/Composite/concat_boxes.cpp
+++ b/src/Typeset/Boxes/Composite/concat_boxes.cpp
@@ -620,11 +620,11 @@ concat_box_rep::graphical_select (SI x1, SI y1, SI x2, SI y2) {
 
 class phrase_box_rep: public concat_box_rep {
 public:
-  array<rectangle>* logs_ptr;
+  rectangles* logs_ptr;
   SI          ox, oy;
   phrase_box_rep (path ip, array<box> bs, array<SI> spc);
   ~phrase_box_rep ();
-  void position_at (SI x, SI y, array<rectangle>& change_log_ptr);
+  void position_at (SI x, SI y, rectangles& change_log_ptr);
   void display (renderer ren);
 };
 
@@ -633,23 +633,20 @@ phrase_box_rep::phrase_box_rep (path ip, array<box> bs, array<SI> spc):
 
 phrase_box_rep::~phrase_box_rep () {
   if (logs_ptr != NULL) {
-    array<rectangle>& logs= *logs_ptr;
-    logs= array<rectangle>(rectangle (0, 0, 0, 0), rectangle (ox+x3, oy+y3, ox+x4, oy+y4));
+    rectangles& logs= *logs_ptr;
+    logs= rectangles (rectangle (ox+x3, oy+y3, ox+x4, oy+y4), logs);
+    logs= rectangles (rectangle (0, 0, 0, 0), logs);
     // cout << "  8=X " << rectangle (ox+x3, oy+y3, ox+x4, oy+y4) << "\n";
   }
 }
 
 void
-phrase_box_rep::position_at (SI x, SI y, array<rectangle>& logs) {
+phrase_box_rep::position_at (SI x, SI y, rectangles& logs) {
   x += x0; y += y0;
-  if (logs_ptr == NULL) {
-    logs << rectangle (0, 0, 0, 0);
-  }
-  else {
-    logs << rectangle (ox+x3, oy+y3, ox+x4, oy+y4);
-  }
+  if (logs_ptr == NULL) logs= rectangles (rectangle (0, 0, 0, 0), logs);
+  else logs= rectangles (rectangle (ox+x3, oy+y3, ox+x4, oy+y4), logs);
   ox= x; oy= y;
-  logs << rectangle (ox+x3, oy+y3, ox+x4, oy+y4);
+  logs= rectangles (rectangle (ox+x3, oy+y3, ox+x4, oy+y4), logs);
   logs_ptr= &logs;
 }
 

--- a/src/Typeset/Bridge/impl_typesetter.hpp
+++ b/src/Typeset/Bridge/impl_typesetter.hpp
@@ -17,7 +17,7 @@ class typesetter_rep {
 public:
   edit_env&    env;
   bridge       br;
-  array<rectangle> change_log;
+  rectangles   change_log;
   array<brush> old_bgs;
 
   array<page_item> l;      // current lines

--- a/src/Typeset/Bridge/typesetter.cpp
+++ b/src/Typeset/Bridge/typesetter.cpp
@@ -105,15 +105,16 @@ typesetter_rep::local_end (array<page_item>& prev_l, stack_border& prev_sb) {
 * Main typesetting routines
 ******************************************************************************/
 
-static array<rectangle>
-requires_update (array<rectangle> log) {
-  array<rectangle> rs;
-  for (int i=0; 2*i+1<N(log); i++) {
-    rectangle r1= log[2*i];
-    rectangle r2= log[2*i+1];
-    if (r1 == rectangle (0, 0, 0, 0)) rs << r2;
-    else if (r2 == rectangle (0, 0, 0, 0)) rs << r1;
-    else if (r1 != r2) rs << r1 << r2;
+static rectangles
+requires_update (rectangles log) {
+  rectangles rs;
+  while (!is_nil (log)) {
+    rectangle r1= log->item;
+    rectangle r2= log->next->item;
+    if (r1 == rectangle (0, 0, 0, 0)) rs= rectangles (r2, rs);
+    else if (r2 == rectangle (0, 0, 0, 0)) rs= rectangles (r1, rs);
+    else if (r1 != r2) rs= rectangles (r1, rectangles (r2, rs));
+    log= log->next->next;
   }
   return reverse (rs);
 }
@@ -180,7 +181,7 @@ typesetter_rep::typeset (SI& x1b, SI& y1b, SI& x2b, SI& y2b) {
   b->position_at (0, 0, change_log);
   change_log= requires_update (change_log);
   rectangle r (0, 0, 0, 0);
-  if (N(change_log) != 0) r= least_upper_bound (change_log);
+  if (!is_nil (change_log)) r= least_upper_bound (change_log);
   array<brush> new_bgs;
   array<rectangle> rs;
   b->collect_page_colors (new_bgs, rs);
@@ -189,7 +190,7 @@ typesetter_rep::typeset (SI& x1b, SI& y1b, SI& x2b, SI& y2b) {
       r= least_upper_bound (r, rs[i]);
   old_bgs= new_bgs;
   x1b= r->x1; y1b= r->y1; x2b= r->x2; y2b= r->y2;
-  change_log= array<rectangle> ();
+  change_log= rectangles ();
   return b;
 }
 

--- a/src/Typeset/boxes.hpp
+++ b/src/Typeset/boxes.hpp
@@ -146,7 +146,7 @@ public:
   virtual tree message (tree t, SI x, SI y, rectangles& rs);
   virtual void loci (SI x, SI y, SI d, list<string>& ids, rectangles& rs);
   virtual void display_links (renderer ren);
-  virtual void position_at (SI x, SI y, array<rectangle>& change_log);
+  virtual void position_at (SI x, SI y, rectangles& change_log);
   virtual void collect_page_numbers (hashmap<string,tree>& h, tree page);
   virtual void collect_page_colors (array<brush>& bs, array<rectangle>& rs);
   virtual path find_tag (string name);


### PR DESCRIPTION
This reverts commit 5f8724a21742dcc1fc87255bc88ac2ba44e73744.