### PR TITLE
[64_7] Fix the encoding of the name for the inserted images

### DIFF
--- a/src/Edit/Modify/edit_text.cpp
+++ b/src/Edit/Modify/edit_text.cpp
@@ -387,7 +387,7 @@ edit_text_rep::make_image (string file_name, bool link, string w, string h,
       set_message (concat ("File '", vim, "' is not an image"), "make image");
       return;
     }
-    t << tuple (tree (RAW_DATA, s), as_string (tail (image)));
+    t << tuple (tree (RAW_DATA, s), utf8_to_cork (as_string (tail (image))));
   }
   t << tree (w) << tree (h) << tree (x) << tree (y);
   insert_tree (t);


### PR DESCRIPTION
## What
as title

## How to test your changes?
+ [x] Linux
+ [ ] Windows
+ [ ] macOS

`Insert->Image->Insert image...` of a image with Chinese file name, for example: `微信图片_xxxx.jpg`

The file name of the inserted image should be `微信图片_xxxx.jpg`.