### PR TITLE
[75_12] Fix rendering of linked image on Windows using absolute path

### DIFF
--- a/src/Typeset/Concat/concat_active.cpp
+++ b/src/Typeset/Concat/concat_active.cpp
@@ -428,7 +428,7 @@ concater_rep::typeset_image (tree t, path ip) {
   if (is_atomic (image_tree)) {
     if (N (image_tree->label) == 0)
       error_image (tree (WITH, "color", "red", "no image"));
-    url im= cork_to_utf8 (image_tree->label);
+    url im= url_system (cork_to_utf8 (image_tree->label));
     if (is_rooted (im)) {
       image= im;
     }


### PR DESCRIPTION
## What and Why
It was a fix on branch `lts-125`.

For `branch-1.2`, since we have upgraded to lolly 1.4.x, the implicit conversion from string to url is using url_system now. This pull request is for using url_system explicitly but not a fix now. Let us keep the pull request title in `branch-1.2`.

## How to test your changes?
+ [x] Linux
+ [x] Windows
+ [ ] macOS

Insert a linked image with absolute path to see if it is rendered correctly.
