### PR TITLE
[60_8] Maxima: remove snap installed one from binary candidates

### DIFF
--- a/TeXmacs/plugins/maxima/progs/binary/maxima.scm
+++ b/TeXmacs/plugins/maxima/progs/binary/maxima.scm
@@ -22,8 +22,7 @@
          (list "C:\\maxima-*\\bin\\maxima.bat"))
         (else
          (list
-          "/usr/bin/maxima"
-          "/snap/bin/maxima"))))
+          "/usr/bin/maxima"))))
 
 (tm-define (find-binary-maxima)
   (:synopsis "Find the url to the maxima binary, return (url-none) if not found")


### PR DESCRIPTION
## What
as title

## Why
`/snap/bin/maxima -p /usr/share/xxx.lisp` does not work 

## How to test your changes?
Build and install deb, try to launch maxima the via the snap installed one.