### PR TITLE
[59_22] macOS: Fix shortcuts of option with non-alphanum keys

### DIFF
--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -1277,7 +1277,8 @@ from_key_press_event (const QKeyEvent* event) {
     }
     else if (mods_text == "A-") {
       // A-: Alt+key or Option+key
-      if (os_macos () && !nss.isEmpty ()) {
+      if (os_macos () && !is_alpha (key_original) && !is_digit (key_original) &&
+          !nss.isEmpty ()) {
         r << from_qstring_utf8 (nss);
       }
       else {

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -1275,8 +1275,16 @@ from_key_press_event (const QKeyEvent* event) {
       debug_keyboard << mods_text << key_original << " should be invalid" << LF;
       r= "";
     }
-    else if (mods_text == "A-" || mods_text == "C-" || mods_text == "M-") {
+    else if (mods_text == "A-") {
       // A-: Alt+key or Option+key
+      if (os_macos () && !nss.isEmpty ()) {
+        r << from_qstring_utf8 (nss);
+      }
+      else {
+        r << mods_text << key_locased;
+      }
+    }
+    else if (mods_text == "C-" || mods_text == "M-") {
       // C-: Ctrl+key or Ctrl+key
       // M-: Win+key or Command+key
       r << mods_text << key_locased;

--- a/src/Plugins/Qt/qt_utilities.cpp
+++ b/src/Plugins/Qt/qt_utilities.cpp
@@ -1279,6 +1279,20 @@ from_key_press_event (const QKeyEvent* event) {
       // A-: Alt+key or Option+key
       if (os_macos () && !is_alpha (key_original) && !is_digit (key_original) &&
           !nss.isEmpty ()) {
+        // there are special rules for the key combo with Option on macOS:
+        // A-<    ->    ≤
+        // A->    ->    ≥
+        // A-6    ->    §
+        // A-p    ->    π
+        //
+        // case 1: for key which is alpha or number
+        // there are also special rules for the key combo with Option on macOS
+        // but we have defined A-1, A-2, A-v in TeXmacs
+        // for defined A-1 (¡ on macOS), we override it using the TeXmacs one
+        // for undefined A-6 (§ on macoS), we ignore it
+        //
+        // case 2: for key which is not alpha and not number: -, =, ,, ., /, ...
+        // we reserve the special rules here
         r << from_qstring_utf8 (nss);
       }
       else {

--- a/tests/Plugins/Qt/qt_utilities_test.cpp
+++ b/tests/Plugins/Qt/qt_utilities_test.cpp
@@ -75,6 +75,16 @@ TestQtUtilities::test_from_key_press_event () {
     auto ctrl_plus= QKeyEvent (QEvent::KeyPress, (int) '=',
                                Qt::ControlModifier | Qt::ShiftModifier, "=");
     qcompare (from_key_press_event (&ctrl_plus), "M-S-=");
+
+    // A-<number>
+    auto alt_1= QKeyEvent (QEvent::KeyPress, (int) '1', Qt::AltModifier, "¡");
+    qcompare (from_key_press_event (&alt_1), "A-1");
+    // A-<alpha>
+    auto alt_v= QKeyEvent (QEvent::KeyPress, (int) 'V', Qt::AltModifier, "√");
+    qcompare (from_key_press_event (&alt_v), "A-v");
+    // A-<not alpha and not number>
+    auto alt_dot= QKeyEvent (QEvent::KeyPress, (int) '.', Qt::AltModifier, "≥");
+    qcompare (from_key_press_event (&alt_dot), "≥");
   }
 }
 


### PR DESCRIPTION
Affected shortcuts:
```
A-=
A--
A-[
A-]
A-\
A-;
A-'
A-<
A->
A-/
```