### PR TITLE
[61_3] Binary: version-binary-xyz impl

### DIFF
--- a/TeXmacs/plugins/binary/progs/binary/aspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/aspell.scm
@@ -30,3 +30,5 @@
 (tm-define (has-binary-aspell?)
   (not (url-none? (find-binary-aspell))))
 
+(tm-define (version-binary-aspell)
+  (version-binary (find-binary-aspell)))

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -29,5 +29,6 @@
            u)))))
 
 (tm-define (version-binary u)
-  (with ret (check-stdout (string-append (url->system u) " --version"))
-    ret))
+  (if (url-none? u)
+    ""
+    (check-stdout (string-append (url->system u) " --version"))))

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -31,4 +31,10 @@
 (tm-define (version-binary u)
   (if (url-none? u)
     ""
-    (check-stdout (string-append (url->system u) " --version"))))
+    (let*
+     ((msg (check-stdout (string-append (url->system u) " --version")))
+      (msg-l (filter (lambda (x) (not (string-null? x)))
+                 (string-split msg #\newline))))
+     (if (== (length msg-l) 0)
+         ""
+         (car msg-l)))))

--- a/TeXmacs/plugins/binary/progs/binary/convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/convert.scm
@@ -32,6 +32,9 @@
 (tm-define (has-binary-convert?)
   (not (url-none? (find-binary-convert))))
 
+(tm-define (version-binary-convert)
+  (version-binary (find-binary-convert)))
+
 (tm-define (pdf-file->imagemagick-raster x opts)
   (let* ((dest (assoc-ref opts 'dest))
          (res (get-raster-resolution opts)))

--- a/TeXmacs/plugins/binary/progs/binary/hunspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/hunspell.scm
@@ -29,3 +29,9 @@
 
 (tm-define (has-binary-hunspell?)
   (not (url-none? (find-binary-hunspell))))
+
+(tm-define (version-binary-hunspell)
+  (with msg (version-binary (find-binary-hunspell))
+    (if (string-null? msg)
+        ""
+        (car (string-split msg #\newline)))))

--- a/TeXmacs/plugins/binary/progs/binary/hunspell.scm
+++ b/TeXmacs/plugins/binary/progs/binary/hunspell.scm
@@ -31,7 +31,4 @@
   (not (url-none? (find-binary-hunspell))))
 
 (tm-define (version-binary-hunspell)
-  (with msg (version-binary (find-binary-hunspell))
-    (if (string-null? msg)
-        ""
-        (car (string-split msg #\newline)))))
+  (version-binary (find-binary-hunspell)))

--- a/TeXmacs/plugins/binary/progs/binary/identify.scm
+++ b/TeXmacs/plugins/binary/progs/binary/identify.scm
@@ -31,3 +31,6 @@
 
 (tm-define (has-binary-identify?)
   (not (url-none? (find-binary-identify))))
+
+(tm-define (version-binary-identify)
+  (version-binary (find-binary-identify)))

--- a/TeXmacs/plugins/binary/progs/binary/inkscape.scm
+++ b/TeXmacs/plugins/binary/progs/binary/inkscape.scm
@@ -28,3 +28,6 @@
 
 (tm-define (has-binary-inkscape?)
   (not (url-none? (find-binary-inkscape))))
+
+(tm-define (version-binary-inkscape)
+  (version-binary (find-binary-inkscape)))

--- a/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
+++ b/TeXmacs/plugins/binary/progs/binary/pdftocairo.scm
@@ -30,6 +30,9 @@
 (tm-define (has-binary-pdftocairo?)
   (not (url-none? (find-binary-pdftocairo))))
 
+(tm-define (version-binary-pdftocairo)
+  (version-binary (find-binary-pdftocairo)))
+
 (tm-define (pdf-file->pdftocairo-raster x opts)
   (let* ((dest (assoc-ref opts 'dest))
          (fullname (url-concretize dest))

--- a/TeXmacs/plugins/binary/progs/binary/rsvg-convert.scm
+++ b/TeXmacs/plugins/binary/progs/binary/rsvg-convert.scm
@@ -30,6 +30,9 @@
 (tm-define (has-binary-rsvg-convert?)
   (not (url-none? (find-binary-rsvg-convert))))
 
+(tm-define (version-binary-rsvg-convert)
+  (version-binary (find-binary-rsvg-convert)))
+
 (tm-define (svg2png-by-rsvg-convert x opts)
   (let* ((dest (assoc-ref opts 'dest))
          (fm (url-format (url-concretize dest)))

--- a/TeXmacs/plugins/maxima/progs/binary/maxima.scm
+++ b/TeXmacs/plugins/maxima/progs/binary/maxima.scm
@@ -33,7 +33,4 @@
   (not (url-none? (find-binary-maxima))))
 
 (tm-define (version-binary-maxima)
-  (with u (find-binary-maxima)
-    (if (url-none? u)
-      ""
-      (check-stdout (string-append (url->system u) " --version")))))
+  (version-binary (find-binary-maxima)))

--- a/TeXmacs/plugins/octave/progs/binary/octave.scm
+++ b/TeXmacs/plugins/octave/progs/binary/octave.scm
@@ -35,8 +35,7 @@
   (not (url-none? (find-binary-octave))))
 
 (tm-define (version-binary-octave)
-  (with u (find-binary-octave)
-    (if (url-none? u)
+  (with msg (version-binary (find-binary-octave))
+    (if (string-null? msg)
         ""
-        (with msg (check-stdout (string-append (url->system u) " --version"))
-          (car (string-split msg #\newline))))))
+        (car (string-split msg #\newline)))))

--- a/TeXmacs/plugins/octave/progs/binary/octave.scm
+++ b/TeXmacs/plugins/octave/progs/binary/octave.scm
@@ -35,7 +35,4 @@
   (not (url-none? (find-binary-octave))))
 
 (tm-define (version-binary-octave)
-  (with msg (version-binary (find-binary-octave))
-    (if (string-null? msg)
-        ""
-        (car (string-split msg #\newline)))))
+  (version-binary (find-binary-octave)))

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -301,9 +301,9 @@
       (version-binary-convert)
     </input>
 
-    <\folded-io|Scheme] >
+    <\unfolded-io|Scheme] >
       (use-modules (binary hunspell))
-    <|folded-io>
+    <|unfolded-io>
       (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
       supports-python? 'python-launcher python-launcher 'python-utf8-command
       python-utf8-command 'python-serialize python-serialize
@@ -313,13 +313,13 @@
       python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
       python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
       'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
-    </folded-io>
+    </unfolded-io>
 
-    <\folded-io|Scheme] >
+    <\unfolded-io|Scheme] >
       (version-binary-hunspell)
-    <|folded-io>
+    <|unfolded-io>
       @(#) International Ispell Version 3.2.06 (but really Hunspell 1.7.2)
-    </folded-io>
+    </unfolded-io>
 
     <\folded-io|Scheme] >
       (use-modules (binary identify))

--- a/TeXmacs/tests/tm/61_3.tm
+++ b/TeXmacs/tests/tm/61_3.tm
@@ -259,6 +259,140 @@
       \;
     </input>
   </session>
+
+  <section|Version>
+
+  <\session|scheme|default>
+    <\folded-io|Scheme] >
+      (use-modules (binary aspell))
+    <|folded-io>
+      (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
+      supports-python? 'python-launcher python-launcher 'python-utf8-command
+      python-utf8-command 'python-serialize python-serialize
+      'scala-snippet-\<gtr\>texmacs scala-snippet-\<gtr\>texmacs
+      'scala-\<gtr\>texmacs scala-\<gtr\>texmacs 'texmacs-\<gtr\>scala
+      texmacs-\<gtr\>scala 'python-snippet-\<gtr\>texmacs
+      python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
+      python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
+      'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
+    </folded-io>
+
+    <\folded-io|Scheme] >
+      (version-binary-aspell)
+    <|folded-io>
+      @(#) International Ispell Version 3.1.20 (but really Aspell 0.60.8.1)
+    </folded-io>
+
+    <\folded-io|Scheme] >
+      (use-modules (binary convert))
+    <|folded-io>
+      (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
+      supports-python? 'python-launcher python-launcher 'python-utf8-command
+      python-utf8-command 'python-serialize python-serialize
+      'scala-snippet-\<gtr\>texmacs scala-snippet-\<gtr\>texmacs
+      'scala-\<gtr\>texmacs scala-\<gtr\>texmacs 'texmacs-\<gtr\>scala
+      texmacs-\<gtr\>scala 'python-snippet-\<gtr\>texmacs
+      python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
+      python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
+      'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
+    </folded-io>
+
+    <\input|Scheme] >
+      (version-binary-convert)
+    </input>
+
+    <\folded-io|Scheme] >
+      (use-modules (binary hunspell))
+    <|folded-io>
+      (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
+      supports-python? 'python-launcher python-launcher 'python-utf8-command
+      python-utf8-command 'python-serialize python-serialize
+      'scala-snippet-\<gtr\>texmacs scala-snippet-\<gtr\>texmacs
+      'scala-\<gtr\>texmacs scala-\<gtr\>texmacs 'texmacs-\<gtr\>scala
+      texmacs-\<gtr\>scala 'python-snippet-\<gtr\>texmacs
+      python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
+      python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
+      'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
+    </folded-io>
+
+    <\folded-io|Scheme] >
+      (version-binary-hunspell)
+    <|folded-io>
+      @(#) International Ispell Version 3.2.06 (but really Hunspell 1.7.2)
+    </folded-io>
+
+    <\folded-io|Scheme] >
+      (use-modules (binary identify))
+    <|folded-io>
+      (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
+      supports-python? 'python-launcher python-launcher 'python-utf8-command
+      python-utf8-command 'python-serialize python-serialize
+      'scala-snippet-\<gtr\>texmacs scala-snippet-\<gtr\>texmacs
+      'scala-\<gtr\>texmacs scala-\<gtr\>texmacs 'texmacs-\<gtr\>scala
+      texmacs-\<gtr\>scala 'python-snippet-\<gtr\>texmacs
+      python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
+      python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
+      'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
+    </folded-io>
+
+    <\input|Scheme] >
+      (version-binary-identify)
+    </input>
+
+    <\folded-io|Scheme] >
+      (use-modules (binary inkscape))
+    <|folded-io>
+      (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
+      supports-python? 'python-launcher python-launcher 'python-utf8-command
+      python-utf8-command 'python-serialize python-serialize
+      'scala-snippet-\<gtr\>texmacs scala-snippet-\<gtr\>texmacs
+      'scala-\<gtr\>texmacs scala-\<gtr\>texmacs 'texmacs-\<gtr\>scala
+      texmacs-\<gtr\>scala 'python-snippet-\<gtr\>texmacs
+      python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
+      python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
+      'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
+    </folded-io>
+
+    <\input|Scheme] >
+      (version-binary-inkscape)
+    </input>
+
+    <\input|Scheme] >
+      (version-binary-pdftocairo)
+    </input>
+
+    <\folded-io|Scheme] >
+      (use-modules (binary rsvg-convert))
+    <|folded-io>
+      (#1=(inlet 'supports-slidemove? supports-slidemove? 'supports-python?
+      supports-python? 'python-launcher python-launcher 'python-utf8-command
+      python-utf8-command 'python-serialize python-serialize
+      'scala-snippet-\<gtr\>texmacs scala-snippet-\<gtr\>texmacs
+      'scala-\<gtr\>texmacs scala-\<gtr\>texmacs 'texmacs-\<gtr\>scala
+      texmacs-\<gtr\>scala 'python-snippet-\<gtr\>texmacs
+      python-snippet-\<gtr\>texmacs 'python-\<gtr\>texmacs
+      python-\<gtr\>texmacs 'texmacs-\<gtr\>python texmacs-\<gtr\>python
+      'julia-snippet-\<gtr\>texmacs julia-snippet-\<gtr\>texmacs ...))
+    </folded-io>
+
+    <\input|Scheme] >
+      (version-binary-rsvg-convert)
+    </input>
+
+    <\input|Scheme] >
+      (version-binary-octave)
+    </input>
+
+    <\folded-io|Scheme] >
+      (version-binary-maxima)
+    <|folded-io>
+      Maxima 5.46.0
+    </folded-io>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
 </body>
 
 <\initial>
@@ -273,6 +407,7 @@
     <associate|auto-2|<tuple|2|?>>
     <associate|auto-3|<tuple|3|?>>
     <associate|auto-4|<tuple|4|?>>
+    <associate|auto-5|<tuple|5|?>>
   </collection>
 </references>
 
@@ -290,6 +425,15 @@
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|3<space|2spc>Various
       other binaries> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-3><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|4<space|2spc>Test
+      on the switcher for all binary plugins>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-4><vspace|0.5fn>
+
+      <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|5<space|2spc>Version>
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-5><vspace|0.5fn>
     </associate>
   </collection>
 </auxiliary>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
+ Common routines `(version-binary)`

Return the first non-empty line as the version line for the binary.

## Why
Binary version is needed for all binaries.

## How to test your changes?
Open `TeXmacs/tests/tm/61_3.tm`.
