### PR TITLE
[71_38] Add View->Focus mode, remove View->Header bars

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -672,6 +672,7 @@
 ("floating object" "浮动对象")
 ("floating table" "浮动表格")
 ("focus dependent icons" "焦点工具栏")
+("focus mode" "专注模式")
 ("focus" "焦点")
 ("fold all fields" "折叠全部区域")
 ("fold comments" "折叠所有批注")

--- a/TeXmacs/progs/kernel/texmacs/tm-modes.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-modes.scm
@@ -263,6 +263,7 @@
   (spell-mode% (== (get-input-mode) 3))
   (complete-mode% (== (get-input-mode) 4))
   (remote-control-mode% (== remote-control-flag? #t))
+  (focus-mode% (not (visible-header?)))
   (in-cyrillic-jcuken% (cyrillic-input-method? "jcuken") in-cyrillic%)
   (in-cyrillic-translit% (cyrillic-input-method? "translit") in-cyrillic%)
   (in-cyrillic-yawerty% (cyrillic-input-method? "yawerty") in-cyrillic%)

--- a/TeXmacs/progs/texmacs/menus/main-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/main-menu.scm
@@ -100,6 +100,15 @@
   ---
   (former))
 
+(menu-bind focus-popup-menu
+  ("Focus mode" (toggle-focus-mode)))
+
+(tm-menu (texmacs-popup-menu)
+  (:require (focus-mode?))
+  (link focus-popup-menu)
+  ---
+  (former))
+
 (tm-menu (texmacs-popup-menu)
   (=> "Copy to" (link clipboard-copy-export-menu))
   (=> "Paste from" (link clipboard-paste-import-menu))

--- a/TeXmacs/progs/texmacs/menus/view-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/view-menu.scm
@@ -107,6 +107,7 @@
       ("Close window" (close-document*))
       ---)
   ("Full screen mode"  (toggle-full-screen-edit-mode))
+  ("Focus mode" (toggle-focus-mode))
   ("Presentation mode" (toggle-full-screen-mode))
   ("Show panorama" (toggle-panorama-mode))
   ("Remote control" (toggle-remote-control-mode))
@@ -131,7 +132,6 @@
 
   ("Snap to pages" (toggle-snap-to-pages))
   ---
-  ("Header bars" (toggle-visible-header))
   (when (visible-header?)
         ("Main icon bar" (toggle-visible-icon-bar 0))
         ("Mode dependent icons" (toggle-visible-icon-bar 1))

--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -117,6 +117,11 @@
                (get-boolean-preference "use unified toolbar"))
       (notify-now "Restart TeXmacs to avoid potential visual artefacts"))))
 
+(tm-define (toggle-focus-mode)
+  (:synopsis "Toggle focus mode.")
+  (:check-mark "v" focus-mode?)
+  (toggle-visible-header))
+
 (define saved-informative-flags "default")
 
 (tm-define (toggle-full-screen-mode)


### PR DESCRIPTION
## What
as title

## Why
Quitting `View->Header bars` is too hard. One need to know the `Ctrl+Left click` trick.

Using `View->Focus mode`, just quit the focus mode via the context menu triggered by right click.

## How to test your changes?
Click `View->Focus mode`, and right click and then uncheck `Focus mode` to quit it.
