### PR TITLE
[67_2] Octave: remove the snap installed one from binary candidates

### DIFF
--- a/TeXmacs/plugins/octave/progs/binary/octave.scm
+++ b/TeXmacs/plugins/octave/progs/binary/octave.scm
@@ -25,8 +25,7 @@
           "C:\\Program Files*\\GNU Octave\\Octave*\\mingw64\\bin\\octave-cli.exe"))
         (else
          (list
-          "/usr/bin/octave-cli"
-          "/snap/bin/octave-cli"))))
+          "/usr/bin/octave-cli"))))
 
 (tm-define (find-binary-octave)
   (:synopsis "Find the url to the octave binary, return (url-none) if not found")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
as title

## Why
`/snap/bin/octave-cli -p /usr/share/xxx.m` does not work 

## How to test your changes?
Build and install deb, try to launch octave the via the snap installed one.
