### PR TITLE
[44_4] separate Version->Grain->Block from <block>

### DIFF
--- a/TeXmacs/langs/natural/dic/english-new.scm
+++ b/TeXmacs/langs/natural/dic/english-new.scm
@@ -270,6 +270,7 @@
 ("block" "")
 ("block content" "")
 ("block of code" "")
+("block::version" "")
 ("blue" "")
 ("bluish" "")
 ("blur" "")

--- a/TeXmacs/plugins/lang_zh_CN/data/from_en_US.scm
+++ b/TeXmacs/plugins/lang_zh_CN/data/from_en_US.scm
@@ -195,6 +195,7 @@
 ("blackletter" "黑色字母")
 ("blank column" "空列")
 ("blank row" "空行")
+("block::version" "段落")
 ("block content" "空白内容")
 ("block of code" "代码块")
 ("block" "有框表格")

--- a/TeXmacs/progs/version/version-menu.scm
+++ b/TeXmacs/progs/version/version-menu.scm
@@ -116,5 +116,5 @@
 	("New version" (version-retain 1))))
   (-> "Grain"
       ("Detailed" (version-set-grain "detailed"))
-      ("Block" (version-set-grain "block"))
+      ("Block::version" (version-set-grain "block"))
       ("Rough" (version-set-grain "rough"))))


### PR DESCRIPTION
## Why you open this Pull Request?

Fix translate conflict between Version->Grain->Block menu and <block> tag.



## What work have you done in the current Pull Request?

- [x] rename menu item to `Block::version`
- [x] add corresponding translations 
- [x] add this string to translation template



