### PR TITLE
[61_3] Binary: improve impl for finding binary in sys path

### DIFF
--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -20,10 +20,9 @@
 
 ; If candidates name could bin found in path, return it, otherwise, return (url-none)
 (define (find-binary-in-candidates-name candidates)
-  (with u (list-find
-            (map (lambda (x) (find-binary-in-path (url->string (url-tail x)))) candidates)
-            url-exists?)
-    (or u (url-none))))
+  (with names (list-remove-duplicates (map (lambda (x) (url->string (url-tail x))) candidates))
+    (with u (list-find (map (lambda (x) (find-binary-in-path x)) names) url-exists?)
+      (or u (url-none)))))
 
 ; If candidates exist, return it, otherwise, return #f
 (define (find-binary-in-candidates candidates)

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -20,8 +20,9 @@
 
 ; If candidates name could bin found in path, return it, otherwise, return (url-none)
 (define (find-binary-in-candidates-name candidates)
-  (with u (list-find candidates
-            (lambda (x) (url-exists? (find-binary-in-path (url->string (url-tail x))))))
+  (with u (list-find
+            (map (lambda (x) (find-binary-in-path (url->string (url-tail x)))) candidates)
+            url-exists?)
     (or u (url-none))))
 
 ; If candidates exist, return it, otherwise, return #f

--- a/TeXmacs/plugins/binary/progs/binary/common.scm
+++ b/TeXmacs/plugins/binary/progs/binary/common.scm
@@ -14,11 +14,17 @@
 (texmacs-module (binary common))
 
 (define (find-binary-in-path name)
-  (let* ((name-exe (if (os-win32?) (string-append name ".exe") name))
-         (u (url-resolve-in-path name-exe))
+  (let* ((u (url-resolve-in-path name))
          (excluded? (and (os-win32?) (url-descends? u (system->url "C:\\Windows\\System32")))))
     (if excluded? (url-none) u)))
 
+; If candidates name could bin found in path, return it, otherwise, return (url-none)
+(define (find-binary-in-candidates-name candidates)
+  (with u (list-find candidates
+            (lambda (x) (url-exists? (find-binary-in-path (url->string (url-tail x))))))
+    (or u (url-none))))
+
+; If candidates exist, return it, otherwise, return #f
 (define (find-binary-in-candidates candidates)
   (with u (list-find candidates (lambda (x) (url-exists? (url-resolve x "r"))))
     (and u (url-resolve u "r"))))
@@ -29,16 +35,16 @@
         u
         #f)))
 
-(tm-define (find-binary candidates name)
+(tm-define (find-binary candidates binary-id)
   (let* ((global-binary-opt (get-preference "plugin:binary"))
-         (this-binary-opt (get-preference (string-append "plugin:binary:" name))))
+         (this-binary-opt (get-preference (string-append "plugin:binary:" binary-id))))
     (cond ((== global-binary-opt "off") (url-none))
           ((== this-binary-opt "off") (url-none))
           ((== this-binary-opt "candidates-only") (find-binary-in-candidates candidates))
           (else
            (or (and (!= this-binary-opt "default") (find-binary-in-specified this-binary-opt))
                (find-binary-in-candidates candidates)
-               (find-binary-in-path name))))))
+               (find-binary-in-candidates-name candidates))))))
 
 (tm-define (version-binary u)
   (if (url-none? u)

--- a/TeXmacs/plugins/binary/progs/binary/gs.scm
+++ b/TeXmacs/plugins/binary/progs/binary/gs.scm
@@ -16,10 +16,13 @@
 
 (define (gs-binary-candidates)
   (cond ((os-macos?)
-         (list "/opt/homebrew/Cellar/ghostscript/1*/bin/gs"
-               "/usr/local/Cellar/ghostscript/1*/bin/gs"))
+         (list
+          "/opt/homebrew/Cellar/ghostscript/1*/bin/gs"
+          "/usr/local/Cellar/ghostscript/1*/bin/gs"))
         ((os-win32?)
-         (list "C:\\Program Files*\\gs\\gs*\\bin\\gswin*c.exe"))
+         (list
+          "C:\\Program Files*\\gs\\gs*\\bin\\gswin64c.exe"
+          "C:\\Program Files*\\gs\\gs*\\bin\\gswin32c.exe"))
         (else
          (list "/usr/bin/gs"))))
 

--- a/TeXmacs/plugins/binary/progs/binary/python3.scm
+++ b/TeXmacs/plugins/binary/progs/binary/python3.scm
@@ -26,7 +26,7 @@
 
 (tm-define (find-binary-python3)
   (:synopsis "Find the url to the python3 binary, return (url-none) if not found")
-  (find-binary (python3-binary-candidates) (if (os-win32?) "python" "python3")))
+  (find-binary (python3-binary-candidates) "python3"))
 
 (tm-define (has-binary-python3?)
   (not (url-none? (find-binary-python3))))


### PR DESCRIPTION
## What
Re-impl finding binary in sys path.

Related pull request: https://github.com/XmacsLabs/mogan/pull/1744

## Why
We must keep the consistency of `binary-id`. In the previous impl, the binary-id for python3 is `python3` on linux and macOS, and is `python` on windows.

## How to test your changes?
Open `TeXmacs/tests/tm/61_3.tm`
