### PR TITLE
[75_21] Upgrade to lolly 1.4.17, moebius 0.1.17

### DIFF
--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -24,7 +24,7 @@ package("lolly")
 
     add_urls("https://github.com/XmacsLabs/lolly.git")
     add_urls("https://gitee.com/XmacsLabs/lolly.git")
-    add_versions("1.4.13", "v1.4.13")
+    add_versions("1.4.17", "v1.4.17")
 
     add_deps("tbox")
     if not is_plat("wasm") then

--- a/xmake/packages/m/moebius/xmake.lua
+++ b/xmake/packages/m/moebius/xmake.lua
@@ -24,7 +24,7 @@ package("moebius")
 
     add_urls("https://github.com/XmacsLabs/moebius.git")
     add_urls("https://gitee.com/XmacsLabs/moebius.git")
-    add_versions("0.1.15", "v0.1.15")
+    add_versions("0.1.17", "v0.1.17")
 
     add_deps("lolly")
 

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -19,7 +19,7 @@ STABLE_VERSION = TEXMACS_VERSION
 STABLE_RELEASE = 1
 
 -- XmacsLabs dependencies
-LOLLY_VERSION = "1.4.13"
+LOLLY_VERSION = "1.4.17"
 
 -- Third-party dependencies
 S7_VERSION = "20230413"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
as title

## Why
bump version for lolly and moebius, keep them up-to-date after the string->lolly_string attempt

## How to test your changes?
+ [x] macOS
+ [x] Windows
+ [ ] Linux

```
xmake b research
xmake r research
```