### PR TITLE
[73_20] xmake: add the missing syslink on Windows surface

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -215,7 +215,7 @@ target("libmogan") do
     end
 
     if is_plat("windows") then
-        add_syslinks("secur32", "shell32", "winhttp", "rpcrt4",{public = true})
+        add_syslinks("secur32", "shell32", "winhttp", "rpcrt4", {public = true})
     elseif is_plat("macosx") then
         add_syslinks("iconv")
     end

--- a/xmake.lua
+++ b/xmake.lua
@@ -215,7 +215,7 @@ target("libmogan") do
     end
 
     if is_plat("windows") then
-        add_syslinks("secur32", "shell32", {public = true})
+        add_syslinks("secur32", "shell32", "winhttp", "rpcrt4",{public = true})
     elseif is_plat("macosx") then
         add_syslinks("iconv")
     end


### PR DESCRIPTION
## What
add_syslink on Windows for Surface, otherwise, it failed to link libmogan

## How to test your changes?
Config and build on MS Surface devices.
```
xmake b research
```
