### PR TITLE
[7_13] Fix 100% CPU when delay is 0 and delayed_commands.wait is false

### DIFF
--- a/src/Plugins/Qt/qt_gui.cpp
+++ b/src/Plugins/Qt/qt_gui.cpp
@@ -857,7 +857,10 @@ qt_gui_rep::update () {
   if (interrupted) needing_update= true;
   if (!headless_mode && nr_windows == 0) qApp->quit ();
 
-  time_t delay= delayed_commands.lapse - texmacs_time ();
+  time_t delay= std_delay;
+  if (delayed_commands.wait) {
+    delay= delayed_commands.lapse - texmacs_time ();
+  }
   if (needing_update) delay= 0;
   else delay= max (0, min (std_delay, static_cast<int> (delay)));
   if (postpone_treatment) delay= 9; // NOTE: force occasional display


### PR DESCRIPTION
## What
as title

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [ ] Windows

Steps:
1. Disable autosave
2. Restart Mogan Research
3. Open Help->Welcome, and edit randomly and wait for 100% CPU

Related bug: https://savannah.gnu.org/bugs/?62156

