### PR TITLE
[56_5] Cache styles by content digest

### DIFF
--- a/src/Data/Document/new_style.cpp
+++ b/src/Data/Document/new_style.cpp
@@ -62,13 +62,22 @@ hashmap<string, bool>        hidden_packages (false);
 static url
 resolve_local_style (string style_name) {
   string pack= style_name * ".ts";
-  return resolve (url ("$TEXMACS_STYLE_PATH") * pack);
+  url    ret = resolve (url ("$TEXMACS_STYLE_PATH") * pack);
+  if (DEBUG_IO) {
+    debug_io << "Resolved local style: " << style_name << " -> " << ret << LF;
+  }
+  return ret;
 }
 
 static url
 resolve_relative_style (string style_name, url master) {
   string pack= style_name * ".ts";
-  return resolve (expand (head (master) * url_ancestor () * pack));
+  url    ret = resolve (expand (head (master) * url_ancestor () * pack));
+  if (DEBUG_IO) {
+    debug_io << "Resolved relative style: (" << style_name << ", " << master
+             << ")" << LF << "-> " << ret << LF;
+  }
+  return ret;
 }
 
 url

--- a/src/Data/Document/new_style.cpp
+++ b/src/Data/Document/new_style.cpp
@@ -98,17 +98,17 @@ resolve_style (string style_name, url master) {
  ******************************************************************************/
 
 tree
-preprocess_style (tree st, url name) {
-  if (is_rooted_tmfs (name)) return st;
-  if (is_atomic (st)) st= tree (TUPLE, st);
-  if (!is_tuple (st)) return st;
+preprocess_style (tree styles, url name) {
+  if (is_rooted_tmfs (name)) return styles;
+  if (is_atomic (styles)) styles= tree (TUPLE, styles);
+  if (!is_tuple (styles)) return styles;
 
-  int  n= N (st);
+  int  n= N (styles);
   tree r (TUPLE, n);
   for (int i= 0; i < n; i++) {
-    r[i]= st[i];
-    if (!is_atomic (st[i])) continue;
-    string style_name    = st[i]->label;
+    r[i]= styles[i];
+    if (!is_atomic (styles[i])) continue;
+    string style_name    = styles[i]->label;
     url    resolved_style= resolve_style (style_name, name);
     if (!is_none (resolved_style)) {
       r[i]= as_string (resolved_style);

--- a/src/Data/Document/new_style.cpp
+++ b/src/Data/Document/new_style.cpp
@@ -20,6 +20,7 @@
 #include "tmfs_url.hpp"
 #include "web_files.hpp"
 
+#include <lolly/hash/md5.hpp>
 #include <lolly/hash/sha.hpp>
 
 using namespace moebius;
@@ -58,6 +59,40 @@ init_style_data () {
 extern hashmap<string, tree> style_tree_cache;
 hashmap<string, bool>        hidden_packages (false);
 
+static url
+resolve_local_style (string style_name) {
+  string pack= style_name * ".ts";
+  return resolve (url ("$TEXMACS_STYLE_PATH") * pack);
+}
+
+static url
+resolve_relative_style (string style_name, url master) {
+  string pack= style_name * ".ts";
+  return resolve (expand (head (master) * url_ancestor () * pack));
+}
+
+url
+resolve_style (string style_name, url master) {
+  bool remote= is_rooted_web (master);
+
+  // TODO: the relative style resolving should only resolve styles in the same
+  // Git repo
+  if (remote) {
+    url relative_style= resolve_relative_style (style_name, master);
+    if (!is_none (relative_style)) {
+      return relative_style;
+    }
+    return resolve_local_style (style_name);
+  }
+  else {
+    url local_style= resolve_local_style (style_name);
+    if (!is_none (local_style)) {
+      return local_style;
+    }
+    return resolve_relative_style (style_name, master);
+  }
+}
+
 /******************************************************************************
  * Modify style so as to search in all ancestor directories
  ******************************************************************************/
@@ -67,19 +102,19 @@ preprocess_style (tree st, url name) {
   if (is_rooted_tmfs (name)) return st;
   if (is_atomic (st)) st= tree (TUPLE, st);
   if (!is_tuple (st)) return st;
-  // if (is_rooted_web (name)) return st;
-  bool remote= is_rooted_web (name);
-  tree r (TUPLE, N (st));
-  for (int i= 0; i < N (st); i++) {
+
+  int  n= N (st);
+  tree r (TUPLE, n);
+  for (int i= 0; i < n; i++) {
     r[i]= st[i];
     if (!is_atomic (st[i])) continue;
-    string pack= st[i]->label * ".ts";
-    if (!remote || is_none (resolve (url ("$TEXMACS_STYLE_PATH") * pack))) {
-      url stf= resolve (expand (head (name) * url_ancestor () * pack));
-      if (!is_none (stf)) r[i]= as_string (stf);
+    string style_name    = st[i]->label;
+    url    resolved_style= resolve_style (style_name, name);
+    if (!is_none (resolved_style)) {
+      r[i]= as_string (resolved_style);
     }
   }
-  // if (r != st) cout << "old: " << st << "\nnew: " << r << "\n";
+
   return r;
 }
 
@@ -123,7 +158,9 @@ cache_file_name_sub (tree t) {
 
 static string
 cache_file_name (tree t) {
-  return cache_file_name_sub (t) * ".scm";
+  url tmp= url_temp ("txt");
+  save_string (tmp, cache_file_name_sub (t));
+  return lolly::hash::md5_hexdigest (tmp) * ".scm";
 }
 
 void

--- a/src/Data/Document/new_style.hpp
+++ b/src/Data/Document/new_style.hpp
@@ -19,7 +19,7 @@
 
 using moebius::drd::drd_info;
 
-tree preprocess_style (tree st, url name);
+tree preprocess_style (tree styles, url name);
 url  resolve_style (string style_name, url master);
 
 void style_invalidate_cache ();

--- a/src/Data/Document/new_style.hpp
+++ b/src/Data/Document/new_style.hpp
@@ -20,6 +20,7 @@
 using moebius::drd::drd_info;
 
 tree preprocess_style (tree st, url name);
+url  resolve_style (string style_name, url master);
 
 void style_invalidate_cache ();
 void style_set_cache (tree style, hashmap<string, tree> H, tree t);

--- a/src/Edit/Editor/edit_typeset.cpp
+++ b/src/Edit/Editor/edit_typeset.cpp
@@ -312,8 +312,8 @@ use_modules (tree t) {
 }
 
 void
-edit_typeset_rep::typeset_style_use_cache (tree style) {
-  style= preprocess_style (style, buf->buf->master);
+edit_typeset_rep::typeset_style_use_cache (tree style_orig) {
+  tree style= preprocess_style (style_orig, buf->buf->master);
   // cout << "Typesetting style using cache " << style << LF;
   bool                  ok;
   hashmap<string, tree> H;

--- a/src/Edit/Editor/edit_typeset.cpp
+++ b/src/Edit/Editor/edit_typeset.cpp
@@ -312,13 +312,13 @@ use_modules (tree t) {
 }
 
 void
-edit_typeset_rep::typeset_style_use_cache (tree style_orig) {
-  tree style= preprocess_style (style_orig, buf->buf->master);
+edit_typeset_rep::typeset_style_use_cache (tree styles_orig) {
+  tree styles= preprocess_style (styles_orig, buf->buf->master);
   // cout << "Typesetting style using cache " << style << LF;
   bool                  ok;
   hashmap<string, tree> H;
   tree                  t;
-  style_get_cache (style, H, t, ok);
+  style_get_cache (styles, H, t, ok);
   if (ok) {
     env->patch_env (H);
     ok= drd->set_locals (t);
@@ -326,10 +326,10 @@ edit_typeset_rep::typeset_style_use_cache (tree style_orig) {
   }
   if (!ok) {
     // cout << "Typeset without cache " << style << LF;
-    if (!is_tuple (style)) TM_FAILED ("tuple expected as style");
-    H  = get_style_env (style);
-    drd= get_style_drd (style);
-    style_set_cache (style, H, drd->get_locals ());
+    if (!is_tuple (styles)) TM_FAILED ("tuple expected as style");
+    H  = get_style_env (styles);
+    drd= get_style_drd (styles);
+    style_set_cache (styles, H, drd->get_locals ());
     env->patch_env (H);
     drd->set_environment (H);
   }

--- a/src/System/Files/tm_file.cpp
+++ b/src/System/Files/tm_file.cpp
@@ -187,8 +187,8 @@ search_sub_dirs (url& all, url root) {
     }
   }
   else if (is_or (root)) {
-    search_sub_dirs (all, root[1]);
     search_sub_dirs (all, root[2]);
+    search_sub_dirs (all, root[1]);
   }
 }
 

--- a/src/System/Files/tm_file.cpp
+++ b/src/System/Files/tm_file.cpp
@@ -178,7 +178,8 @@ search_sub_dirs (url& all, url root) {
     bool          err= false;
     array<string> a  = read_directory (root, err);
     if (!err) {
-      for (int i= 0; i < N (a); i++) {
+      int N_a= N (a);
+      for (int i= 0; i < N_a; i++) {
         url subdir= root * a[i];
         if (is_directory (subdir)) {
           search_sub_dirs (all, subdir);

--- a/src/System/Files/tm_file.hpp
+++ b/src/System/Files/tm_file.hpp
@@ -56,6 +56,8 @@ string file_format (url u);
  *
  * Here is the order of the result of search `a | b`
  * a/a1/a2 | a/a1 | a | b/ba1/ba2 | b/ba1 | b/bb1/bb2 | b/bb1 | b
+ * a/a1/a2 | a/a1 | a | b/bb1/bb2 | b/bb1 | b/ba1/ba2 | b/ba1 | b
+ * There is no order in the same directory level
  */
 url search_sub_dirs (url root);
 

--- a/src/System/Files/tm_file.hpp
+++ b/src/System/Files/tm_file.hpp
@@ -51,7 +51,14 @@ url    url_scratch (string prefix= "no_name_", string postfix= ".tm", int i= 1);
 bool   is_scratch (url u);
 string file_format (url u);
 
-url           search_sub_dirs (url root);
+/**
+ * List the sub dir of root resursively including the given directory
+ *
+ * Here is the order of the result of search `a | b`
+ * a/a1/a2 | a/a1 | a | b/ba1/ba2 | b/ba1 | b/bb1/bb2 | b/bb1 | b
+ */
+url search_sub_dirs (url root);
+
 array<string> file_completions (url search, url dir);
 
 url grep (string what, url u);

--- a/tests/System/Files/tm_file_test.cpp
+++ b/tests/System/Files/tm_file_test.cpp
@@ -36,8 +36,8 @@ TestTMFile::test_search_sub_dirs () {
 
   QVERIFY (is_or (ret));
   // Make sure the order of the search result
-  // the order depends on the order of read_directory, it is the natual order now:
-  // doc/about -> doc/main
+  // the order depends on the order of read_directory, it is the natual order
+  // now: doc/about -> doc/main
   QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc/about")));
 }
 

--- a/tests/System/Files/tm_file_test.cpp
+++ b/tests/System/Files/tm_file_test.cpp
@@ -36,7 +36,7 @@ TestTMFile::test_search_sub_dirs () {
 
   QVERIFY (is_or (ret));
   // Make sure the order of the search result
-  QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc")));
+  QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc/about")));
 }
 
 QTEST_MAIN (TestTMFile)

--- a/tests/System/Files/tm_file_test.cpp
+++ b/tests/System/Files/tm_file_test.cpp
@@ -32,7 +32,11 @@ TestTMFile::test_load_ramdisc () {
 void
 TestTMFile::test_search_sub_dirs () {
   url u= url_system ("$TEXMACS_PATH/doc") | url_system ("$TEXMACS_PATH/langs");
-  QVERIFY (is_or (search_sub_dirs (u)));
+  url ret= search_sub_dirs (u);
+
+  QVERIFY (is_or (ret));
+  // Make sure the order of the search result
+  QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc")));
 }
 
 QTEST_MAIN (TestTMFile)

--- a/tests/System/Files/tm_file_test.cpp
+++ b/tests/System/Files/tm_file_test.cpp
@@ -36,9 +36,9 @@ TestTMFile::test_search_sub_dirs () {
 
   QVERIFY (is_or (ret));
   // Make sure the order of the search result
-  // the order depends on the order of read_directory, it is the natual order
-  // now: doc/about -> doc/main
-  QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc/about")));
+  // the order depends on the order of read_directory, it is not sorted for
+  // better performance
+  QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc")));
 }
 
 QTEST_MAIN (TestTMFile)

--- a/tests/System/Files/tm_file_test.cpp
+++ b/tests/System/Files/tm_file_test.cpp
@@ -36,6 +36,8 @@ TestTMFile::test_search_sub_dirs () {
 
   QVERIFY (is_or (ret));
   // Make sure the order of the search result
+  // the order depends on the order of read_directory, it is the natual order now:
+  // doc/about -> doc/main
   QVERIFY (descends (ret[1], url_system ("$TEXMACS_PATH/doc/about")));
 }
 


### PR DESCRIPTION
## What
+ Fix the search result orders for `search_sub_dirs`
  + Side effect: user installed fonts will override the system fonts (it is a fix on the wrong behavior)
+ Cache all styles by content digests
+ Check `Debug->io` for the debug info of style resolving

Here is the expected order to load a style or package:
+ `$TEXMACS_HOME_PATH/styles`
+ `$TEXMACS_PATH/styles`
+ `$TEXMACS_HOME_PATH/plugins/xxx/styles/`
+ `$TEXMACS_PATH/plugins/xxx/styles`
+ `$TEXMACS_HOME_PATH/packages`
+ `$TEXMACS_PATH/packages`
+ `$TEXMACS_HOME_PATH/plugins/xxx/packages/`
+ `$TEXMACS_PATH/plugins/xxx/packages/`

## Why
Content digests should be adopted for modification on user defined styles/packages.

## How to test your changes?
Try customizing https://github.com/XmacsLabs/physics
