### PR TITLE
[78_2] Revert: Gitee Scan Rule 025: Effective C++, item 30: understan…

### DIFF
--- a/src/Edit/Editor/edit_main.hpp
+++ b/src/Edit/Editor/edit_main.hpp
@@ -43,7 +43,7 @@ private:
 public:
   edit_main_rep (server_rep* sv, tm_buffer buf);
   ~edit_main_rep ();
-  inline void* derived_this () { return (edit_main_rep*) this; }
+  virtual inline void* derived_this () { return (edit_main_rep*) this; }
 
   void        set_property (scheme_tree what, scheme_tree val);
   void        set_bool_property (string what, bool val);

--- a/src/Edit/editor.hpp
+++ b/src/Edit/editor.hpp
@@ -136,7 +136,7 @@ protected:
 public:
   editor_rep ();
   editor_rep (server_rep* sv, tm_buffer buf);
-  virtual ~editor_rep () {}
+  inline virtual ~editor_rep () {}
   bool is_current_editor ();
 
   /* public routines from edit_interface */

--- a/src/Graphics/Gui/widget.hpp
+++ b/src/Graphics/Gui/widget.hpp
@@ -38,8 +38,8 @@ protected:
 public:
   widget_rep ();
   virtual ~widget_rep ();
-  inline void*        derived_this () { return (widget_rep*) this; }
-  virtual tm_ostream& print (tm_ostream& out);
+  inline virtual void* derived_this () { return (widget_rep*) this; }
+  virtual tm_ostream&  print (tm_ostream& out);
 
   virtual void send (slot s, blackbox val);
   // send a message val to the slot s

--- a/src/Graphics/Pictures/effect.hpp
+++ b/src/Graphics/Pictures/effect.hpp
@@ -26,7 +26,7 @@ class effect {
 class effect_rep : public abstract_struct {
 public:
   inline effect_rep () {}
-  virtual ~effect_rep () {}
+  inline virtual ~effect_rep () {}
 
   virtual rectangle get_logical_extents (array<rectangle> rs);
   virtual rectangle get_extents (array<rectangle> rs)    = 0;

--- a/src/Graphics/Pictures/picture.hpp
+++ b/src/Graphics/Pictures/picture.hpp
@@ -42,7 +42,7 @@ protected:
 
 public:
   inline picture_rep () : unique_id (unique_picture_id ()) {}
-  virtual ~picture_rep () {}
+  inline virtual ~picture_rep () {}
 
   inline unsigned long long int get_unique_id () { return unique_id; }
   virtual picture_kind          get_type ()  = 0;

--- a/src/Graphics/Pictures/scalable.hpp
+++ b/src/Graphics/Pictures/scalable.hpp
@@ -31,7 +31,7 @@ class scalable {
 class scalable_rep : public abstract_struct {
 public:
   inline scalable_rep () {}
-  virtual ~scalable_rep () {}
+  inline virtual ~scalable_rep () {}
 
   virtual scalable_kind get_type ()  = 0;
   virtual void*         get_handle ()= 0;

--- a/src/Graphics/Renderer/brush.hpp
+++ b/src/Graphics/Renderer/brush.hpp
@@ -19,7 +19,7 @@ enum brush_kind { brush_none, brush_color, brush_pattern };
 class brush_rep : abstract_struct {
 public:
   inline brush_rep () {}
-  virtual ~brush_rep () {}
+  inline virtual ~brush_rep () {}
 
   virtual brush_kind get_type ()  = 0;
   virtual void*      get_handle ()= 0;

--- a/src/Graphics/Renderer/pencil.hpp
+++ b/src/Graphics/Renderer/pencil.hpp
@@ -26,7 +26,7 @@ class pencil;
 class pencil_rep : abstract_struct {
 public:
   inline pencil_rep () {}
-  virtual ~pencil_rep () {}
+  inline virtual ~pencil_rep () {}
 
   virtual pencil_kind get_type ()  = 0;
   virtual void*       get_handle ()= 0;

--- a/src/Graphics/Spacial/spacial.hpp
+++ b/src/Graphics/Spacial/spacial.hpp
@@ -38,7 +38,7 @@ class spacial {
 class spacial_rep : public abstract_struct {
 public:
   inline spacial_rep () {}
-  virtual ~spacial_rep () {}
+  inline virtual ~spacial_rep () {}
 
   virtual spacial_kind get_type ()  = 0;
   virtual void*        get_handle ()= 0;

--- a/src/Graphics/Types/curve.hpp
+++ b/src/Graphics/Types/curve.hpp
@@ -16,9 +16,9 @@
 class curve_rep : public abstract_struct {
 public:
   inline curve_rep () {}
-  virtual ~curve_rep () {}
+  inline virtual ~curve_rep () {}
 
-  virtual int nr_components () { return 1; }
+  inline virtual int nr_components () { return 1; }
   // the number of components of the curve is useful for getting
   // nice parameterizations when concatenating curves
 

--- a/src/Graphics/Types/frame.hpp
+++ b/src/Graphics/Types/frame.hpp
@@ -20,7 +20,7 @@ public:
 
 public:
   inline frame_rep () { linear= false; }
-  virtual ~frame_rep () {}
+  inline virtual ~frame_rep () {}
   virtual operator tree ()= 0;
 
   virtual point direct_transform (point p) = 0;

--- a/src/Graphics/Types/grid.hpp
+++ b/src/Graphics/Types/grid.hpp
@@ -39,7 +39,7 @@ public:
   inline grid_rep () {}
   inline grid_rep (array<SI> subd2, array<string> col2, point o)
       : subd (subd2), col (col2), center (o) {}
-  virtual ~grid_rep () {}
+  inline virtual ~grid_rep () {}
 
   virtual void set_aspect (tree aspect);
 

--- a/src/Plugins/Qt/qt_widget.hpp
+++ b/src/Plugins/Qt/qt_widget.hpp
@@ -147,7 +147,7 @@ public:
 
   qt_widget_rep (types _type= none, QWidget* _qwid= 0);
   virtual ~qt_widget_rep ();
-  virtual string get_nickname () { return "popup"; }
+  virtual inline string get_nickname () { return "popup"; }
 
   virtual widget plain_window_widget (string name, command quit, int b= 3);
   virtual widget make_popup_widget ();
@@ -295,7 +295,7 @@ public:
   virtual ~qt_headless_widget_rep () {
     if (DEBUG_QT_WIDGETS) debug_widgets << "~qt_headless_widget_rep" << LF;
   }
-  inline string get_nickname () { return "headless"; }
+  virtual inline string get_nickname () { return "headless"; }
 
   virtual widget plain_window_widget (string name, command quit, int b= 3) {
     (void) name;

--- a/src/Plugins/Qt/qt_window_widget.hpp
+++ b/src/Plugins/Qt/qt_window_widget.hpp
@@ -49,8 +49,8 @@ public:
                         bool fake= false);
   ~qt_window_widget_rep ();
 
-  virtual string get_nickname () { return orig_name; }
-  virtual widget popup_window_widget (string s);
+  virtual inline string get_nickname () { return orig_name; }
+  virtual widget        popup_window_widget (string s);
 
   virtual void     send (slot s, blackbox val);
   virtual blackbox query (slot s, int type_id);

--- a/src/Typeset/Bridge/bridge.hpp
+++ b/src/Typeset/Bridge/bridge.hpp
@@ -48,7 +48,7 @@ public:
 
 public:
   bridge_rep (typesetter ttt, tree st, path ip);
-  virtual ~bridge_rep () {}
+  inline virtual ~bridge_rep () {}
 
   virtual void notify_assign (path p, tree u)= 0;
   virtual void notify_insert (path p, tree u);

--- a/src/Typeset/boxes.hpp
+++ b/src/Typeset/boxes.hpp
@@ -132,7 +132,7 @@ public:
   /****************************** main routines ******************************/
 
   inline box_rep (path ip);
-  virtual ~box_rep ();
+  inline virtual ~box_rep ();
   void        relocate (path p, bool force= false);
   virtual box transform (frame fr);
   virtual operator tree ()= 0;


### PR DESCRIPTION
…d the ins and outs of inlining

## What
+ Revert the removal of inline for `inline virtual xxx()`.
+ Revert the removal of virtual for `inline virtual yyy()`.

## Why
The removal of `virtual` in `inline virtual derived_this ()` leads to a segment fault.

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [ ] Windows

Without this pull request:

1. Open `Help->Plugins->Binary`
2. Use the Replace widget to replace `python3` with `gs`
3. Close the replace widget
4. Open `Help->Plugins->Maxima` and then there will be a segmentation fault at `src/Edit/Interface/edit_repaint.cpp:430`

With this pull request, it will be fixed.
