### PR TITLE
[77_12] Default: page-type defaults to 16:9 when switching to beamer style

### DIFF
--- a/TeXmacs/packages/beamer/presentation.ts
+++ b/TeXmacs/packages/beamer/presentation.ts
@@ -46,7 +46,7 @@
     </src-comment>
   </active*>
 
-  <assign|page-type|4:3>
+  <assign|page-type|16:9>
 
   <assign|page-medium|beamer>
 

--- a/TeXmacs/tests/tm/77_12_16x9.tm
+++ b/TeXmacs/tests/tm/77_12_16x9.tm
@@ -1,0 +1,19 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|beamer|no-page-numbers|chinese>>
+
+<\body>
+  <screens|<\shown>
+    Paper size is 16:9
+  </shown>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-height|auto>
+    <associate|page-medium|beamer>
+    <associate|page-screen-margin|false>
+    <associate|page-type|16:9>
+    <associate|page-width|auto>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tm/77_12_4x3.tm
+++ b/TeXmacs/tests/tm/77_12_4x3.tm
@@ -1,0 +1,16 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|beamer|no-page-numbers|chinese>>
+
+<\body>
+  <screens|<\shown>
+    Paper size is 4:3
+  </shown>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|beamer>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Switch to `16:9` when switching to beamer style for a new TeXmacs doc.

## Why
`16:9` is more widely adopted than `4:3`

## How to test your changes?
+ Create a new document, and switch to beamer style, check the page type in the focus toolbar (should be 16:9)
+ Open `TeXmacs/tests/tm/77_12_4x3.tm`, the page type should be `4:3`
+ Open `TeXmacs/tests/tm/77_12_16x9.tm`, the page type should be `16:9`