### PR TITLE
[59_13] Refactor keyboard handling on printable ascii characters with/without modifiers

### DIFF
--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -614,6 +614,7 @@
   ("macos r" (interactive-replace))
   ("macos F" (toggle-full-screen-mode))
   ("macos C-f" (toggle-full-screen-edit-mode))
+  ("macos S-=" (zoom-in (sqrt (sqrt 2.0))))
 
   ("altcmd x" (interactive footer-eval))
   ("altcmd X" (interactive exec-interactive-command))

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -342,9 +342,13 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
   initkeymap ();
 
   int                   key     = event->key ();
-  QKeyCombination       key_comb= event->keyCombination ();
   Qt::KeyboardModifiers mods    = event->modifiers ();
   QString               nss     = event->text ();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  QKeyCombination       key_comb= event->keyCombination ();
+#endif
+
 #if defined(OS_MINGW) || defined(OS_WIN)
   /* "Qt::Key_AltGr On Windows, when the KeyDown event for this key is sent,
    * the Ctrl+Alt modifiers are also set." (excerpt from Qt doc)
@@ -388,12 +392,14 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
     string key_s= string (key_c);
     r           = "A-" * key_s;
   }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   else if (key < 128 && (mods & Qt::ControlModifier) &&
            (mods & Qt::ShiftModifier) && !(mods & Qt::AltModifier) &&
            !(mods & Qt::MetaModifier)) {
     // Ctrl+Shift+key on Windows/Linux, Command+Shift+key on macOS
     r= from_qkeysequence (QKeySequence (key_comb));
   }
+#endif
   else { // Old keyboard handling code
     if (qtkeymap->contains (key)) {
       r= qtkeymap[key];

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -22,8 +22,6 @@
 #include "scheme.hpp"
 #include "sys_utils.hpp"
 
-#include "config.h"
-
 #include <lolly/data/numeral.hpp>
 using lolly::data::as_hexadecimal;
 
@@ -358,6 +356,9 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
       // M-: Win+key or Command+key
       r << mods_text << key_locased;
     }
+    else if (mods_text == "C-A-") {
+      r << mods_text << key_locased;
+    }
     else if (mods_text == "A-S-") {
       // A-+, A-{, A-?, ...
       r << "A-" << key_original;
@@ -380,6 +381,9 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
           r << "M-" << key_original;
         }
       }
+    }
+    else if (mods_text == "C-A-S-") {
+      r << "C-A-" << key_original;
     }
     else {
       // NOTE: Qt 6 on macOS, M-A- and M-C- is handled in keyReleaseEvent

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -326,13 +326,13 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
     char key_original= (char) key;
     char key_locased = locase (key);
 
-    if (is_empty (mods_text)) {
-      // a-z, 0-9, and others
-      r= key_locased;
-    }
-    else if (mods_text == "S-") {
-      // A-Z and others
-      r= key_original;
+    // With CapsLock, we should use the text_key
+    unsigned short unic= nss.data ()[0].unicode ();
+    char text_key= (char) unic;
+
+    if (is_empty (mods_text) || mods_text == "S-") {
+      // a-z, A-Z, 0-9, and others
+      r << text_key;
     }
     else if (is_locase (key_original)) {
       debug_keyboard << mods_text << key_original << " should be invalid" << LF;

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -373,7 +373,8 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
         if (os_macos ()) {
           // M-+ for Qt 6.5 on macOS is M-S-=
           r << "M-S-" << key_original;
-        } else {
+        }
+        else {
           r << "M-" << key_original;
         }
       }

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -22,7 +22,8 @@
 #include "scheme.hpp"
 #include "sys_utils.hpp"
 
-#include "config.h"
+#include <lolly/data/numeral.hpp>
+using lolly::data::as_hexadecimal;
 
 #include <QApplication>
 #include <QDebug>
@@ -321,14 +322,25 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
   Qt::KeyboardModifiers mods     = event->modifiers ();
   string                mods_text= from_modifiers (mods);
 
+  // See https://doc.qt.io/qt-6/qt.html#Key-enum
+  // cout << "key:\t0x" << locase_all (as_hexadecimal (key, 8)) << LF;
+  // if (is_printable_key (key)) {
+  //   cout << "raw:\t" << mods_text << (char) key << LF;
+  // }
+  // else {
+  //   cout << "mods:\t" << mods_text << LF;
+  // }
+  // cout << "text(" << nss.count () << "):\t" << from_qstring (nss) << LF;
+  // cout << LF;
+
   string r= "";
   if (is_printable_key (key)) {
     char key_original= (char) key;
     char key_locased = locase (key);
 
     // With CapsLock, we should use the text_key
-    unsigned short unic= nss.data ()[0].unicode ();
-    char text_key= (char) unic;
+    unsigned short unic    = nss.data ()[0].unicode ();
+    char           text_key= (char) unic;
 
     if (is_empty (mods_text) || mods_text == "S-") {
       // a-z, A-Z, 0-9, and others

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -297,8 +297,9 @@ void
 QTMWidget::keyPressEvent (QKeyEvent* event) {
   if (is_nil (tmwid)) return;
 
-  int     key= event->key ();
-  QString nss= event->text ();
+  int                   key = event->key ();
+  QString               nss = event->text ();
+  Qt::KeyboardModifiers mods= event->modifiers ();
 
 #if defined(OS_MINGW) || defined(OS_WIN)
   /* "Qt::Key_AltGr On Windows, when the KeyDown event for this key is sent,
@@ -319,8 +320,7 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
   }
 #endif
 
-  Qt::KeyboardModifiers mods     = event->modifiers ();
-  string                mods_text= from_modifiers (mods);
+  string mods_text= from_modifiers (mods);
 
   // See https://doc.qt.io/qt-6/qt.html#Key-enum
   // cout << "key:\t0x" << locase_all (as_hexadecimal (key, 8)) << LF;

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -494,7 +494,7 @@ QTMWidget::keyReleaseEvent (QKeyEvent* event) {
 
     // see https://bugreports.qt.io/browse/QTBUG-115525
     // This branch is only for Option-Command-x or Ctrl-Command-x
-    if (mods_text == "M-A" || mods_text == "M-C") {
+    if (mods_text == "M-A-" || mods_text == "M-C-") {
       string r;
       if (is_printable_key (key)) {
         char key_c= (char) key;

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -370,7 +370,12 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
         r << "M-" << key_original;
       }
       else {
-        r << "M-S-" << key_locased;
+        if (os_macos ()) {
+          // M-+ for Qt 6.5 on macOS is M-S-=
+          r << "M-S-" << key_original;
+        } else {
+          r << "M-" << key_original;
+        }
       }
     }
     else {

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -338,25 +338,31 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
       debug_keyboard << mods_text << key_original << " should be invalid" << LF;
       r= "";
     }
-    else if (mods_text == "A-" || mods_text == "C-") {
+    else if (mods_text == "A-" || mods_text == "C-" || mods_text == "M-") {
       // A-: Alt+key or Option+key
-      // C-: Ctrl+key or Command+key
+      // C-: Ctrl+key or Ctrl+key
+      // M-: Win+key or Command+key
       r << mods_text << key_locased;
     }
     else if (mods_text == "A-S-") {
-      // A-+, A-{, A-?
+      // A-+, A-{, A-?, ...
       r << "A-" << key_original;
     }
     else if (mods_text == "C-S-") {
+      // C-+, C-{, C-?, ...
+      r << "C-" << key_original;
+    }
+    else if (mods_text == "M-S-") {
       if (is_alpha (key_original)) {
-        // C-A, C-B, ..., C-Z
-        r << "C-" << key_original;
+        // M-A, M-B, ..., M-Z
+        r << "M-" << key_original;
       }
       else {
-        r << "C-S-" << key_locased;
+        r << "M-S-" << key_locased;
       }
     }
     else {
+      // NOTE: Qt 6 on macOS, M-A- and M-C- is handled in keyReleaseEvent
       r << mods_text << key_locased;
     }
   }

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -480,7 +480,7 @@ QTMWidget::keyPressEvent (QKeyEvent* event) {
   }
 
   if (is_empty (r)) return;
-  debug_qt << "key press: " << r << LF;
+  if (DEBUG_KEYBOARD) debug_qt << "key pressed: " << r << LF;
   the_gui->process_keypress (tm_widget (), r, texmacs_time ());
 }
 
@@ -488,15 +488,15 @@ void
 QTMWidget::keyReleaseEvent (QKeyEvent* event) {
   if (os_macos ()) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    Qt::KeyboardModifiers mods= event->modifiers ();
-    int                   key = event->key ();
+    int                   key      = event->key ();
+    Qt::KeyboardModifiers mods     = event->modifiers ();
+    string                mods_text= from_modifiers (mods);
 
     // see https://bugreports.qt.io/browse/QTBUG-115525
     // This branch is only for Option-Command-x or Ctrl-Command-x
-    if ((mods & Qt::ControlModifier) &&
-        ((mods & Qt::AltModifier) || (mods & Qt::MetaModifier))) {
+    if (mods_text == "M-A" || mods_text == "M-C") {
       string r;
-      if (key >= 32 && key < 128) {
+      if (is_printable_key (key)) {
         char key_c= (char) key;
         if ((mods & Qt::ShiftModifier) == 0 && is_upcase (key_c)) {
           key_c= locase (key_c);
@@ -509,13 +509,8 @@ QTMWidget::keyReleaseEvent (QKeyEvent* event) {
       else {
         return;
       }
-      if (mods & Qt::AltModifier) {
-        r= "M-A-" * r;
-      }
-      if (mods & Qt::MetaModifier) {
-        r= "M-C-" * r;
-      }
-      if (DEBUG_QT && DEBUG_KEYBOARD) debug_qt << "key press: " << r << LF;
+      r= mods_text * r;
+      if (DEBUG_KEYBOARD) debug_qt << "key released: " << r << LF;
       the_gui->process_keypress (tm_widget (), r, texmacs_time ());
     }
 #endif

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -22,6 +22,8 @@
 #include "scheme.hpp"
 #include "sys_utils.hpp"
 
+#include "config.h"
+
 #include <lolly/data/numeral.hpp>
 using lolly::data::as_hexadecimal;
 

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -39,6 +39,7 @@
 #include "dictionary.hpp"
 #include "locale.hpp"
 #include "scheme.hpp"
+#include "sys_utils.hpp"
 #include "wencoding.hpp"
 
 #include "editor.hpp"
@@ -1065,4 +1066,21 @@ void
 set_standard_style_sheet (QWidget* w) {
   if (current_style_sheet != "")
     w->setStyleSheet (to_qstring (current_style_sheet));
+}
+
+string
+from_modifiers (Qt::KeyboardModifiers mods) {
+  string r;
+
+  if (mods & Qt::ShiftModifier) r= "S-" * r;
+  if (mods & Qt::AltModifier) r= "A-" * r;
+  if (os_macos ()) {
+    if (mods & Qt::MetaModifier) r= "C-" * r;    // The "Control" key
+    if (mods & Qt::ControlModifier) r= "M-" * r; // The "Command" key
+  }
+  else {
+    if (mods & Qt::ControlModifier) r= "C-" * r;
+    if (mods & Qt::MetaModifier) r= "M-" * r; // The "Windows" key
+  }
+  return r;
 }

--- a/src/Plugins/Qt/qt_utilities.hpp
+++ b/src/Plugins/Qt/qt_utilities.hpp
@@ -166,3 +166,5 @@ tm_ostream& operator<< (tm_ostream& out, coord2 c);
   }
 
 #endif // QT_UTILITIES_HPP
+
+string from_modifiers (Qt::KeyboardModifiers mods);

--- a/src/Plugins/Qt/qt_utilities.hpp
+++ b/src/Plugins/Qt/qt_utilities.hpp
@@ -165,6 +165,6 @@ tm_ostream& operator<< (tm_ostream& out, coord2 c);
     if (DEBUG_QT) debug_qt << x << " not implemented yet.\n";                  \
   }
 
-#endif // QT_UTILITIES_HPP
-
 string from_modifiers (Qt::KeyboardModifiers mods);
+
+#endif // QT_UTILITIES_HPP


### PR DESCRIPTION
+ Refactor keyboard handling with printable ascii characters
+ Fix `Command-+` on macOS to zoom in
+ Shortcuts in Input Method is not handled in this pull request