### PR TITLE
[79_2] IM: disable preedit by default on linux to speedup editing

### DIFF
--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -222,9 +222,17 @@ QTMWidget::inputMethodEvent (QInputMethodEvent* event) {
   if (DEBUG_QT)
     debug_qt << "IM preediting :" << preedit_string.toUtf8 ().data () << LF;
 
-  string r= "pre-edit:";
-  if (!preedit_string.isEmpty ()) {
+  bool   im_preedit_switch= false;
+  string im_preedit_str   = get_preference ("IM:preedit");
+  if (im_preedit_str == "off") {
+    im_preedit_switch= false;
+  }
+  else if (im_preedit_str == "on") {
+    im_preedit_switch= true;
+  }
 
+  string r= "pre-edit:";
+  if (im_preedit_switch && !preedit_string.isEmpty ()) {
     // find cursor position in the preedit string
     QList<QInputMethodEvent::Attribute> const& attrs= event->attributes ();
     //    int pos = preedit_string.count();
@@ -259,7 +267,7 @@ QTMWidget::inputMethodEvent (QInputMethodEvent* event) {
     r= r * as_string (pos) * ":" * from_qstring_utf8 (preedit_string);
   }
 
-  if (!is_nil (tmwid)) {
+  if (im_preedit_switch && !is_nil (tmwid)) {
     preediting= !preedit_string.isEmpty ();
     the_gui->process_keypress (tm_widget (), r, texmacs_time ());
   }

--- a/src/Plugins/Qt/QTMWidget.cpp
+++ b/src/Plugins/Qt/QTMWidget.cpp
@@ -222,8 +222,11 @@ QTMWidget::inputMethodEvent (QInputMethodEvent* event) {
   if (DEBUG_QT)
     debug_qt << "IM preediting :" << preedit_string.toUtf8 ().data () << LF;
 
-  bool   im_preedit_switch= false;
-  string im_preedit_str   = get_preference ("IM:preedit");
+  bool im_preedit_switch= false;
+  if (os_win () || os_macos ()) {
+    im_preedit_switch= true;
+  }
+  string im_preedit_str= get_preference ("IM:preedit");
   if (im_preedit_str == "off") {
     im_preedit_switch= false;
   }


### PR DESCRIPTION
## What
Disable IM preedit on Linux to speedup.

Menu entry to turn on/turn of IM pre-editing will be implemented in another pull request.

## Why
Performance tuning.

Why not turn it on by default on macOS and Windows: because input via speech is available on Windows and macOS.

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [ ] Windows
