### PR TITLE
[44_8] fix error when reading file in subdirectory on windows

### DIFF
--- a/src/Plugins/Git/git.cpp
+++ b/src/Plugins/Git/git.cpp
@@ -56,7 +56,7 @@ git_status_file (url file_u, url repo_u) {
 
   git_repository* repo= NULL;
   c_string        repo_c (as_string (repo_u));
-  c_string        file_c (as_string (file_u));
+  c_string        file_c (as_unix_string (file_u));
   int             error;
   unsigned int    status_flags;
   char            istatus, wstatus;
@@ -119,7 +119,7 @@ git_load_blob (string rev, url file_u, url repo_u) {
   const git_blob* blob = NULL;
   int             error;
   c_string        repo_c (as_string (repo_u));
-  c_string        rev_c (rev * ":" * as_string (file_u));
+  c_string        rev_c (rev * ":" * as_unix_string (file_u));
 
   git_libgit2_init ();
   error= git_repository_open (&repo, repo_c);


### PR DESCRIPTION
## Why you open this Pull Request?

Fix error caused by slash`\`. When a file under some directory is loaded by libgit on windows, slash is used rather than backslash`/`, therefore libgit treat that slash as regular filename.

## What work have you done in the current Pull Request?

- [x] use `as_unix_string` to serialize relative path of input file