### PR TITLE
[27_2] Graphics: fix copy/cut on selection via mouse

### DIFF
--- a/TeXmacs/tests/tm/27_2_graphics.tm
+++ b/TeXmacs/tests/tm/27_2_graphics.tm
@@ -25,12 +25,6 @@
     <item>Succeed to copy the above graphics area with an extra space in the
     same paragraph
   </enumerate>
-
-  \;
-
-  \;
-
-  \;
 </body>
 
 <\initial>

--- a/TeXmacs/tests/tm/27_2_graphics.tm
+++ b/TeXmacs/tests/tm/27_2_graphics.tm
@@ -1,0 +1,41 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|chinese>>
+
+<\body>
+  Hello
+
+  <with|gr-mode|<tuple|edit|circle>|gr-frame|<tuple|scale|1cm|<tuple|0.5gw|0.550026gh>>|gr-geometry|<tuple|geometry|1par|0.6par>|gr-grid|<tuple|cartesian|<point|0|0>|2>|gr-edit-grid-aspect|<tuple|<tuple|axes|none>|<tuple|1|none>|<tuple|10|none>>|gr-edit-grid|<tuple|cartesian|<point|0|0>|1>|<graphics||<circle|<point|0|0>|<point|-2.0|0.0>>>>
+
+  <fill-dots>
+
+  Use mouse instead of keyboard to select the expected part:
+
+  <\enumerate>
+    <item>Failed to copy the above graphics area and then paste
+
+    <item>Failed to cut the above graphics area and then paste
+
+    <item>Failed to copy the above graphics area with the Hello line and then
+    paste
+
+    <item>Failed to copy the above graphics area with the dot line and then
+    paste
+
+    <item>Succeed to copy the above graphics area with an extra space in the
+    same paragraph
+  </enumerate>
+
+  \;
+
+  \;
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|beamer>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Edit/Replace/edit_select.cpp
+++ b/src/Edit/Replace/edit_select.cpp
@@ -628,11 +628,6 @@ edit_select_rep::selection_set (tree t) {
 void
 edit_select_rep::selection_copy (string key) {
   bool emacs= (get_preference ("look and feel", "default") == "emacs");
-  if (inside_active_graphics ()) {
-    tree t= as_tree (eval ("(graphics-copy)"));
-    selection_set (key, t, !emacs);
-    return;
-  }
   if (selection_active_any ()) {
     path      old_tp= tp;
     selection sel;
@@ -642,6 +637,12 @@ edit_select_rep::selection_copy (string key) {
     go_to (sel->start);
     selection_set (key, t, !emacs);
     go_to (old_tp);
+    return;
+  }
+  if (inside_active_graphics ()) {
+    tree t= as_tree (eval ("(graphics-copy)"));
+    selection_set (key, t, !emacs);
+    return;
   }
 }
 

--- a/src/Edit/Replace/edit_select.cpp
+++ b/src/Edit/Replace/edit_select.cpp
@@ -876,13 +876,7 @@ edit_select_rep::raw_cut (path p1, path p2) {
 
 void
 edit_select_rep::selection_cut (string key) {
-  if (inside_active_graphics ()) {
-    if (key != "none") {
-      tree t= as_tree (eval ("(graphics-cut)"));
-      selection_set (key, t);
-    }
-  }
-  else if (selection_active_any ()) {
+  if (selection_active_any ()) {
     path p1, p2;
     if (selection_active_table ()) {
       p1= start (cur_sel);
@@ -902,6 +896,12 @@ edit_select_rep::selection_cut (string key) {
       }
     }
     cut (p1, p2);
+  }
+  else if (inside_active_graphics ()) {
+    if (key != "none") {
+      tree t= as_tree (eval ("(graphics-cut)"));
+      selection_set (key, t);
+    }
   }
 }
 


### PR DESCRIPTION
## What
When using mouse to select the graphics area, it will enter the graphics mode.
+ `selection_active_any ()` is true
+ `inside_active_graphics ()` is true

After entering the graphics mode, and we select the graphics objects:
+ `selection_active_any ()` is false
+ `inside_active_graphics ()` is true

For most cases with selections:
+ `select_active_any ()` is true
+ `inside_active_graphics ()` is false

## How to test your changes?
see `27_2_graphics.tm`
