### PR TITLE
[65_10] Qt: deprecate Qt::AA_UseHighDpiPixmaps

### DIFF
--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -182,7 +182,6 @@ qt_gui_rep::qt_gui_rep (int& argc, char** argv)
   if (has_user_preference ("retina-scale"))
     retina_scale= as_double (get_user_preference ("retina-scale"));
 
-  qApp->setAttribute (Qt::AA_UseHighDpiPixmaps);
   if (!use_native_menubar) {
     qApp->setAttribute (Qt::AA_DontUseNativeMenuBar);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
```
warning: ‘Qt::AA_UseHighDpiPixmaps’ is deprecated: High-DPI pixmaps are always enabled. This attribute no longer has any effect. [-Wdeprecated-declarations]
  185 |   qApp->setAttribute (Qt::AA_UseHighDpiPixmaps);
      |                          ^~~~~~~~~~~~~~~~~~~~
```
## Why
code cleaning

## How to test your changes?
No need.
