### PR TITLE
[3_5] Ubuntu: set qt6-qpa-plugins as the dep

### DIFF
--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -8,7 +8,7 @@ Homepage: https://mogan.app
 
 Package: mogan-research
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, qt6-qpa-plugins
 Description:  A structured editor for science and technology
 	     Mogan Research is a fork of GNU TeXmacs using S7 Scheme and Qt 5 with massive
 	     online TeXmacs documents provided by Xmacs Planet and TMML wiki.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Use virtualbox to install Ubuntu 24.04, and install mogan-research v1.2.5.1, you will find that it fails to launch. `apt install qt6-qpa-plugins` will fix the bug.

Fix the missing xcb error by add `qt6-qpa-plugins` as a dep

## How to test your changes?
```
./packages/deb/package.sh
```
And check if `qt6-qpa-plugins` is a dep of the mogan-research deb.
