### PR TITLE
[20_9] Replace: fix replace-one and replace-all on replace-toolbar

### DIFF
--- a/TeXmacs/progs/generic/search-widgets.scm
+++ b/TeXmacs/progs/generic/search-widgets.scm
@@ -363,7 +363,7 @@
                  (search-next-match #t)))))))
 
 (tm-define (replace-one)
-  (and-with by (by-tree)
+  (and-with by (or (by-tree) current-replace)
     (with-buffer (master-buffer)
       (start-editing)
       (replace-next by)
@@ -371,7 +371,7 @@
     (perform-search*)))
 
 (tm-define (replace-all)
-  (and-with by (by-tree)
+  (and-with by (or (by-tree) current-replace)
     (with-buffer (master-buffer)
       (start-editing)
       (while (replace-next by)


### PR DESCRIPTION
## What
Fix replace-one and replace-all on the replace toolbar.

## Why
bug fix

## How to test your changes?
Click `Help->Welcome`, and click `Edit->Replace` and then replace `<from>` with `<to>`, using the Enter key, it should work fine. Using the mouse to click the button, it should work fine too with this pull request.