### PR TITLE
[65_11] Qt 6: deprecate QVariant::canConvert(int targetTypeId)

### DIFF
--- a/src/Plugins/Qt/QTMMenuHelper.cpp
+++ b/src/Plugins/Qt/QTMMenuHelper.cpp
@@ -27,6 +27,7 @@
 #include <QApplication>
 #include <QCompleter>
 #include <QKeyEvent>
+#include <QMetaType>
 #include <QToolTip>
 
 #include <moebius/data/scheme.hpp>
@@ -1188,12 +1189,12 @@ QTMTreeView::callOnChange (const QModelIndex& index, bool mouse) {
   // docs state the index is valid, no need to check
   QVariant d= tmModel ()->data (index, QTMTreeModel::CommandRole);
   // If there's no CommandRole, we return the subtree by default
-  if (!d.isValid () || !d.canConvert (QVariant::String))
+  if (!d.isValid () || !d.canConvert (QMetaType (QVariant::String)))
     arguments= cons (tmModel ()->item_from_index (index), arguments);
   else arguments= cons (from_qstring (d.toString ()), arguments);
   int cnt= QTMTreeModel::TMUserRole;
   d      = tmModel ()->data (index, cnt);
-  while (d.isValid () && d.canConvert (QVariant::String)) {
+  while (d.isValid () && d.canConvert (QMetaType (QVariant::String))) {
     arguments= cons (from_qstring (d.toString ()), arguments);
     d        = tmModel ()->data (index, ++cnt);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
https://doc.qt.io/qt-6/qvariant-obsolete.html#canConvert-1
> `bool QVariant::canConvert(int targetTypeId) const`
> This function is deprecated since 6.0. We strongly advise against using it in new code.
> This is an overloaded function.
> Use canConvert(QMetaType(targetTypeId)) instead.

## How to test your changes?
CI
