### PR TITLE
[59_24] Fix for the escape key

### DIFF
--- a/src/Edit/Interface/edit_keyboard.cpp
+++ b/src/Edit/Interface/edit_keyboard.cpp
@@ -322,7 +322,7 @@ edit_interface_rep::key_press (string gkey) {
     call ("kbd-insert", "<" * key * ">");
     interrupt_shortcut ();
   }
-  else if (N (key) > 1 && !is_combo_shortcuts (key)) {
+  else if (N (key) > 1 && !is_combo_shortcuts (key) && key != "escape") {
     archive_state ();
     call ("insert", key);
     interrupt_shortcut ();


### PR DESCRIPTION
Related commits:
+ https://github.com/XmacsLabs/mogan/commit/b5c2160af760ad9b3149b719d78f06d8d9036a0d