### PR TITLE
[75_24] Upgrade to moebius 0.1.18 and lolly 1.4.20

### DIFF
--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -24,7 +24,7 @@ package("lolly")
 
     add_urls("https://github.com/XmacsLabs/lolly.git")
     add_urls("https://gitee.com/XmacsLabs/lolly.git")
-    add_versions("1.4.19", "v1.4.19")
+    add_versions("1.4.20", "v1.4.20")
 
     add_deps("tbox")
     if not is_plat("wasm") then

--- a/xmake/packages/m/moebius/xmake.lua
+++ b/xmake/packages/m/moebius/xmake.lua
@@ -24,7 +24,7 @@ package("moebius")
 
     add_urls("https://github.com/XmacsLabs/moebius.git")
     add_urls("https://gitee.com/XmacsLabs/moebius.git")
-    add_versions("0.1.17", "v0.1.17")
+    add_versions("0.1.18", "v0.1.18")
 
     add_deps("lolly")
 

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -19,7 +19,7 @@ STABLE_VERSION = TEXMACS_VERSION
 STABLE_RELEASE = 1
 
 -- XmacsLabs dependencies
-LOLLY_VERSION = "1.4.19"
+LOLLY_VERSION = "1.4.20"
 
 -- Third-party dependencies
 S7_VERSION = "20230413"


### PR DESCRIPTION
## What
+ moebius `0.1.17 -> 0.1.18` (the alias: tree_u8)
+ lolly `1.4.19 -> 1.4.20` (minor fix on string_vew.hpp)

## Why
Regular upgrade of deps.

## How to test your changes?
CI.
