### PR TITLE
[77_13] Beamer: fit-to-screen-width after entering presentation-mode

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -132,7 +132,7 @@
         (set! saved-informative-flags (get-init "info-flag"))
         (init-env "info-flag" "none")
         (full-screen-mode #t #f)
-        (fit-to-screen))))
+        (fit-to-screen-width))))
 
 (tm-define (toggle-full-screen-edit-mode)
   (:synopsis "Toggle full screen edit mode.")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
`fit-to-screen-width` after clicking `View->Presentation mode`

## Why
Do not need to zoom out. Before it is `fit-to-screen`, we need to zoom out to make it work.

## How to test your changes?
Open `TeXmacs/doc/about/mogan/beamer.en.tm` and click `View->Presentation mode`.
And then, quit the Presentation mode, and switch to the Slide page rendering, and click `View->Presentation mode` again.