### PR TITLE
[61_3] Binary plugins: find-binary

### DIFF
--- a/TeXmacs/plugins/binary/progs/binary/aspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/aspell.scm
@@ -24,10 +24,7 @@
 
 (tm-define (find-binary-aspell)
   (:synopsis "Find the url to the aspell binary, return (url-none) if not found")
-  (with u (or (list-find (aspell-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "aspell"))
-    (url-resolve u "r")))
+  (find-binary (apsell-binary-candidates) "aspell"))
 
 (tm-define (has-binary-aspell?)
   (not (url-none? (find-binary-aspell))))

--- a/TeXmacs/plugins/binary/progs/binary/aspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/aspell.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary aspell))
+(texmacs-module (binary aspell)
+  (:use (binary common)))
 
 (define (aspell-binary-candidates)
   (cond ((os-macos?)
@@ -24,7 +25,7 @@
 
 (tm-define (find-binary-aspell)
   (:synopsis "Find the url to the aspell binary, return (url-none) if not found")
-  (find-binary (apsell-binary-candidates) "aspell"))
+  (find-binary (aspell-binary-candidates) "aspell"))
 
 (tm-define (has-binary-aspell?)
   (not (url-none? (find-binary-aspell))))

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -22,6 +22,6 @@
     (with u (list-find candidates (lambda (x) (url-exists? (url-resolve x "r"))))
       (and u (url-resolve u "r")))
     (with u (url-resolve-in-path (if (os-win32?) (string-append default ".exe") default))
-      (if (and (os-win32?) (url-descends? u (system->url "C:\\Windows\\System32"))))
+      (if (and (os-win32?) (url-descends? u (system->url "C:\\Windows\\System32")))
         (url-none)
-        u)))
+        u))))

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -21,4 +21,7 @@
              (if (and (url-exists? u) (url-regular? u)) u #f))))
     (with u (list-find candidates (lambda (x) (url-exists? (url-resolve x "r"))))
       (and u (url-resolve u "r")))
-    (url-resolve-in-path (if (os-win32?) (string-append default ".exe") default))))
+    (with u (url-resolve-in-path (if (os-win32?) (string-append default ".exe") default))
+      (if (and (os-win32?) (url-descends? u (system->url "C:\\Windows\\System32"))))
+        (url-none)
+        u)))

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -1,0 +1,24 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : common.scm
+;; DESCRIPTION : routines for Binary plugins
+;; COPYRIGHT   : (C) 2024  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (binary common))
+
+(tm-define (find-binary candidates default)
+  (or
+    (with path (get-preference (string-append "plugin:binary:" default))
+      (and (!= path "default")
+           (with u (url-resolve path "r")
+             (if (and (url-exists? u) (url-regular? u)) u #f))))
+    (with u (list-find candidates (lambda (x) (url-exists? (url-resolve x "r"))))
+      (url-resolve u "r"))
+    (url-resolve-in-path (if (os-win32?) (string-append default ".exe") default))))

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -20,5 +20,5 @@
            (with u (url-resolve path "r")
              (if (and (url-exists? u) (url-regular? u)) u #f))))
     (with u (list-find candidates (lambda (x) (url-exists? (url-resolve x "r"))))
-      (url-resolve u "r"))
+      (and u (url-resolve u "r")))
     (url-resolve-in-path (if (os-win32?) (string-append default ".exe") default))))

--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -19,7 +19,9 @@
          (list "/opt/homebrew/bin/convert"
                "/usr/local/bin/convert"))
         ((os-win32?)
-         (list "$USERPROFILE\\scoop\\apps\\imagemagick\\current\\convert.exe"))
+         (list 
+          "C:\\Program Files*\\ImageMagick*\\convert.exe"
+          "$USERPROFILE\\scoop\\apps\\imagemagick\\current\\convert.exe"))
         (else
          (list "/usr/bin/convert"))))
 

--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -24,10 +24,7 @@
 
 (tm-define (find-binary-convert)
   (:synopsis "Find the url to the convert binary, return (url-none) if not found")
-  (with u (or (list-find (convert-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "convert"))
-    (url-resolve u "r")))
+  (find-binary (convert-binary-candidates) "convert"))
 
 (tm-define (has-binary-convert?)
   (not (url-none? (find-binary-convert))))

--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -2,7 +2,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; MODULE      : convert.scm
-;; DESCRIPTION : Imagemagick Binary plugin
+;; DESCRIPTION : Imagemagick Binary plugin: convert
 ;; COPYRIGHT   : (C) 2024  Darcy Shen
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -11,20 +11,24 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary convert))
+(texmacs-module (binary convert)
+  (:use (binary common)))
 
 (define (convert-binary-candidates)
   (cond ((os-macos?)
          (list "/opt/homebrew/bin/convert"
                "/usr/local/bin/convert"))
         ((os-win32?)
-         (list ))
+         (list "$USERPROFILE\\scoop\\apps\\imagemagick\\current\\convert.exe"))
         (else
          (list "/usr/bin/convert"))))
 
 (tm-define (find-binary-convert)
   (:synopsis "Find the url to the convert binary, return (url-none) if not found")
-  (find-binary (convert-binary-candidates) "convert"))
+  (with u (find-binary (convert-binary-candidates) "convert")
+    (if (and (os-win32?) (== u (system->url "C:\\Windows\\System32\\convert.exe")))
+        (url-none)
+        u)))
 
 (tm-define (has-binary-convert?)
   (not (url-none? (find-binary-convert))))

--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -25,10 +25,7 @@
 
 (tm-define (find-binary-convert)
   (:synopsis "Find the url to the convert binary, return (url-none) if not found")
-  (with u (find-binary (convert-binary-candidates) "convert")
-    (if (and (os-win32?) (== u (system->url "C:\\Windows\\System32\\convert.exe")))
-        (url-none)
-        u)))
+  (with u (find-binary (convert-binary-candidates) "convert")))
 
 (tm-define (has-binary-convert?)
   (not (url-none? (find-binary-convert))))

--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -25,7 +25,7 @@
 
 (tm-define (find-binary-convert)
   (:synopsis "Find the url to the convert binary, return (url-none) if not found")
-  (with u (find-binary (convert-binary-candidates) "convert")))
+  (find-binary (convert-binary-candidates) "convert"))
 
 (tm-define (has-binary-convert?)
   (not (url-none? (find-binary-convert))))

--- a/TeXmacs/plugins/binary/progs/binary/gs.scm
+++ b/TeXmacs/plugins/binary/progs/binary/gs.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary gs))
+(texmacs-module (binary gs)
+  (:use (binary common)))
 
 (define (gs-binary-candidates)
   (cond ((os-macos?)
@@ -24,10 +25,7 @@
 
 (tm-define (find-binary-gs)
   (:synopsis "Find the url to the gs binary, return (url-none) if not found")
-  (with u (or (list-find (gs-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "gs"))
-    (url-resolve u "r")))
+  (find-binary (gs-binary-candidates) "gs"))
 
 (tm-define (has-binary-gs?)
   (not (url-none? (find-binary-gs))))

--- a/TeXmacs/plugins/binary/progs/binary/hunspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/hunspell.scm
@@ -23,11 +23,8 @@
          (list "/usr/bin/hunspell"))))
 
 (tm-define (find-binary-hunspell)
-  (:synopsis "Find the url to the convert binary, return (url-none) if not found")
-  (with u (or (list-find (hunspell-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "hunspell"))
-    (url-resolve u "r")))
+  (:synopsis "Find the url to the hunspell binary, return (url-none) if not found")
+  (find-binary (hunspell-binary-candidates) "hunspell"))
 
 (tm-define (has-binary-hunspell?)
   (not (url-none? (find-binary-hunspell))))

--- a/TeXmacs/plugins/binary/progs/binary/hunspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/hunspell.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary hunspell))
+(texmacs-module (binary hunspell)
+  (:use (binary common)))
 
 (define (hunspell-binary-candidates)
   (cond ((os-macos?)

--- a/TeXmacs/plugins/binary/progs/binary/inkscape.scm
+++ b/TeXmacs/plugins/binary/progs/binary/inkscape.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary inkscape))
+(texmacs-module (binary inkscape)
+  (:use (binary common)))
 
 (define (inkscape-binary-candidates)
   (cond ((os-macos?)

--- a/TeXmacs/plugins/binary/progs/binary/inkscape.scm
+++ b/TeXmacs/plugins/binary/progs/binary/inkscape.scm
@@ -23,10 +23,7 @@
 
 (tm-define (find-binary-inkscape)
   (:synopsis "Find the url to the inkscape binary, return (url-none) if not found")
-  (with u (or (list-find (inkscape-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "inkscape"))
-    (url-resolve u "r")))
+  (find-binary (inkscape-binary-candidates) "inkscape"))
 
 (tm-define (has-binary-inkscape?)
   (not (url-none? (find-binary-inkscape))))

--- a/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
+++ b/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
@@ -24,10 +24,7 @@
 
 (tm-define (find-binary-pdftocairo)
   (:synopsis "Find the url to the pdftocairo binary, return (url-none) if not found")
-  (with u (or (list-find (pdftocairo-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "pdftocairo"))
-    (url-resolve u "r")))
+  (find-binary (pdftocairo-binary-candidates) "pdftocairo"))
 
 (tm-define (has-binary-pdftocairo?)
   (not (url-none? (find-binary-pdftocairo))))

--- a/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
+++ b/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary pdftocairo))
+(texmacs-module (binary pdftocairo)
+  (:use (binary common)))
 
 (define (pdftocairo-binary-candidates)
   (cond ((os-macos?)

--- a/TeXmacs/plugins/binary/progs/binary/python3.scm
+++ b/TeXmacs/plugins/binary/progs/binary/python3.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary python3))
+(texmacs-module (binary python3)
+  (:use (binary common)))
 
 (define (python3-binary-candidates)
   (cond ((os-macos?)

--- a/TeXmacs/plugins/binary/progs/binary/python3.scm
+++ b/TeXmacs/plugins/binary/progs/binary/python3.scm
@@ -25,10 +25,7 @@
 
 (tm-define (find-binary-python3)
   (:synopsis "Find the url to the python3 binary, return (url-none) if not found")
-  (with u (or (list-find (python3-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "python3"))
-    (url-resolve u "r")))
+  (find-binary (python3-binary-candidates) "python3"))
 
 (tm-define (has-binary-python3?)
   (not (url-none? (find-binary-python3))))

--- a/TeXmacs/plugins/binary/progs/binary/python3.scm
+++ b/TeXmacs/plugins/binary/progs/binary/python3.scm
@@ -26,7 +26,7 @@
 
 (tm-define (find-binary-python3)
   (:synopsis "Find the url to the python3 binary, return (url-none) if not found")
-  (find-binary (python3-binary-candidates) "python3"))
+  (find-binary (python3-binary-candidates) (if (os-win32?) "python" "python3")))
 
 (tm-define (has-binary-python3?)
   (not (url-none? (find-binary-python3))))

--- a/TeXmacs/plugins/binary/progs/binary/rsvg-convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/rsvg-convert.scm
@@ -11,7 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (binary rsvg-convert))
+(texmacs-module (binary rsvg-convert)
+  (:use (binary common)))
 
 (define (rsvg-convert-binary-candidates)
   (cond ((os-macos?)

--- a/TeXmacs/plugins/binary/progs/binary/rsvg-convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/rsvg-convert.scm
@@ -24,10 +24,7 @@
 
 (tm-define (find-binary-rsvg-convert)
   (:synopsis "Find the url to the rsvg-convert binary, return (url-none) if not found")
-  (with u (or (list-find (rsvg-convert-binary-candidates)
-                (lambda (x) (url-exists? (url-resolve x "r"))))
-              (url-resolve-in-path "rsvg-convert"))
-    (url-resolve u "r")))
+  (find-binary (rsvg-convert-binary-candidates) "rsvg-convert"))
 
 (tm-define (has-binary-rsvg-convert?)
   (not (url-none? (find-binary-rsvg-convert))))

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -55,7 +55,7 @@
 
   <\session|scheme|default>
     <\unfolded-io|Scheme] >
-      (use-modules (binary gs))
+      (use-modules (binary gs) (binary common))
     <|unfolded-io>
       (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier
       with-remote-identifier 'with-remote-get-user-name
@@ -66,7 +66,7 @@
       'with-remote-get-entry with-remote-get-entry
       'with-remote-get-attributes with-remote-get-attributes
       'with-remote-get-field with-remote-get-field 'tm-call-back tm-call-back
-      'with-remote-context with-remote-context ...))
+      'with-remote-context with-remote-context ...) #1#)
     </unfolded-io>
 
     <\input|Scheme] >
@@ -116,15 +116,101 @@
     </input>
 
     <\unfolded-io|Scheme] >
-      (find-binary-gs)
+      (find-binary (list ) "gs")
     <|unfolded-io>
       \<less\>url C:\\Program Files (x86)\\TeXmacs\\bin\\gs.exe\<gtr\>
     </unfolded-io>
 
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
+
+  <section|Various other binaries>
+
+  <\session|scheme|default>
     <\unfolded-io|Scheme] >
-      (version-binary-gs)
+      (use-modules (binary aspell))
     <|unfolded-io>
-      9.24
+      (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier
+      with-remote-identifier 'with-remote-get-user-name
+      with-remote-get-user-name 'with-remote-get-user-pseudo
+      with-remote-get-user-pseudo 'with-remote-search-user
+      with-remote-search-user 'with-remote-search with-remote-search
+      'with-remote-create-entry with-remote-create-entry
+      'with-remote-get-entry with-remote-get-entry
+      'with-remote-get-attributes with-remote-get-attributes
+      'with-remote-get-field with-remote-get-field 'tm-call-back tm-call-back
+      'with-remote-context with-remote-context ...))
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-aspell)
+    <|unfolded-io>
+      \<less\>url C:\\Users\\darcy\\scoop\\apps\\aspell\\current\\bin\\aspell.exe\<gtr\>
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (use-modules (binary convert))
+    <|unfolded-io>
+      (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier
+      with-remote-identifier 'with-remote-get-user-name
+      with-remote-get-user-name 'with-remote-get-user-pseudo
+      with-remote-get-user-pseudo 'with-remote-search-user
+      with-remote-search-user 'with-remote-search with-remote-search
+      'with-remote-create-entry with-remote-create-entry
+      'with-remote-get-entry with-remote-get-entry
+      'with-remote-get-attributes with-remote-get-attributes
+      'with-remote-get-field with-remote-get-field 'tm-call-back tm-call-back
+      'with-remote-context with-remote-context ...))
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-convert)
+    <|unfolded-io>
+      \<less\>url C:\\Users\\darcy\\scoop\\apps\\imagemagick\\current\\convert.exe\<gtr\>
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (use-modules (binary inkscape))
+    <|unfolded-io>
+      (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier
+      with-remote-identifier 'with-remote-get-user-name
+      with-remote-get-user-name 'with-remote-get-user-pseudo
+      with-remote-get-user-pseudo 'with-remote-search-user
+      with-remote-search-user 'with-remote-search with-remote-search
+      'with-remote-create-entry with-remote-create-entry
+      'with-remote-get-entry with-remote-get-entry
+      'with-remote-get-attributes with-remote-get-attributes
+      'with-remote-get-field with-remote-get-field 'tm-call-back tm-call-back
+      'with-remote-context with-remote-context ...))
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-inkscape)
+    <|unfolded-io>
+      \<less\>url C:\\Program Files\\Inkscape\\bin\\inkscape.exe\<gtr\>
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (use-modules (binary python3))
+    <|unfolded-io>
+      (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier
+      with-remote-identifier 'with-remote-get-user-name
+      with-remote-get-user-name 'with-remote-get-user-pseudo
+      with-remote-get-user-pseudo 'with-remote-search-user
+      with-remote-search-user 'with-remote-search with-remote-search
+      'with-remote-create-entry with-remote-create-entry
+      'with-remote-get-entry with-remote-get-entry
+      'with-remote-get-attributes with-remote-get-attributes
+      'with-remote-get-field with-remote-get-field 'tm-call-back tm-call-back
+      'with-remote-context with-remote-context ...))
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-python3)
+    <|unfolded-io>
+      \<less\>url C:\\Users\\darcy\\AppData\\Local\\Programs\\Python\\Python311\\python.exe\<gtr\>
     </unfolded-io>
 
     <\input|Scheme] >
@@ -143,6 +229,7 @@
   <\collection>
     <associate|auto-1|<tuple|1|?>>
     <associate|auto-2|<tuple|2|?>>
+    <associate|auto-3|<tuple|3|?>>
   </collection>
 </references>
 
@@ -156,6 +243,10 @@
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|2<space|2spc>Test
       on Windows> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-2><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|3<space|2spc>Various
+      other binaries> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-3><vspace|0.5fn>
     </associate>
   </collection>
 </auxiliary>

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -168,7 +168,7 @@
     <\unfolded-io|Scheme] >
       (find-binary-convert)
     <|unfolded-io>
-      \<less\>url C:\\Users\\darcy\\scoop\\apps\\imagemagick\\current\\convert.exe\<gtr\>
+      \<less\>url C:\\Program Files\\ImageMagick-7.1.1-Q16-HDRI\\convert.exe\<gtr\>
     </unfolded-io>
 
     <\unfolded-io|Scheme] >

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -1,0 +1,57 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|british>>
+
+<\body>
+  <\session|scheme|default>
+    <\input|Scheme] >
+      (reset-preference "plugin:binary:gs")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url /opt/homebrew/Cellar/ghostscript/10.02.1/bin/gs\<gtr\>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (set-preference "plugin:binary:gs" "/bin/gs")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url /opt/homebrew/Cellar/ghostscript/10.02.1/bin/gs\<gtr\>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (set-preference "plugin:binary:gs" "/Applications/TeXmacs.app/Contents/Resources/share/TeXmacs/bin/gs")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url /Applications/TeXmacs.app/Contents/Resources/share/TeXmacs/bin/gs\<gtr\>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (set-preference "plugin:binary:gs" "/bin")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url /opt/homebrew/Cellar/ghostscript/10.02.1/bin/gs\<gtr\>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -3,6 +3,8 @@
 <style|<tuple|generic|no-page-numbers|british>>
 
 <\body>
+  <section|Test on macOS>
+
   <\session|scheme|default>
     <\input|Scheme] >
       (reset-preference "plugin:binary:gs")
@@ -48,6 +50,87 @@
       \;
     </input>
   </session>
+
+  <section|Test on Windows>
+
+  <\session|scheme|default>
+    <\unfolded-io|Scheme] >
+      (use-modules (binary gs))
+    <|unfolded-io>
+      (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier
+      with-remote-identifier 'with-remote-get-user-name
+      with-remote-get-user-name 'with-remote-get-user-pseudo
+      with-remote-get-user-pseudo 'with-remote-search-user
+      with-remote-search-user 'with-remote-search with-remote-search
+      'with-remote-create-entry with-remote-create-entry
+      'with-remote-get-entry with-remote-get-entry
+      'with-remote-get-attributes with-remote-get-attributes
+      'with-remote-get-field with-remote-get-field 'tm-call-back tm-call-back
+      'with-remote-context with-remote-context ...))
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (reset-preference "plugin:binary:gs")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url C:\\Program Files\\gs\\gs10.01.2\\bin\\gswin64c.exe\<gtr\>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (set-preference "plugin:binary:gs" "/bin/gs")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url C:\\Program Files\\gs\\gs10.01.2\\bin\\gswin64c.exe\<gtr\>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (set-preference "plugin:binary:gs" "C:\\\\Program Files
+      (x86)\\\\TeXmacs\\\\bin\\\\gs.exe")
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url C:\\Program Files (x86)\\TeXmacs\\bin\\gs.exe\<gtr\>
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (version-binary-gs)
+    <|unfolded-io>
+      9.24
+    </unfolded-io>
+
+    <\input|Scheme] >
+      (reset-preference "plugin:binary:gs")
+    </input>
+
+    <\input|Scheme] >
+      (system-setenv "PATH" (string-append (system-getenv "PATH") ";"
+      "C:\\\\Program Files (x86)\\\\TeXmacs\\\\bin\\\\"))
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (find-binary-gs)
+    <|unfolded-io>
+      \<less\>url C:\\Program Files (x86)\\TeXmacs\\bin\\gs.exe\<gtr\>
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
+      (version-binary-gs)
+    <|unfolded-io>
+      9.24
+    </unfolded-io>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
 </body>
 
 <\initial>
@@ -55,3 +138,24 @@
     <associate|page-screen-margin|false>
   </collection>
 </initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|1|?>>
+    <associate|auto-2|<tuple|2|?>>
+  </collection>
+</references>
+
+<\auxiliary>
+  <\collection>
+    <\associate|toc>
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|1<space|2spc>Test
+      on macOS> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-1><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|2<space|2spc>Test
+      on Windows> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-2><vspace|0.5fn>
+    </associate>
+  </collection>
+</auxiliary>

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -172,6 +172,12 @@
     </unfolded-io>
 
     <\unfolded-io|Scheme] >
+      (find-binary () "convert")
+    <|unfolded-io>
+      \<less\>url {}\<gtr\>
+    </unfolded-io>
+
+    <\unfolded-io|Scheme] >
       (use-modules (binary inkscape))
     <|unfolded-io>
       (#1=(inlet '$tmapidoc $tmapidoc 'with-remote-identifier


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
+ impl common routine `find-binary` in the following order:
   1. Check `plugin:binary:<binary-name>` first
   2. Check `(binary-gs-candidates)` secondly
   3. Check binary under the PATH (excluding im-proper PATH like `C:/Windows/System32`)
+ Migrate all binary plugins to `(find-binary)`
+ Added two path candidates for ImageMagick convert on Windows


## Why
+ Fix convert bug on Windows
+ Reduce duplicated code

## How to test your changes?
+ [x] macOS
+ [x] Windows
+ [ ] Linux

Open `TeXmacs/tests/tm/61_3.tm` and evaluate the Scheme sessions.
