### PR TITLE
[68_11] Better error handling for PDF images

### DIFF
--- a/TeXmacs/tests/tm/68_11.tm
+++ b/TeXmacs/tests/tm/68_11.tm
@@ -1,0 +1,12 @@
+<TeXmacs|2.1.2>
+
+<style|generic>
+
+<\body>
+  Test remote pdf which does not exist
+
+  <image|https://mogan.app/no_such.pdf|0.3par|||>
+</body>
+
+<initial|<\collection>
+</collection>>

--- a/TeXmacs/tests/tm/68_11.tm
+++ b/TeXmacs/tests/tm/68_11.tm
@@ -3,7 +3,11 @@
 <style|generic>
 
 <\body>
-  Test remote pdf which does not exist
+  Test local pdf which does not exist:
+
+  <image|$TEXMACS_PATH/no_such.pdf|0.3par|||>
+
+  Test remote pdf which does not exist:
 
   <image|https://mogan.app/no_such.pdf|0.3par|||>
 </body>

--- a/src/Plugins/Pdf/pdf_image.cpp
+++ b/src/Plugins/Pdf/pdf_image.cpp
@@ -23,6 +23,7 @@
 #include "scheme.hpp"
 #include "tm_debug.hpp"
 #include "tm_url.hpp"
+#include "url.hpp"
 
 #ifdef QTTEXMACS
 #include "Qt/qt_utilities.hpp"
@@ -356,13 +357,15 @@ pdf_raw_image_rep::flush (PDFWriter& pdfw) {
 
 void
 hummus_pdf_image_size (url image, int& w, int& h) {
-  InputFile  pdfFile;
-  PDFParser* parser        = new PDFParser ();
-  c_string   resolved_image= concretize (image);
+  string resolved_image= concretize (image);
   if (is_none (resolved_image)) {
     io_error << "Failed to concretize " << image << LF;
   }
-  pdfFile.OpenFile ((char*) resolved_image);
+
+  PDFParser* parser= new PDFParser ();
+  InputFile  pdfFile;
+  c_string   f (resolved_image);
+  pdfFile.OpenFile ((char*) f);
   EStatusCode status= parser->StartPDFParsing (pdfFile.GetInputStream ());
   if (status != PDFHummus::eFailure) {
     PDFPageInput pageInput (parser, parser->ParsePage (0));

--- a/src/Plugins/Pdf/pdf_image.cpp
+++ b/src/Plugins/Pdf/pdf_image.cpp
@@ -357,14 +357,15 @@ pdf_raw_image_rep::flush (PDFWriter& pdfw) {
 
 void
 hummus_pdf_image_size (url image, int& w, int& h) {
-  string resolved_image= concretize (image);
+  url resolved_image= concretize_url (image);
   if (is_none (resolved_image)) {
     io_error << "Failed to concretize " << image << LF;
+    return;
   }
 
   PDFParser* parser= new PDFParser ();
   InputFile  pdfFile;
-  c_string   f (resolved_image);
+  c_string   f (as_string (resolved_image));
   pdfFile.OpenFile ((char*) f);
   EStatusCode status= parser->StartPDFParsing (pdfFile.GetInputStream ());
   if (status != PDFHummus::eFailure) {

--- a/src/Plugins/Pdf/pdf_image.cpp
+++ b/src/Plugins/Pdf/pdf_image.cpp
@@ -357,8 +357,12 @@ pdf_raw_image_rep::flush (PDFWriter& pdfw) {
 void
 hummus_pdf_image_size (url image, int& w, int& h) {
   InputFile  pdfFile;
-  PDFParser* parser= new PDFParser ();
-  pdfFile.OpenFile (as_charp (concretize (image)));
+  PDFParser* parser        = new PDFParser ();
+  c_string   resolved_image= concretize (image);
+  if (is_none (resolved_image)) {
+    io_error << "Failed to concretize " << image << LF;
+  }
+  pdfFile.OpenFile ((char*) resolved_image);
   EStatusCode status= parser->StartPDFParsing (pdfFile.GetInputStream ());
   if (status != PDFHummus::eFailure) {
     PDFPageInput pageInput (parser, parser->ParsePage (0));
@@ -368,8 +372,8 @@ hummus_pdf_image_size (url image, int& w, int& h) {
     delete (parser);
   }
   else {
-    convert_error << "pdf_hummus, failed to get image size for: " << image
-                  << LF;
+    convert_error << "pdf_hummus, failed to get image size for: "
+                  << resolved_image << LF << "resolved from " << image << LF;
     w= h= 0;
   }
 }

--- a/src/System/Files/image_files.cpp
+++ b/src/System/Files/image_files.cpp
@@ -448,15 +448,9 @@ image_to_pdf (url image, url pdf, int w_pt, int h_pt, int dpi) {
 
 void
 image_to_png (url image, url png, int w, int h) { // IN PIXEL UNITS!
-  string source_suffix= suffix (image);
-  if (DEBUG_CONVERT) debug_convert << "image_to_png ... ";
-    /* if (suffix (png) != "png") {
-       std_warning << concretize (png) << " has no .png suffix\n";
-       }
-    */
 #ifdef QTTEXMACS
   if (qt_supports (image)) {
-    if (DEBUG_CONVERT) debug_convert << " using qt " << LF;
+    if (DEBUG_CONVERT) debug_convert << "image_to_png using qt " << LF;
     qt_convert_image (image, png, w, h);
     return;
   }
@@ -470,7 +464,7 @@ image_to_png (url image, url png, int w, int h) { // IN PIXEL UNITS!
 
 bool
 call_scm_converter (url image, url dest, int w, int h) {
-  if (DEBUG_CONVERT) debug_convert << " using scm" << LF;
+  if (DEBUG_CONVERT) debug_convert << "Image conversion using scm" << LF;
   if (as_bool (call ("file-converter-exists?", "x." * suffix (image),
                      "x." * suffix (dest)))) {
     call ("file-convert", object (image), object (dest),

--- a/src/System/Files/image_files.cpp
+++ b/src/System/Files/image_files.cpp
@@ -462,7 +462,6 @@ image_to_png (url image, url png, int w, int h) { // IN PIXEL UNITS!
   }
 #endif
   if (call_scm_converter (image, png, w, h)) return;
-  call_imagemagick_convert (image, png, w, h);
   if (!exists (png)) {
     convert_error << image << " could not be converted to png" << LF;
     copy ("$TEXMACS_PATH/misc/pixmaps/unknown.png", png);

--- a/src/System/Files/web_files.cpp
+++ b/src/System/Files/web_files.cpp
@@ -21,9 +21,13 @@
 #include "scheme.hpp"
 #include "tmfs_url.hpp"
 
-#include "lolly/io/http.hpp"
+#include <lolly/io/http.hpp>
+
+using lolly::io::http_head;
+using lolly::io::http_label;
 
 #define MAX_CACHED 25
+
 static int                 web_nr= 0;
 static array<tree>         web_cache (MAX_CACHED);
 static hashmap<tree, tree> web_cache_resolve ("");
@@ -83,6 +87,13 @@ web_encode (string s) {
 url
 get_from_web (url name) {
   if (!is_rooted_web (name)) return url_none ();
+
+  long status_code= open_box<long> (
+      http_response_ref (http_head (name), http_label::STATUS_CODE)->data);
+
+  if (status_code != 200) {
+    return url_none ();
+  }
 
   url res= get_cache (name);
   if (!is_none (res)) return res;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
1. Error handling for `hummus_pdf_image_size`
2. Unify the conversion from x to png using scheme (remove the call to the imagemagick C++ routine)
3. Only `get_from_web` when the HTTP status code is 200

## Why
The error message for PDF images is confusing. Improve the error handling slightly.

## How to test your changes?
Open `TeXmacs/tests/tm/68_11.tm`.
