### PR TITLE
[75_12] Upgrade to lolly 1.4.0

### DIFF
--- a/src/Graphics/Fonts/translator.cpp
+++ b/src/Graphics/Fonts/translator.cpp
@@ -71,7 +71,8 @@ load_virtual (string name) {
   string s, r;
   name= name * ".vfn";
   if (DEBUG_STD) debug_fonts << "Loading " << name << "\n";
-  url u ("$TEXMACS_HOME_PATH/fonts/virtual:$TEXMACS_PATH/fonts/virtual", name);
+  url u= url_unix (
+      "$TEXMACS_HOME_PATH/fonts/virtual:$TEXMACS_PATH/fonts/virtual", name);
   load_string (u, s, true);
   tree t= string_to_scheme_tree (s);
   ASSERT (is_tuple (t, "virtual-font"), "bad virtual font format");
@@ -100,7 +101,8 @@ load_translator (string name) {
   string s, r;
   string file_name= name * ".enc";
   if (DEBUG_STD) debug_fonts << "Loading " << file_name << "\n";
-  url u ("$TEXMACS_HOME_PATH/fonts/enc:$TEXMACS_PATH/fonts/enc", file_name);
+  url u= url_unix ("$TEXMACS_HOME_PATH/fonts/enc:$TEXMACS_PATH/fonts/enc",
+                   file_name);
   if (exists (u)) {
     s= string_load (u);
   }

--- a/src/Scheme/L2/glue_lolly.lua
+++ b/src/Scheme/L2/glue_lolly.lua
@@ -193,22 +193,6 @@ function main()
                 }
             },
             {
-                scm_name = "utf8->t2a",
-                cpp_name = "utf8_to_t2a",
-                ret_type = "string",
-                arg_list = {
-                    "string"
-                }
-            },
-            {
-                scm_name = "t2a->utf8",
-                cpp_name = "t2a_to_utf8",
-                ret_type = "string",
-                arg_list = {
-                    "string"
-                }
-            },
-            {
                 scm_name = "utf8->cork",
                 cpp_name = "utf8_to_cork",
                 ret_type = "string",

--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -179,7 +179,7 @@ get_env_path (string which, url def) {
 
 static url
 plugin_path (string which) {
-  url base= "$TEXMACS_HOME_PATH:/etc/TeXmacs:$TEXMACS_PATH:/usr/share/TeXmacs";
+  url base  = url_unix ("$TEXMACS_HOME_PATH:$TEXMACS_PATH");
   url search= base * "plugins" * url_wildcard ("*") * which;
   return expand (complete (search, "r"));
 }
@@ -322,7 +322,7 @@ release_boot_lock () {
 
 static void
 init_scheme () {
-  url guile_path= "$TEXMACS_PATH/progs:$GUILE_LOAD_PATH";
+  url guile_path= url_system ("$TEXMACS_PATH/progs");
   guile_path= guile_path | "$TEXMACS_HOME_PATH/progs" | plugin_path ("progs");
   set_env_path ("GUILE_LOAD_PATH", guile_path);
 }
@@ -347,12 +347,13 @@ init_env_vars () {
 
   // Get TeXmacs style and package paths
   url style_root= get_env_path (
-      "TEXMACS_STYLE_ROOT", "$TEXMACS_HOME_PATH/styles:$TEXMACS_PATH/styles" |
-                                plugin_path ("styles"));
-  url package_root=
-      get_env_path ("TEXMACS_PACKAGE_ROOT",
-                    "$TEXMACS_HOME_PATH/packages:$TEXMACS_PATH/packages" |
-                        plugin_path ("packages"));
+      "TEXMACS_STYLE_ROOT",
+      url_unix ("$TEXMACS_HOME_PATH/styles:$TEXMACS_PATH/styles") |
+          plugin_path ("styles"));
+  url package_root= get_env_path (
+      "TEXMACS_PACKAGE_ROOT",
+      url_unix ("$TEXMACS_HOME_PATH/packages:$TEXMACS_PATH/packages") |
+          plugin_path ("packages"));
   url all_root= style_root | package_root;
   url style_path=
       get_env_path ("TEXMACS_STYLE_PATH", search_sub_dirs (all_root));
@@ -364,10 +365,11 @@ init_env_vars () {
 
   // Get other data paths
   (void) get_env_path ("TEXMACS_FILE_PATH", text_path | style_path);
-  (void) set_env_path ("TEXMACS_DOC_PATH",
-                       get_env_path ("TEXMACS_DOC_PATH") |
-                           "$TEXMACS_HOME_PATH/doc:$TEXMACS_PATH/doc" |
-                           plugin_path ("doc"));
+  (void) set_env_path (
+      "TEXMACS_DOC_PATH",
+      get_env_path ("TEXMACS_DOC_PATH") |
+          url_unix ("$TEXMACS_HOME_PATH/doc:$TEXMACS_PATH/doc") |
+          plugin_path ("doc"));
   (void) set_env_path ("TEXMACS_SECURE_PATH",
                        get_env_path ("TEXMACS_SECURE_PATH") |
                            "$TEXMACS_PATH:$TEXMACS_HOME_PATH");

--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -33,6 +33,7 @@ package("lolly")
     add_versions("1.3.23", "v1.3.23")
     add_versions("1.3.24", "v1.3.24")
     add_versions("1.3.25", "v1.3.25")
+    add_versions("1.4.0", "v1.4.0")
 
     add_deps("tbox")
     if not is_plat("wasm") then

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -19,7 +19,7 @@ STABLE_VERSION = TEXMACS_VERSION
 STABLE_RELEASE = 1
 
 -- XmacsLabs dependencies
-LOLLY_VERSION = "1.3.25"
+LOLLY_VERSION = "1.4.0"
 
 -- Third-party dependencies
 S7_VERSION = "20230413"


### PR DESCRIPTION
This is a breaking change.

Before
```
(string->url "xxx") <=> (url-unix "xxx")
```

Now:
```
(string->url "xxx") <=> (system->url "xxx")
```

And `string->url` is the implicit conversion from string to url in Scheme or C++.