### PR TITLE
[73_33] Upgrade CICD from macOS 11 to macOS 12

### DIFF
--- a/.github/workflows/cd_research_on_macos.yml
+++ b/.github/workflows/cd_research_on_macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   macosbuild:
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-xmake-macos.yml
+++ b/.github/workflows/ci-xmake-macos.yml
@@ -30,9 +30,9 @@ jobs:
   macosbuild:
     strategy:
       matrix:
-        os: [macos-11]
+        os: [macos-12]
         arch: [x86_64]
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 45
     if: always()
     steps:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
as title

## Why
macos-11 runner is deprecated

## How to test your changes?
CICD.
