### PR TITLE
[71_39] UI: Remove the duplicated separator in the submenu of Format->Color

### DIFF
--- a/TeXmacs/progs/generic/format-menu.scm
+++ b/TeXmacs/progs/generic/format-menu.scm
@@ -76,7 +76,6 @@
         (pick-background "" (setter answer)))
     (if (not (allow-pattern-colors?))
         (pick-color (setter answer)))
-    ---
     ("Palette" (interactive-color setter '()))
     (if (allow-pattern-colors?)
         ("Pattern" (open-pattern-selector setter "1cm")))


### PR DESCRIPTION
## What
Remove the duplicated separator in the submenu of `Format -> Color`

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [ ] Windows

Check the submenu of `Format->Color`.