### PR TITLE
[38_8] Deprecate the usage of call_imagemagick_convert

### DIFF
--- a/src/Edit/Editor/edit_main.cpp
+++ b/src/Edit/Editor/edit_main.cpp
@@ -351,7 +351,6 @@ edit_main_rep::print_snippet (url name, tree t, bool conserve_preamble) {
       make_eps (temp, b, dpi);
       ::remove (name);
       if (!call_scm_converter (temp, name)) {
-        call_imagemagick_convert (temp, name);
         if (!exists (name))
           convert_error << "could not convert snippet " << temp
                         << " into :" << name << "\n";

--- a/src/System/Files/image_files.cpp
+++ b/src/System/Files/image_files.cpp
@@ -443,7 +443,6 @@ image_to_pdf (url image, url pdf, int w_pt, int h_pt, int dpi) {
   }
 #endif
   if ((s != "svg") && call_scm_converter (image, pdf)) return;
-  call_imagemagick_convert (image, pdf, w_pt, h_pt, dpi);
 }
 
 void
@@ -494,27 +493,6 @@ static url
 find_binary_identify () {
   eval ("(use-modules (binary identify))");
   return as_url (eval ("(find-binary-identify)"));
-}
-
-void
-call_imagemagick_convert (url image, url dest, int w_pt, int h_pt, int dpi) {
-  url binary_convert= find_binary_convert ();
-  if (!is_none (binary_convert)) {
-    string cmd= sys_concretize (binary_convert);
-    string s  = suffix (image);
-    if (s != "pdf" && s != "ps" && s != "eps" && dpi > 0 && w_pt > 0 &&
-        h_pt > 0) {
-      int  ww= w_pt * dpi / 72; // number of pixels @dpi to make w_pt
-      int  hh= h_pt * dpi / 72;
-      int  w_px, h_px;
-      bool ok= imagemagick_image_size (image, w_px, h_px, false);
-      if (ok && (ww < w_px || hh < h_px)) {
-        // down-sample image if unecessarily large
-        cmd << " -resize " * as_string (ww) * "x" * as_string (hh) * "!";
-      }
-    }
-    system (cmd, image, dest);
-  }
 }
 
 bool

--- a/src/System/Files/image_files.hpp
+++ b/src/System/Files/image_files.hpp
@@ -32,8 +32,6 @@ void   image_to_pdf (url image, url eps, int w_pt= 0, int h_pt= 0, int dpi= 0);
 string image_to_psdoc (url image);
 void   image_to_png (url image, url png, int w= 0, int h= 0);
 bool   call_scm_converter (url image, url dest, int w= 0, int h= 0);
-void   call_imagemagick_convert (url image, url dest, int w_pt= 0, int h_pt= 0,
-                                 int dpi= 72);
 bool   imagemagick_image_size (url image, int& w, int& h, bool pt_units= true);
 url    find_binary_convert ();
 void   native_image_size (url image, int& w, int& h);


### PR DESCRIPTION
## What
+ Deprecate `call_imagemagick_convert` when converting image formats to pdf format
+ Deprecate `call_imagemagick_convert` when exporting the selected document

## Why
Unify the image format conversion to image plugin.

## How to test your changes?
Make sure `(has-binary-convert?)` is true and then:
+ Export `TeXmacs/tests/tm/38_8.tm` to PDF
+ Export the selected part in `TeXmacs/tests/tm/38_8.tm` as the supported image format
