### PR TITLE
[75_22] Upgrade lolly to 1.4.18 and use string_u8 in converter

### DIFF
--- a/src/Data/String/converter.cpp
+++ b/src/Data/String/converter.cpp
@@ -365,7 +365,7 @@ sourcecode_to_cork (string input) {
   return output;
 }
 
-string
+string_u8
 cork_to_utf8 (string input) {
   converter conv = load_converter ("Cork", "UTF-8");
   int       start= 0, i, n= N (input);
@@ -383,7 +383,7 @@ cork_to_utf8 (string input) {
   return r;
 }
 
-string
+string_u8
 strict_cork_to_utf8 (string input) {
   converter conv = load_converter ("Strict-Cork", "UTF-8");
   int       start= 0, i, n= N (input);
@@ -420,7 +420,7 @@ cork_to_sourcecode (string input) {
 }
 
 string
-utf8_to_t2a (string input) {
+utf8_to_t2a (string_u8 input) {
   converter conv= load_converter ("UTF-8", "T2A");
   int       start, i, n= N (input);
   string    output;
@@ -479,7 +479,7 @@ code_point_to_cyrillic_subset_in_t2a (string input) {
   return r;
 }
 
-string
+string_u8
 t2a_to_utf8 (string input) {
   converter conv = load_converter ("T2A", "UTF-8");
   int       start= 0, i, n= N (input);
@@ -498,7 +498,7 @@ t2a_to_utf8 (string input) {
 }
 
 string
-utf8_to_html (string input) {
+utf8_to_html (string_u8 input) {
   converter conv= load_converter ("UTF-8", "HTML");
   string    s   = apply (conv, input);
   return utf8_to_hex_entities (s);
@@ -804,7 +804,7 @@ convert_char_entity (string s, int& start, bool& success) {
   else return "";
 }
 
-string
+string_u8
 encode_as_utf8 (unsigned int code) {
   if (/* 0x0 <= code && */ code <= 0x7F) {
     // 0x0ddddddd
@@ -838,7 +838,7 @@ encode_as_utf8 (unsigned int code) {
 }
 
 unsigned int
-decode_from_utf8 (string s, int& i) {
+decode_from_utf8 (string_u8 s, int& i) {
   unsigned char c= s[i];
   if ((0x80 & c) == 0) {
     // 0x0ddddddd
@@ -885,7 +885,7 @@ decode_from_utf8 (string s, int& i) {
 }
 
 string
-utf8_to_hex_entities (string s) {
+utf8_to_hex_entities (string_u8 s) {
   string result;
   int    i, n= N (s);
   for (i= 0; i < n;) {
@@ -907,7 +907,7 @@ utf8_to_hex_entities (string s) {
 }
 
 string
-utf8_to_utf16be_string (string s) {
+utf8_to_utf16be_string (string_u8 s) {
   string result, hex;
   int    i, n= N (s);
   for (i= 0; i < n;) {
@@ -939,7 +939,7 @@ utf8_to_utf16be_string (string s) {
 }
 
 string
-utf8_to_pdf_hex_string (string s) {
+utf8_to_pdf_hex_string (string_u8 s) {
   return "<FEFF" * utf8_to_utf16be_string (cork_to_utf8 (s)) * ">";
 }
 

--- a/src/Data/String/converter.hpp
+++ b/src/Data/String/converter.hpp
@@ -80,16 +80,20 @@ bool   check_encoding (string input, string encoding);
 string convert (string input, string from, string to);
 string convert_to_cork (string input, string from);
 string convert_from_cork (string input, string to);
-string utf8_to_cork (string input);
-string cork_to_utf8 (string input);
-string strict_cork_to_utf8 (string input);
+
+string_u8 cork_to_utf8 (string input);
+string_u8 strict_cork_to_utf8 (string input);
+string_u8 convert_LaTeX_to_utf8 (string input);
+
 string cork_to_sourcecode (string input);
 string sourcecode_to_cork (string input);
-string convert_utf8_to_LaTeX (string input);
-string convert_LaTeX_to_utf8 (string input);
-string utf8_to_html (string input);
-string utf8_to_t2a (string input);
-string t2a_to_utf8 (string input);
+
+string    convert_utf8_to_LaTeX (string_u8 input);
+string    utf8_to_cork (string_u8 input);
+string    utf8_to_html (string_u8 input);
+string    utf8_to_t2a (string_u8 input);
+string_u8 t2a_to_utf8 (string input);
+
 string cyrillic_subset_in_t2a_to_code_point (string input);
 string code_point_to_cyrillic_subset_in_t2a (string input);
 string cork_to_ascii (string input);
@@ -121,13 +125,13 @@ void hashtree_from_dictionary (hashtree<char, string> dic, string file_name,
  ***************************************************************************/
 
 int          hex_digit_to_int (unsigned char c);
-string       encode_as_utf8 (unsigned int code);
-unsigned int decode_from_utf8 (string s, int& i);
+string_u8    encode_as_utf8 (unsigned int code);
+unsigned int decode_from_utf8 (string_u8 s, int& i);
 string       convert_escapes (string in, bool utf8);
 string       convert_char_entities (string s);
 string       convert_char_entity (string s, int& start, bool& success);
-string       utf8_to_hex_entities (string s);
-string       utf8_to_pdf_hex_string (string s);
+string       utf8_to_hex_entities (string_u8 s);
+string       utf8_to_pdf_hex_string (string_u8 s);
 tree         convert_OTS1_symbols_to_universal_encoding (tree t);
 
 #endif // CONVERTER_H

--- a/xmake/packages.lua
+++ b/xmake/packages.lua
@@ -48,6 +48,7 @@ function add_requires_of_mogan()
        add_requireconfs("lolly.cpr", {version = CPR_VERSION, system = false, override=true})
     end
     add_requires("moebius", {system=false})
+    add_requireconfs("moebius.lolly", {version = LOLLY_VERSION, system = false, override=true})
 
     -- package: libcurl
     if is_plat("linux") and using_apt() then

--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -24,7 +24,7 @@ package("lolly")
 
     add_urls("https://github.com/XmacsLabs/lolly.git")
     add_urls("https://gitee.com/XmacsLabs/lolly.git")
-    add_versions("1.4.17", "v1.4.17")
+    add_versions("1.4.18", "v1.4.18")
 
     add_deps("tbox")
     if not is_plat("wasm") then

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -19,7 +19,7 @@ STABLE_VERSION = TEXMACS_VERSION
 STABLE_RELEASE = 1
 
 -- XmacsLabs dependencies
-LOLLY_VERSION = "1.4.17"
+LOLLY_VERSION = "1.4.18"
 
 -- Third-party dependencies
 S7_VERSION = "20230413"


### PR DESCRIPTION
## What
+ Upgrade lolly to 1.4.18
   + as_int now support `+1`, `+10` by @jingkaimori 
+ Use string_u8 in converter

## Why
string_u8 as an alias of string is just a indicator.

## How to test your changes?
No need to test.
