### PR TITLE
[66_6] Protocol: scheme_u8 for UTF-8 Scheme tree

### DIFF
--- a/TeXmacs/tests/tm/66_6.tm
+++ b/TeXmacs/tests/tm/66_6.tm
@@ -43,7 +43,7 @@
     <|unfolded-io>
       flush_any ("scheme_u8:(frac \<#5206\>\<#5B50\> \<#5206\>\<#6BCD\>)")
     <|unfolded-io>
-      <frac|分子|分母>
+      <frac|\<#5206\>\<#5B50\>|\<#5206\>\<#6BCD\>>
     </unfolded-io>
 
     <\input>

--- a/TeXmacs/tests/tm/66_6.tm
+++ b/TeXmacs/tests/tm/66_6.tm
@@ -1,0 +1,64 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|chinese|python>>
+
+<\body>
+  <\session|scheme|default>
+    <\unfolded-io|Scheme] >
+      (stree-\<gtr\>tree `(frac 1 2))
+    <|unfolded-io>
+      <text|<frac|1|2>>
+    </unfolded-io>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
+
+  <\session|python|default>
+    <\output>
+      Python 3.12.2 [/usr/bin/python3]
+
+      Python plugin for TeXmacs.
+
+      Please see the documentation in Help -\<gtr\> Plugins -\<gtr\> Python
+    </output>
+
+    <\input>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|input>
+      from tmpy.protocol import flush_any
+    </input>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      flush_any ("scheme_u8:(frac 1 2)")
+    <|unfolded-io>
+      <frac|1|2>
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|unfolded-io>
+      flush_any ("scheme_u8:(frac \<#5206\>\<#5B50\> \<#5206\>\<#6BCD\>)")
+    <|unfolded-io>
+      <frac|分子|分母>
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\<gtr\>\<gtr\>\ 
+    <|input>
+      \;
+    </input>
+  </session>
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Data/Convert/Generic/input.cpp
+++ b/src/Data/Convert/Generic/input.cpp
@@ -24,6 +24,7 @@
 #include "tree.hpp"
 #include "tree_helper.hpp"
 #include "tree_modify.hpp"
+#include "tree_traverse.hpp"
 
 #include <moebius/vars.hpp>
 
@@ -45,6 +46,7 @@ using moebius::data::scheme_to_tree;
 #define MODE_COMMAND 8
 #define MODE_XFORMAT 9
 #define MODE_FILE 10
+#define MODE_SCHEME_UTF8 11
 
 /******************************************************************************
  * Universal data input
@@ -76,6 +78,7 @@ texmacs_input_rep::get_mode (string s) {
   if (s == "channel") return MODE_CHANNEL;
   if (s == "command") return MODE_COMMAND;
   if (s == "file") return MODE_FILE;
+  if (s == "scheme_u8") return MODE_SCHEME_UTF8;
   if (format_exists (s)) return MODE_XFORMAT;
   return MODE_VERBATIM;
 }
@@ -238,6 +241,9 @@ texmacs_input_rep::flush (bool force) {
   case MODE_FILE:
     file_flush (force);
     break;
+  case MODE_SCHEME_UTF8:
+    scheme_u8_flush (force);
+    break;
   default:
     TM_FAILED ("invalid mode");
     break;
@@ -269,6 +275,14 @@ void
 texmacs_input_rep::scheme_flush (bool force) {
   if (force) {
     write (simplify_correct (scheme_to_tree (buf)));
+    buf= "";
+  }
+}
+
+void
+texmacs_input_rep::scheme_u8_flush (bool force) {
+  if (force) {
+    write (simplify_correct (tree_utf8_to_cork (scheme_to_tree (buf))));
     buf= "";
   }
 }

--- a/src/Data/Convert/Generic/input.hpp
+++ b/src/Data/Convert/Generic/input.hpp
@@ -40,6 +40,7 @@ struct texmacs_input_rep : concrete_struct {
   void verbatim_flush (bool force= false);
   void utf8_flush (bool force= false);
   void scheme_flush (bool force= false);
+  void scheme_u8_flush (bool force= false);
   void latex_flush (bool force= false);
   void html_flush (bool force= false);
   void ps_flush (bool force= false);

--- a/src/Data/Tree/tree_traverse.cpp
+++ b/src/Data/Tree/tree_traverse.cpp
@@ -733,12 +733,14 @@ search_sections (tree t) {
 
 tree
 tree_utf8_to_cork (tree_u8 t) {
-  if (is_atomic (t)) return tree (utf8_to_cork (t->label));
+  if (is_atomic (t)) {
+    return tree (utf8_to_cork (t->label));
+  }
   else {
     int  i, n= N (t);
     tree t2 (t, n);
     for (i= 0; i < n; i++)
-      t2[i]= copy (t[i]);
+      t2[i]= tree_utf8_to_cork (t[i]);
     return t2;
   }
 }

--- a/src/Data/Tree/tree_traverse.cpp
+++ b/src/Data/Tree/tree_traverse.cpp
@@ -729,3 +729,15 @@ search_sections (tree t) {
   search_sections (a, t);
   return a;
 }
+
+tree
+tree_utf8_to_cork (tree_u8 t) {
+  if (is_atomic (t)) return tree (utf8_to_cork (t->label));
+  else {
+    int  i, n= N (t);
+    tree t2 (t, n);
+    for (i= 0; i < n; i++)
+      t2[i]= copy (t[i]);
+    return t2;
+  }
+}

--- a/src/Data/Tree/tree_traverse.cpp
+++ b/src/Data/Tree/tree_traverse.cpp
@@ -11,6 +11,7 @@
 
 #include "tree_traverse.hpp"
 #include "analyze.hpp"
+#include "converter.hpp"
 #include "cork.hpp"
 #include "hashset.hpp"
 #include "scheme.hpp"

--- a/src/Data/Tree/tree_traverse.hpp
+++ b/src/Data/Tree/tree_traverse.hpp
@@ -68,4 +68,6 @@ bool inside_contiguous_document (tree t, path op, path oq);
 array<tree> search_sections (tree t);
 path        previous_section (tree t, path p);
 
+tree tree_utf8_to_cork (tree_u8 t);
+
 #endif // defined TREE_TRAVERSE_H


### PR DESCRIPTION
## What
This is a protocol change, it brings new feature which is absent for GNU TeXmacs <= 2.1.4.

Add `scheme_u8` input mode for UTF-8 Scheme tree.

## Why
Use UTF-8 Scheme tree as the protocol for plugins.

## How to test your changes?
See `TeXmacs/tests/tm/66_6.tm`

How it works:
1. `66_6.tm` is encoded in cork
2. `python-serialize` in `init-python.scm` will convert the cork encoded tree into UTF-8 python code snippet
3. The python interpreter evaluates the UTF-8 python code snippet and generate the UTF-8 output
4. The output is captured by the "fragile" protocol defined in `input.cpp`


`tree_utf8_to_cork` is an adhoc impl, it will be migrated to moebius later. Please focus on the protocol design to review this pr. In scala snippet, `tree_utf8_to_cork` should be implemented as `tree.map (utf8_to_cork)`. The C++'s syntax is too ugly for functional programming. I don't know if it is possible for us to add several sweet functional interfaces in lolly.
