### PR TITLE
[7_11] Fix typesetting failure caused by `ones (0)` in the Octave session

### DIFF
--- a/TeXmacs/plugins/octave/octave/convert/mat2scm.m
+++ b/TeXmacs/plugins/octave/octave/convert/mat2scm.m
@@ -14,13 +14,17 @@
 function ret= mat2scm (M)
   ret= "(matrix (tformat (table";
   [r,c]= size(M);
-  for i=1:r
-    ret= [ret,"(row "];
-    for j=1:c
-      ret= [ret, "(cell ", num2scm(M(i,j)), ") "];
+  if (r==0 && c == 0)
+    ret= str2scm ("[](0x0)");
+  else
+    for i=1:r
+      ret= [ret,"(row "];
+      for j=1:c
+        ret= [ret, "(cell ", num2scm(M(i,j)), ") "];
+      endfor
+      ret= [ret,") "];
     endfor
-    ret= [ret,") "];
-  endfor
-  ret= [ret,")))"];
-  ret= with_mode_math (ret, true);
+    ret= [ret,")))"];
+    ret= with_mode_math (ret, true);
+  endif
 endfunction

--- a/TeXmacs/tests/tm/7_11.tm
+++ b/TeXmacs/tests/tm/7_11.tm
@@ -1,8 +1,10 @@
 <TeXmacs|2.1.2>
 
-<style|<tuple|generic|no-page-numbers|chinese>>
+<style|<tuple|generic|no-page-numbers|british>>
 
 <\body>
+  How to reproduce the bug:
+
   <\session|octave|default>
     <\output>
       GNU Octave (8.4.0) Session in GNU TeXmacs
@@ -22,6 +24,34 @@
       \<gtr\>\<gtr\>\ 
     <|input>
       ones (0)
+    </input>
+  </session>
+
+  The scheme data:
+
+  <\session|octave|default>
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      mat2scm (ones (0))
+    <|unfolded-io>
+      (with "mode" "math" "math-display" "true" (matrix (tformat (table))))
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\<gtr\>\ 
+    <|input>
+      \;
+    </input>
+  </session>
+
+  Flush scheme data to reproduce the bug:
+
+  <\session|octave|default>
+    <\input>
+      \<gtr\>\<gtr\>\ 
+    <|input>
+      flush_scheme ("(matrix (tformat (table)))")
     </input>
   </session>
 </body>

--- a/TeXmacs/tests/tm/7_11.tm
+++ b/TeXmacs/tests/tm/7_11.tm
@@ -53,7 +53,13 @@
     <|input>
       flush_scheme ("(matrix (tformat (table)))")
     </input>
+
+    <\input|Octave] >
+      flush_scheme ("(tformat (table))")
+    </input>
   </session>
+
+  \;
 </body>
 
 <\initial>

--- a/TeXmacs/tests/tm/7_11.tm
+++ b/TeXmacs/tests/tm/7_11.tm
@@ -3,6 +3,8 @@
 <style|<tuple|generic|no-page-numbers|british>>
 
 <\body>
+  <section|How to reproduce the bug>
+
   How to reproduce the bug:
 
   <\session|octave|default>
@@ -11,14 +13,6 @@
 
       Welcome to star and fork it at https://github.com/texmacs/octave
     </output>
-
-    <\unfolded-io>
-      \<gtr\>\<gtr\>\ 
-    <|unfolded-io>
-      ones (1)
-    <|unfolded-io>
-      <with|mode|math|1>
-    </unfolded-io>
 
     <\input>
       \<gtr\>\<gtr\>\ 
@@ -59,6 +53,40 @@
     </input>
   </session>
 
+  <section|How to test>
+
+  <\session|octave|default>
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      ones(0)
+    <|unfolded-io>
+      <stack|<tformat|<table|<row|<cell|[](0x0)>>>>>
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      ones(1)
+    <|unfolded-io>
+      <with|mode|math|1>
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      ones(2)
+    <|unfolded-io>
+      <with|mode|math|math-display|true|<matrix|<tformat|<table|<row|<cell|<with|mode|math|1>>|<cell|<with|mode|math|1>>>|<row|<cell|<with|mode|math|1>>|<cell|<with|mode|math|1>>>>>>>
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\<gtr\>\ 
+    <|input>
+      \;
+    </input>
+  </session>
+
   \;
 </body>
 
@@ -68,3 +96,24 @@
     <associate|page-screen-margin|false>
   </collection>
 </initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|1|?>>
+    <associate|auto-2|<tuple|2|?>>
+  </collection>
+</references>
+
+<\auxiliary>
+  <\collection>
+    <\associate|toc>
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|1<space|2spc>How
+      to reproduce the bug> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-1><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|2<space|2spc>How
+      to test> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-2><vspace|0.5fn>
+    </associate>
+  </collection>
+</auxiliary>

--- a/TeXmacs/tests/tm/7_11.tm
+++ b/TeXmacs/tests/tm/7_11.tm
@@ -1,0 +1,34 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|chinese>>
+
+<\body>
+  <\session|octave|default>
+    <\output>
+      GNU Octave (8.4.0) Session in GNU TeXmacs
+
+      Welcome to star and fork it at https://github.com/texmacs/octave
+    </output>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      ones (1)
+    <|unfolded-io>
+      <with|mode|math|1>
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\<gtr\>\ 
+    <|input>
+      ones (0)
+    </input>
+  </session>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|beamer>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/bin/research
+++ b/bin/research
@@ -1,0 +1,3 @@
+#!/usr/bin/env elvish
+
+xmake r research


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Fix typesetting failure caused by `ones (0)` in the Octave.

This pull request fixed the bug in the Octave side. It does not fix the bug in the typesetter.

## Why
Fixing the bug in the typesetter is much harder. Fix the bug first and then find the best way to fix it.

## How to test your changes?
See `TeXmacs/tests/11_7.tm`.