### PR TITLE
[78_2] Add the missing virtual for widget_rep:derived_this

### DIFF
--- a/src/Graphics/Gui/widget.hpp
+++ b/src/Graphics/Gui/widget.hpp
@@ -38,8 +38,8 @@ protected:
 public:
   widget_rep ();
   virtual ~widget_rep ();
-  inline void*        derived_this () { return (widget_rep*) this; }
-  virtual tm_ostream& print (tm_ostream& out);
+  inline virtual void* derived_this () { return (widget_rep*) this; }
+  virtual tm_ostream&  print (tm_ostream& out);
 
   virtual void send (slot s, blackbox val);
   // send a message val to the slot s


### PR DESCRIPTION
## What
as title

## Why
The removal of `virtual` in `inline virtual derived_this ()` leads to a segment fault.

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [x] Windows

Without this pull request:

1. Open `Help->Plugins->Binary`
2. Use the Replace widget to replace `python3` with `gs`
3. Close the replace widget
4. Open `Help->Plugins->Maxima` and then there will be a segmentation fault at `src/Edit/Interface/edit_repaint.cpp:430`

With this pull request, it will be fixed.