### PR TITLE
[79_1] Properly caching to speed up search-options and search-parameters

### DIFF
--- a/TeXmacs/progs/source/macro-search.scm
+++ b/TeXmacs/progs/source/macro-search.scm
@@ -177,8 +177,7 @@
       (if std
           (begin
             ;;(display* "Std= " std "\n")
-            (for (x std)
-              (ahash-set! v x #t)))
+            (for (x std) (ahash-set! v x #t)))
           (with def (get-init-tree l)
             ;;(display* "  Def= " def "\n")
             (cond ((tree-is? def 'uninit) (noop))

--- a/TeXmacs/progs/source/macro-search.scm
+++ b/TeXmacs/progs/source/macro-search.scm
@@ -57,7 +57,7 @@
 
 (define (collect-options l t)
   (when (not (ahash-ref t l))
-    ;;(display* "Collect " l "\n")
+    ;;(display* "collect-options " l "\n")
     (ahash-set! t l '())
     (ahash-set! t l
       (with std (standard-options (string->symbol l))
@@ -170,7 +170,7 @@
 
 (define (collect-parameters l v t)
   (when (not (ahash-ref t l))
-    ;;(display* "Collect " l "\n")
+    (display* "collect-parameters " l "\n")
     (ahash-set! t l #t)
     (with std (standard-parameters l)
       (if std

--- a/TeXmacs/progs/source/macro-search.scm
+++ b/TeXmacs/progs/source/macro-search.scm
@@ -171,7 +171,7 @@
 
 (define (collect-parameters l v t)
   (when (not (ahash-ref t l))
-    (display* "collect-parameters " l "\n")
+    ;;(display* "collect-parameters " l "\n")
     (ahash-set! t l #t)
     (with std (standard-parameters l)
       (if std

--- a/TeXmacs/progs/source/macro-search.scm
+++ b/TeXmacs/progs/source/macro-search.scm
@@ -18,6 +18,8 @@
 ;; Routines for subsequent customization
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define tag-options-table (make-ahash-table))
+
 (tm-define (standard-options l) #f)
 
 (tm-define (standard-parameters l) #f)
@@ -67,10 +69,9 @@
   (ahash-ref t l))
 
 (tm-define (search-options l)
-  (if (symbol? l) (set! l (symbol->string l)))
-  (with t (make-ahash-table)
-    (collect-options l t)
-    (ahash-ref t l)))
+  (with label (if (symbol? l) (symbol->string l) l)
+    (collect-options label tag-options-table)
+    (ahash-ref tag-options-table label)))
 
 (tm-define (search-tag-options t)
   (search-options (tree-label t)))

--- a/TeXmacs/progs/source/macro-search.scm
+++ b/TeXmacs/progs/source/macro-search.scm
@@ -19,6 +19,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define tag-options-table (make-ahash-table))
+(define tag-parameters-table (make-ahash-table))
 
 (tm-define (standard-options l) #f)
 
@@ -178,18 +179,17 @@
             ;;(display* "Std= " std "\n")
             (for (x std)
               (ahash-set! v x #t)))
-	  (with def (get-init-tree l)
+          (with def (get-init-tree l)
             ;;(display* "  Def= " def "\n")
-	    (cond ((tree-is? def 'uninit) (noop))
-		  ((tree-in? def '(macro xmacro))
-		   (collect-parameters-sub def v t))
-		  (else (ahash-set! v l #t))))))))
+            (cond ((tree-is? def 'uninit) (noop))
+                  ((tree-in? def '(macro xmacro))
+                   (collect-parameters-sub def v t))
+                  (else (ahash-set! v l #t))))))))
 
 (tm-define (search-parameters l)
-  (if (symbol? l) (set! l (symbol->string l)))
-  (let* ((v (make-ahash-table))
-	 (t (make-ahash-table)))
-    (collect-parameters l v t)
+  (let* ((label (if (symbol? l) (symbol->string l) l))
+         (v (make-ahash-table)))
+    (collect-parameters label v tag-parameters-table)
     (sort (ahash-set->list v) string<=?)))
 
 (tm-define (search-tag-parameters t)


### PR DESCRIPTION
## What
as title

## Why
to speed up `search-options` and `search-parameters`

## How to test your changes?
Bench `object xmenu= call ("menu-expand", eval ("'" * menu));` in `tm_window_rep::get_menu_widget`

We can find that in beamer style, in the inserted beamer `tit`, menu-expand time of the focus toolbar could be reduced from 96ms to 55ms after the speed up of `search-options`, and it is reduced from 55ms to 25ms after the speed up of `search-parameters`.
