### PR TITLE
[20_10] Fix Edit->Copy to->Image by setting texmacs->image:format to png

### DIFF
--- a/TeXmacs/progs/convert/images/tmimage.scm
+++ b/TeXmacs/progs/convert/images/tmimage.scm
@@ -20,17 +20,6 @@
   (:use (convert tmml tmmlout)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Handling of image convertion preferences
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define (default-image-export-format)
-  (if (nnot (converter-search "pdf-file" "svg-file")) "svg" "pdf"))
-
-(define-preferences
-  ("texmacs->image:format" (default-image-export-format) noop))
-  ;("texmacs->image:scale" "2.0" noop)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; private functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/TeXmacs/progs/texmacs/texmacs/tm-server.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-server.scm
@@ -131,7 +131,8 @@
   ("gui:line-input:autocommit" "on" noop)
   ("use native menubar" (get-default-native-menubar) noop)
   ("use unified toolbar" (get-default-unified-toolbar) noop)
-  ("tm format without utf8" "on" noop))
+  ("tm format without utf8" "on" noop)
+  ("texmacs->image:format" "png" noop))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Properties of some built-in routines


### PR DESCRIPTION
## What
`Edit->Copy to->Image` does not work because `(get-preference "texmacs->image:format")` is `"default"`

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [x] Windows

Select something in the buffer, and click `Edit->Copy to->Image` and then paste it somewhere else.
