### PR TITLE
[3_5] Fix INSTALL_DIR on Debian and Ubuntu

### DIFF
--- a/packages/debian/package.sh
+++ b/packages/debian/package.sh
@@ -25,7 +25,7 @@ sed -e "s/@DEVEL_VERSION@/$VERSION/" -e "s/@DEVEL_RELEASE@/1/" \
 
 cd $APP_HOME
 rm -rf $APP_HOME/TeXmacs/docs/tests
-export INSTALL_DIR=debian/mogan-research/usr
+export INSTALL_DIR=$APP_HOME/debian/mogan-research/usr
 dpkg-buildpackage -us -uc -b
 
 $APP_HOME/debian/rules clean


### PR DESCRIPTION
## What
Using relative INSTALL_DIR, it will be installed to `$(projectdir)/xmake/debian/mogan-research`. This pull request fixed the issue and will install it to `$(projectdir)/debian/mogan-research`

## How to test
```
./packages/debian/package.sh
```