### PR TITLE
[38_7] svg: remove imagemagick as the converter to ps/pdf

### DIFF
--- a/TeXmacs/plugins/image/progs/image/svg.scm
+++ b/TeXmacs/plugins/image/progs/image/svg.scm
@@ -27,10 +27,6 @@
 
 ;; svg -> pdf (the latter one which meets the requirements will work)
 (converter svg-file pdf-file
-  (:require (has-binary-convert?))
-  (:shell ,(url->system (find-binary-convert)) from to))
-
-(converter svg-file pdf-file
   (:require (has-binary-rsvg-convert?))
   (:shell ,(url->system (find-binary-rsvg-convert)) "-f pdf" "-o" to from ))
 
@@ -39,10 +35,6 @@
   (:shell ,(url->system (find-binary-inkscape)) from "-o" to))
 
 ;; svg -> postscript (the latter one which meets the requirements will work)
-(converter svg-file postscript-file
-  (:require (has-binary-convert?))
-  (:shell ,(url->system (find-binary-convert)) from to))
-
 (converter svg-file postscript-file
   (:require (has-binary-rsvg-convert?))
   (:shell ,(url->system (find-binary-rsvg-convert)) "-f eps" "-o" to from ))


### PR DESCRIPTION
## What
as title

## Why
It does not work on Debian 12
```
> convert TeXmacs/misc/pixmaps/modern/24x24/main/tm_cloud.svg /tmp/test.pdf                                                                                                       
convert: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/426.
Exception: convert exited with 1
```

## How to test your changes?
No need to test.
