### PR TITLE
[75_23] Upgrade to lolly 1.4.19

### DIFF
--- a/src/Data/Convert/Texmacs/fromtm.cpp
+++ b/src/Data/Convert/Texmacs/fromtm.cpp
@@ -18,9 +18,11 @@
 #include "tree_helper.hpp"
 
 #include <lolly/data/numeral.hpp>
+#include <lolly/data/unicode.hpp>
 #include <moebius/drd/drd_std.hpp>
 #include <moebius/vars.hpp>
 
+using lolly::data::decode_from_utf8;
 using lolly::data::from_hex;
 using lolly::data::to_Hex;
 using moebius::drd::STD_CODE;
@@ -115,8 +117,8 @@ tm_reader<format_without_utf8>::read_char () {
     return buf (pos - 1, pos);
   }
   else {
-    int          old_pos= pos;
-    unsigned int code   = decode_from_utf8 (buf, pos);
+    int      old_pos= pos;
+    uint32_t code   = decode_from_utf8 (buf, pos);
     if (pos - old_pos == 1) {
       return buf (pos - 1, pos);
     }

--- a/src/Data/String/converter.cpp
+++ b/src/Data/String/converter.cpp
@@ -18,10 +18,13 @@
 #include <errno.h>
 
 #include <lolly/data/numeral.hpp>
+#include <lolly/data/unicode.hpp>
 #include <moebius/data/scheme.hpp>
 
 using namespace moebius;
 
+using lolly::data::decode_from_utf8;
+using lolly::data::encode_as_utf8;
 using lolly::data::from_hex;
 using lolly::data::to_Hex;
 using moebius::data::block_to_scheme_tree;
@@ -802,86 +805,6 @@ convert_char_entity (string s, int& start, bool& success) {
     return encode_as_utf8 (num);
   }
   else return "";
-}
-
-string_u8
-encode_as_utf8 (unsigned int code) {
-  if (/* 0x0 <= code && */ code <= 0x7F) {
-    // 0x0ddddddd
-    return string ((char) code);
-  }
-  else if (0x80 <= code && code <= 0x7FF) {
-    // 0x110ddddd 0x10dddddd
-    string str (2);
-    str[0]= ((code >> 6) & 0x1F) | 0xC0;
-    str[1]= (code & 0x3F) | 0x80;
-    return str;
-  }
-  else if (0x800 <= code && code <= 0xFFFF) {
-    // 0x1110dddd 0x10dddddd 0x10dddddd
-    string str (3);
-    str[0]= ((code >> 12) & 0x0F) | 0xE0;
-    str[1]= ((code >> 6) & 0x3F) | 0x80;
-    str[2]= (code & 0x3F) | 0x80;
-    return str;
-  }
-  else if (0x10000 <= code && code <= 0x1FFFFF) {
-    // 0x11110uuu 0x10zzzzzz 0x10yyyyyy 0x10xxxxxx
-    string str (4);
-    str[0]= ((code >> 18) & 0x07) | 0xF0;
-    str[1]= ((code >> 12) & 0x3F) | 0x80;
-    str[2]= ((code >> 6) & 0x3F) | 0x80;
-    str[3]= (code & 0x3F) | 0x80;
-    return str;
-  }
-  else return "";
-}
-
-unsigned int
-decode_from_utf8 (string_u8 s, int& i) {
-  unsigned char c= s[i];
-  if ((0x80 & c) == 0) {
-    // 0x0ddddddd
-    i++;
-    return (unsigned int) c;
-  }
-  unsigned int code;
-  int          trail;
-  if ((0xE0 & c) == 0xC0) {
-    // 0x110ddddd 0x10dddddd
-    trail= 1;
-    code = c & 0x1F;
-  }
-  else if ((0xF0 & c) == 0xE0) {
-    // 0x1110dddd 0x10dddddd 0x10dddddd
-    trail= 2;
-    code = c & 0x0F;
-  }
-  else if ((0xF8 & c) == 0xF0) {
-    // 0x11110dddd 0x10dddddd 0x10dddddd 0x10dddddd
-    trail= 3;
-    code = c & 0x07;
-  }
-  else {
-    // failsafe
-    // cout << "failsafe: " << c << " (" << (unsigned int)(c) << ")\n";
-    i++;
-    return (unsigned int) c;
-  }
-  int start= i - 1;
-  for (; trail > 0; trail--) {
-    i++;
-    if (i >= N (s)) i= N (s) - 1;
-    c= s[i];
-    if ((0xC0 & c) == 0x80) code= (code << 6) | (c & 0x3F);
-    else {
-      i= start + 1;
-      c= s[i++];
-      return c;
-    }
-  }
-  i++;
-  return code;
 }
 
 string

--- a/src/Data/String/converter.hpp
+++ b/src/Data/String/converter.hpp
@@ -124,14 +124,12 @@ void hashtree_from_dictionary (hashtree<char, string> dic, string file_name,
  * and HTML/XML character entities to and from UTF-8 byte sequences.
  ***************************************************************************/
 
-int          hex_digit_to_int (unsigned char c);
-string_u8    encode_as_utf8 (unsigned int code);
-unsigned int decode_from_utf8 (string_u8 s, int& i);
-string       convert_escapes (string in, bool utf8);
-string       convert_char_entities (string s);
-string       convert_char_entity (string s, int& start, bool& success);
-string       utf8_to_hex_entities (string_u8 s);
-string       utf8_to_pdf_hex_string (string_u8 s);
-tree         convert_OTS1_symbols_to_universal_encoding (tree t);
+int    hex_digit_to_int (unsigned char c);
+string convert_escapes (string in, bool utf8);
+string convert_char_entities (string s);
+string convert_char_entity (string s, int& start, bool& success);
+string utf8_to_hex_entities (string_u8 s);
+string utf8_to_pdf_hex_string (string_u8 s);
+tree   convert_OTS1_symbols_to_universal_encoding (tree t);
 
 #endif // CONVERTER_H

--- a/src/Data/String/unicode.cpp
+++ b/src/Data/String/unicode.cpp
@@ -12,15 +12,16 @@
 
 #include "unicode.hpp"
 #include "converter.hpp"
-#include "lolly/data/unicode.hpp"
+
+#include <lolly/data/unicode.hpp>
 
 string
 get_unicode_range (string c) {
   string uc= strict_cork_to_utf8 (c);
   if (N (uc) == 0) return "";
-  int    pos  = 0;
-  int    code = decode_from_utf8 (uc, pos);
-  string range= lolly::data::unicode_get_range (code);
+  int      pos  = 0;
+  uint32_t code = lolly::data::decode_from_utf8 (uc, pos);
+  string   range= lolly::data::unicode_get_range (code);
   if (pos == N (uc)) return range;
   return "";
 }

--- a/src/Data/String/universal.cpp
+++ b/src/Data/String/universal.cpp
@@ -15,11 +15,14 @@
 #include "hashmap.hpp"
 
 #include <lolly/data/numeral.hpp>
+#include <lolly/data/unicode.hpp>
 
 using lolly::data::from_hex;
 using lolly::data::to_Hex;
 #define as_hexadecimal to_Hex
 #define from_hexadecimal from_hex
+
+using lolly::data::encode_as_utf8;
 
 /******************************************************************************
  * Transliteration

--- a/src/Data/String/wencoding.cpp
+++ b/src/Data/String/wencoding.cpp
@@ -14,6 +14,10 @@
 #include "cork.hpp"
 #include "locale.hpp"
 
+#include <lolly/data/unicode.hpp>
+
+using lolly::data::decode_from_utf8;
+
 static char controls[32]= {
     // 0x00                   BEL BS HT LF    FF CR    0x0F
     1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1,

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -21,7 +21,9 @@
 #include "unicode.hpp"
 
 #include <lolly/data/numeral.hpp>
+#include <lolly/data/unicode.hpp>
 
+using lolly::data::decode_from_utf8;
 using lolly::data::to_Hex;
 
 bool virtually_defined (string c, string name);

--- a/src/Plugins/Freetype/unicode_font.cpp
+++ b/src/Plugins/Freetype/unicode_font.cpp
@@ -18,7 +18,9 @@
 #include "font.hpp"
 
 #include <lolly/data/numeral.hpp>
+#include <lolly/data/unicode.hpp>
 
+using lolly::data::decode_from_utf8;
 using lolly::data::from_hex;
 
 #define std_dpi 600

--- a/src/Plugins/Freetype/unicode_math_font.cpp
+++ b/src/Plugins/Freetype/unicode_math_font.cpp
@@ -12,6 +12,10 @@
 #include "converter.hpp"
 #include "font.hpp"
 
+#include <lolly/data/unicode.hpp>
+
+using lolly::data::decode_from_utf8;
+
 /******************************************************************************
  * True Type fonts
  ******************************************************************************/

--- a/src/Plugins/Tex/parsetex.cpp
+++ b/src/Plugins/Tex/parsetex.cpp
@@ -15,7 +15,11 @@
 #include "tree_helper.hpp"
 #include "wencoding.hpp"
 
+#include <lolly/data/unicode.hpp>
+
 using namespace moebius;
+using lolly::data::decode_from_utf8;
+using lolly::data::encode_as_utf8;
 
 extern bool textm_class_flag;
 

--- a/src/System/Language/hyphenate.cpp
+++ b/src/System/Language/hyphenate.cpp
@@ -20,6 +20,9 @@
 #include <string.h>
 
 #include <lolly/data/numeral.hpp>
+#include <lolly/data/unicode.hpp>
+
+using lolly::data::decode_from_utf8;
 using lolly::data::from_hex;
 using lolly::data::to_Hex;
 

--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -24,7 +24,7 @@ package("lolly")
 
     add_urls("https://github.com/XmacsLabs/lolly.git")
     add_urls("https://gitee.com/XmacsLabs/lolly.git")
-    add_versions("1.4.18", "v1.4.18")
+    add_versions("1.4.19", "v1.4.19")
 
     add_deps("tbox")
     if not is_plat("wasm") then

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -19,7 +19,7 @@ STABLE_VERSION = TEXMACS_VERSION
 STABLE_RELEASE = 1
 
 -- XmacsLabs dependencies
-LOLLY_VERSION = "1.4.18"
+LOLLY_VERSION = "1.4.19"
 
 -- Third-party dependencies
 S7_VERSION = "20230413"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
+ Migrate `decode_from_utf8`, `encode_as_utf8` to lolly

## Why
Lolly is the kernel part of Mogan. UTF-8 related routines should be maintained in lolly.

## How to test your changes?
CI.
