### PR TITLE
[77_9] Beamer: fit-to-screen-width after open-buffer of beamer tm doc in book page rendering

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -429,6 +429,11 @@
   (and-with master (and (url-rooted-tmfs? name) (tmfs-master name))
     (when (!= master name)
       (buffer-set-master name master)))
+  (when (and (in-beamer?)
+             (== (get-init-page-rendering) "book")
+             (inside? 'slideshow)
+             (> (nr-pages) 1))
+    (delayed (:idle 25) (fit-to-screen-width)))
   (noop))
 
 (define (load-buffer-load name opts)


### PR DESCRIPTION
## What
If the buffer is in beamer style and in book page rendering, `fit-to-screen-width` after `open-buffer`.

## Why
Improve user experience of beamer style.

## How to test your changes?
+ Open `TeXmacs/doc/about/mogan/beamer.en.tm`, it will `fit-to-screen-width`.
+ Open `TeXmacs/doc/about/mogan/research.en.tm`, nothing happened.
