### PR TITLE
[68_8] extract keywords from abstract-data and add them to exported pdf

### DIFF
--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -579,32 +579,41 @@ search_tag (tree t, string tag) {
 }
 
 static string
-search_metadata_tag (tree doc, string tag) {
-  string r;
-  tree t= search_tag (doc, tag);
-  for (int i=0; i<N(t); i++) {
-    if (N(r) != 0) r << ", ";
-    r << tree_to_verbatim (t[i], false, "cork");
+search_metadata_tag_under (tree doc, string parent, string tag) {
+  tree doc_data= search_tag_quick (doc, parent);
+  if (is_compound (doc_data)) {
+    string r;
+    tree   t= search_tag (doc, tag);
+    for (int i= 0; i < N (t); i++) {
+      if (N (r) != 0) r << ", ";
+      r << tree_to_verbatim (t[i], false, "cork");
+    }
+    return r;
   }
-  return r;
+  else {
+    return "";
+  }
 }
 
 string
 search_metadata (tree doc, string kind) {
-  tree doc_data= search_tag_quick (doc, "doc-data");
-  if (doc_data != "") {
-    if (kind == "title")
-      return search_metadata_tag (doc_data, "doc-title");
-    if (kind == "author")
-      return search_metadata_tag (doc_data, "author-name");
-  }
   if (kind == "title") {
-    tree t= search_tag_quick (doc, "tmdoc-title");
-    if (t != "") return tree_to_verbatim (t[0], false, "cork");
+    string r= search_metadata_tag_under (doc, "doc-data", "doc-title");
+    if (is_empty (r)) {
+      tree t= search_tag_quick (doc, "tmdoc-title");
+      if (t != "") return tree_to_verbatim (t[0], false, "cork");
+      else return "";
+    }
+    else {
+      return r;
+    }
   }
-  tree abstract_data= search_tag_quick (doc, "abstract-data");
-  if (!is_empty (abstract_data)) {
-    if (kind == "keyword") {
+  else if (kind == "author") {
+    return search_metadata_tag_under (doc, "doc-data", "author-name");
+  }
+  else if (kind == "keyword") {
+    tree abstract_data= search_tag_quick (doc, "abstract-data");
+    if (is_compound (abstract_data)) {
       for (int i= 0; i < N (abstract_data); i++) {
         if (is_compound (abstract_data[i], "abstract-keywords")) {
           tree abstract_keywords= abstract_data[i];
@@ -614,13 +623,17 @@ search_metadata (tree doc, string kind) {
           else {
             string r= tree_to_verbatim (abstract_keywords[0], false, "cork");
             for (int i= 1; i < N (abstract_keywords); i++) {
-              r << ", " << tree_to_verbatim (abstract_keywords[i], false, "cork");
+              r << ", "
+                << tree_to_verbatim (abstract_keywords[i], false, "cork");
             }
             return r;
           }
         }
       }
     }
+    return "";
   }
-  return "";
+  else {
+    return "";
+  }
 }

--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -591,16 +591,36 @@ search_metadata_tag (tree doc, string tag) {
 
 string
 search_metadata (tree doc, string kind) {
-  tree dd= search_tag_quick (doc, "doc-data");
-  if (dd != "") {
+  tree doc_data= search_tag_quick (doc, "doc-data");
+  if (doc_data != "") {
     if (kind == "title")
-      return search_metadata_tag (dd, "doc-title");
+      return search_metadata_tag (doc_data, "doc-title");
     if (kind == "author")
-      return search_metadata_tag (dd, "author-name");
+      return search_metadata_tag (doc_data, "author-name");
   }
   if (kind == "title") {
     tree t= search_tag_quick (doc, "tmdoc-title");
     if (t != "") return tree_to_verbatim (t[0], false, "cork");
+  }
+  tree abstract_data= search_tag_quick (doc, "abstract-data");
+  if (!is_empty (abstract_data)) {
+    if (kind == "keyword") {
+      for (int i= 0; i < N (abstract_data); i++) {
+        if (is_compound (abstract_data[i], "abstract-keywords")) {
+          tree abstract_keywords= abstract_data[i];
+          if (N (abstract_keywords) == 0) {
+            return "";
+          }
+          else {
+            string r= tree_to_verbatim (abstract_keywords[0], false, "cork");
+            for (int i= 1; i < N (abstract_keywords); i++) {
+              r << ", " << tree_to_verbatim (abstract_keywords[i], false, "cork");
+            }
+            return r;
+          }
+        }
+      }
+    }
   }
   return "";
 }

--- a/src/Edit/Editor/edit_main.cpp
+++ b/src/Edit/Editor/edit_main.cpp
@@ -289,6 +289,7 @@ edit_main_rep::print_doc (url name, bool conform, int first, int last) {
     ren->set_metadata ("title", get_metadata ("title"));
     ren->set_metadata ("author", get_metadata ("author"));
     ren->set_metadata ("subject", get_metadata ("subject"));
+    ren->set_metadata ("keyword", get_metadata ("keyword"));
     for (i=start; i<end; i++) {
       tree bg= env->read (BG_COLOR);
       ren->set_background (bg);

--- a/src/Plugins/Pdf/pdf_hummus_renderer.cpp
+++ b/src/Plugins/Pdf/pdf_hummus_renderer.cpp
@@ -2002,6 +2002,8 @@ pdf_hummus_renderer_rep::flush_metadata () {
     info.Author= utf8_as_hummus_string (metadata["author"]);
   if (metadata->contains ("subject"))
     info.Subject= utf8_as_hummus_string (metadata["subject"]);
+  if (metadata->contains ("keyword"))
+    info.Keywords= utf8_as_hummus_string (metadata["keyword"]);
   string creator = "Mogan " * string (XMACS_VERSION);
   string producer= creator * " + PDFHummus" * string (PDFHUMMUS_VERSION);
   info.Creator   = utf8_as_hummus_string (creator);

--- a/tests/Data/Convert/convert_test.cpp
+++ b/tests/Data/Convert/convert_test.cpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * MODULE     : converter_test.cpp
+ * DESCRIPTION: Properties of characters and strings
+ * COPYRIGHT  : (C) 2019 Darcy Shen
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "base.hpp"
+#include "convert.hpp"
+#include "tree_helper.hpp"
+
+class TestConverter : public QObject {
+  Q_OBJECT
+
+private slots:
+  void test_search_metadata_data ();
+  void test_search_metadata ();
+};
+
+void
+TestConverter::test_search_metadata_data () {
+  QTest::addColumn<tree> ("input_tree");
+  QTest::addColumn<string> ("title");
+  QTest::addColumn<string> ("author");
+  QTest::addColumn<string> ("keyword");
+
+  QTest::newRow ("regular document")
+      << tree (DOCUMENT,
+               compound (
+                   "doc-data", compound ("doc-title", "Test of Metadata"),
+                   compound ("doc-author",
+                             compound ("author-data",
+                                       compound ("author-name", "author1"))),
+                   compound ("doc-author",
+                             compound ("author-data",
+                                       compound ("author-name", "author2"))),
+                   compound ("doc-author",
+                             compound ("author-data",
+                                       compound ("author-name", "author3")))),
+               compound ("abstract-data",
+                         compound ("abstract-keywords", "keyword 1",
+                                   "keyword 2", "keyword 3")))
+      << string ("Test of Metadata") << string ("author1, author2, author3")
+      << string ("keyword 1, keyword 2, keyword 3");
+  QTest::newRow ("texmacs document")
+      << tree (DOCUMENT, compound ("tmdoc-title", "Test of manual title"))
+      << string ("Test of manual title") << string ("") << string ("");
+}
+
+void
+TestConverter::test_search_metadata () {
+  QFETCH (tree, input_tree);
+  QFETCH (string, title);
+  QFETCH (string, author);
+  QFETCH (string, keyword);
+  qcompare (search_metadata (input_tree, "title"), title);
+  qcompare (search_metadata (input_tree, "author"), author);
+  qcompare (search_metadata (input_tree, "keyword"), keyword);
+}
+
+QTEST_MAIN (TestConverter)
+#include "convert_test.moc"

--- a/tests/Data/Convert/convert_test.cpp
+++ b/tests/Data/Convert/convert_test.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * MODULE     : converter_test.cpp
  * DESCRIPTION: Properties of characters and strings
- * COPYRIGHT  : (C) 2019 Darcy Shen
+ * COPYRIGHT  : (C) 2023 jingkaimori
  *******************************************************************************
  * This software falls under the GNU general public license version 3 or later.
  * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
@@ -30,7 +30,9 @@ TestConverter::test_search_metadata_data () {
   QTest::addColumn<string> ("title");
   QTest::addColumn<string> ("author");
   QTest::addColumn<string> ("keyword");
+  QTest::addColumn<string> ("invalid");
 
+  string empty ("");
   QTest::newRow ("regular document")
       << tree (DOCUMENT,
                compound (
@@ -48,10 +50,10 @@ TestConverter::test_search_metadata_data () {
                          compound ("abstract-keywords", "keyword 1",
                                    "keyword 2", "keyword 3")))
       << string ("Test of Metadata") << string ("author1, author2, author3")
-      << string ("keyword 1, keyword 2, keyword 3");
+      << string ("keyword 1, keyword 2, keyword 3") << empty;
   QTest::newRow ("texmacs document")
       << tree (DOCUMENT, compound ("tmdoc-title", "Test of manual title"))
-      << string ("Test of manual title") << string ("") << string ("");
+      << string ("Test of manual title") << empty << empty << empty;
 }
 
 void
@@ -60,9 +62,11 @@ TestConverter::test_search_metadata () {
   QFETCH (string, title);
   QFETCH (string, author);
   QFETCH (string, keyword);
+  QFETCH (string, invalid);
   qcompare (search_metadata (input_tree, "title"), title);
   qcompare (search_metadata (input_tree, "author"), author);
   qcompare (search_metadata (input_tree, "keyword"), keyword);
+  qcompare (search_metadata (input_tree, "invalid"), invalid);
 }
 
 QTEST_MAIN (TestConverter)

--- a/tests/Data/Convert/convert_test.cpp
+++ b/tests/Data/Convert/convert_test.cpp
@@ -13,7 +13,8 @@
 #include "base.hpp"
 #include "convert.hpp"
 #include "tree_helper.hpp"
-Q_DECLARE_METATYPE(string)
+Q_DECLARE_METATYPE (tree)
+Q_DECLARE_METATYPE (string)
 
 class TestConverter : public QObject {
   Q_OBJECT

--- a/tests/Data/Convert/convert_test.cpp
+++ b/tests/Data/Convert/convert_test.cpp
@@ -13,6 +13,7 @@
 #include "base.hpp"
 #include "convert.hpp"
 #include "tree_helper.hpp"
+Q_DECLARE_METATYPE(string)
 
 class TestConverter : public QObject {
   Q_OBJECT


### PR DESCRIPTION
## Why you open this Pull Request?

## What work have you done in the current Pull Request?

<!-- Briefly describe what you have completed and what you have yet to complete -->

- [x] add a new kind of metadata `keyword`, and corresponding searcher.
- [x] export this metadata to PDF document.
- [ ] related tests for all metadata entries, maybe in separate task

## How to test?

Insert abstraction into a document, and add keywords with focus toolbar. Then export this document to PDF, open exported PDF in browser, and open "document properties" dialogue.