### PR TITLE
[14_7] Added wencoding test, suspected problems with wencoding

### DIFF
--- a/tests/L3/Data/String/wencoding_test.cpp
+++ b/tests/L3/Data/String/wencoding_test.cpp
@@ -1,0 +1,66 @@
+#include <QtTest/QtTest>
+#include "wencoding.hpp"
+#include "string.hpp"
+#include <string>
+
+class TestWencoding : public QObject {
+    Q_OBJECT
+
+private slots:
+    void test_looks_ascii();
+    void test_looks_utf8();
+    void test_guess_wencoding();
+    void test_western_to_utf8();
+    void test_western_to_cork();
+};
+
+// Helper function to convert `string` to `std::string`
+std::string toString(const string& s) {
+    std::string result;
+    // Temporarily create a non-const string for iteration purpose
+    string non_const_string = s; 
+    for (int i = 0; i < N(non_const_string); ++i) {
+        result.push_back(non_const_string[i]);
+    }
+    return result;
+}
+
+void TestWencoding::test_looks_ascii() {
+    string ascii_str = "Hello, World!";
+    string non_ascii_str = "こんにちは、世界！";
+    QVERIFY(looks_ascii(ascii_str));
+    QVERIFY(!looks_ascii(non_ascii_str));
+}
+
+void TestWencoding::test_looks_utf8() {
+    string utf8_str = u8"Hello, 世界!";
+    string non_utf8_str = "\xFF\xFE";
+    QVERIFY(looks_utf8(utf8_str));
+    QVERIFY(!looks_utf8(non_utf8_str));
+}
+
+void TestWencoding::test_guess_wencoding() {
+    string ascii_str = "Hello, World!";
+    string utf8_str = u8"こんにちは、世界！";
+    string iso_8859_str = "\xC3\xA9";
+    QCOMPARE(toString(guess_wencoding(ascii_str)), std::string("ASCII"));
+    QCOMPARE(toString(guess_wencoding(utf8_str)), std::string("UTF-8"));
+    QCOMPARE(toString(guess_wencoding(iso_8859_str)), std::string("ISO-8859")); 
+    // 似乎在处理 ISO-8859 编码的字符串时返回了 "UTF-8"。可能该函数在判断编码时误判了 
+    // It seems to return "UTF-8" when processing ISO-8859 encoded strings. Perhaps the function misjudged the encoding when determining the encoding.
+}
+
+void TestWencoding::test_western_to_utf8() {
+    string iso_8859_str = "\xE9"; // é in ISO-8859
+    string utf8_result = western_to_utf8(iso_8859_str);
+    QCOMPARE(toString(utf8_result), std::string(u8"é"));
+}
+
+void TestWencoding::test_western_to_cork() {
+    string utf8_str = u8"Hello, 世界!";
+    string cork_result = western_to_cork(utf8_str);
+    QCOMPARE(toString(cork_result), toString(utf8_str));  // Assuming your conversion to Cork maintains the content
+}
+
+QTEST_MAIN(TestWencoding)
+#include "wencoding_test.moc"

--- a/tests/L3/Data/String/wencoding_test.cpp
+++ b/tests/L3/Data/String/wencoding_test.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * MODULE     : wencoding_test.cpp
  * DESCRIPTION: Tests on wencoding
- * COPYRIGHT  : (C) 2019-2023  ATQlove
+ * COPYRIGHT  : (C) 2019-2024  ATQlove
  *******************************************************************************
  * This software falls under the GNU general public license version 3 or later.
  * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE

--- a/tests/L3/Data/String/wencoding_test.cpp
+++ b/tests/L3/Data/String/wencoding_test.cpp
@@ -1,66 +1,86 @@
-#include <QtTest/QtTest>
-#include "wencoding.hpp"
+/*****************************************************************************
+ * MODULE     : wencoding_test.cpp
+ * DESCRIPTION: Tests on wencoding
+ * COPYRIGHT  : (C) 2019-2023  ATQlove
+ *******************************************************************************
+ * This software falls under the GNU general public license version 3 or later.
+ * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+ * in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+ ******************************************************************************/
+
 #include "string.hpp"
+#include "wencoding.hpp"
+#include <QtTest/QtTest>
 #include <string>
 
 class TestWencoding : public QObject {
-    Q_OBJECT
+  Q_OBJECT
 
 private slots:
-    void test_looks_ascii();
-    void test_looks_utf8();
-    void test_guess_wencoding();
-    void test_western_to_utf8();
-    void test_western_to_cork();
+  void test_looks_ascii ();
+  void test_looks_utf8 ();
+  void test_guess_wencoding ();
+  void test_western_to_utf8 ();
+  void test_western_to_cork ();
 };
 
 // Helper function to convert `string` to `std::string`
-std::string toString(const string& s) {
-    std::string result;
-    // Temporarily create a non-const string for iteration purpose
-    string non_const_string = s; 
-    for (int i = 0; i < N(non_const_string); ++i) {
-        result.push_back(non_const_string[i]);
-    }
-    return result;
+std::string
+toString (const string& s) {
+  std::string result;
+  // Temporarily create a non-const string for iteration purpose
+  string non_const_string= s;
+  for (int i= 0; i < N (non_const_string); ++i) {
+    result.push_back (non_const_string[i]);
+  }
+  return result;
 }
 
-void TestWencoding::test_looks_ascii() {
-    string ascii_str = "Hello, World!";
-    string non_ascii_str = "こんにちは、世界！";
-    QVERIFY(looks_ascii(ascii_str));
-    QVERIFY(!looks_ascii(non_ascii_str));
+void
+TestWencoding::test_looks_ascii () {
+  string ascii_str    = "Hello, World!";
+  string non_ascii_str= "こんにちは、世界！";
+  QVERIFY (looks_ascii (ascii_str));
+  QVERIFY (!looks_ascii (non_ascii_str));
 }
 
-void TestWencoding::test_looks_utf8() {
-    string utf8_str = u8"Hello, 世界!";
-    string non_utf8_str = "\xFF\xFE";
-    QVERIFY(looks_utf8(utf8_str));
-    QVERIFY(!looks_utf8(non_utf8_str));
+void
+TestWencoding::test_looks_utf8 () {
+  string utf8_str    = u8"Hello, 世界!";
+  string non_utf8_str= "\xFF\xFE";
+  QVERIFY (looks_utf8 (utf8_str));
+  QVERIFY (!looks_utf8 (non_utf8_str));
 }
 
-void TestWencoding::test_guess_wencoding() {
-    string ascii_str = "Hello, World!";
-    string utf8_str = u8"こんにちは、世界！";
-    string iso_8859_str = "\xC3\xA9";
-    QCOMPARE(toString(guess_wencoding(ascii_str)), std::string("ASCII"));
-    QCOMPARE(toString(guess_wencoding(utf8_str)), std::string("UTF-8"));
-    QCOMPARE(toString(guess_wencoding(iso_8859_str)), std::string("ISO-8859")); 
-    // 似乎在处理 ISO-8859 编码的字符串时返回了 "UTF-8"。可能该函数在判断编码时误判了 
-    // It seems to return "UTF-8" when processing ISO-8859 encoded strings. Perhaps the function misjudged the encoding when determining the encoding.
+void
+TestWencoding::test_guess_wencoding () {
+  string ascii_str   = "Hello, World!";
+  string utf8_str    = u8"こんにちは、世界！";
+  string iso_8859_str= "\xC3\xA9";
+  QCOMPARE (toString (guess_wencoding (ascii_str)), std::string ("ASCII"));
+  QCOMPARE (toString (guess_wencoding (utf8_str)), std::string ("UTF-8"));
+  QCOMPARE (toString (guess_wencoding (iso_8859_str)),
+            std::string ("ISO-8859"));
+  // It seems to return "UTF-8" when processing ISO-8859 encoded strings.
+  // Perhaps the function misjudged the encoding when determining the encoding.
 }
 
-void TestWencoding::test_western_to_utf8() {
-    string iso_8859_str = "\xE9"; // é in ISO-8859
-    string utf8_result = western_to_utf8(iso_8859_str);
-    QCOMPARE(toString(utf8_result), std::string(u8"é"));
+void
+TestWencoding::test_western_to_utf8 () {
+  string iso_8859_str= "\xE9"; // é in ISO-8859
+  string utf8_result = western_to_utf8 (iso_8859_str);
+  QCOMPARE (toString (utf8_result), std::string (u8"é"));
 }
 
-void TestWencoding::test_western_to_cork() {
-    string utf8_str = u8"Hello, 世界!";
-    string cork_result = western_to_cork(utf8_str);
-    QCOMPARE(toString(cork_result), toString(utf8_str));  // Assuming your conversion to Cork maintains the content
+void
+TestWencoding::test_western_to_cork () {
+  string utf8_str   = u8"Hello, 世界!";
+  string cork_result= western_to_cork (utf8_str);
+  QCOMPARE (
+      toString (cork_result),
+      toString (
+          utf8_str)); // Assuming your conversion to Cork maintains the content
 }
 
-QTEST_MAIN(TestWencoding)
+QTEST_MAIN (TestWencoding)
 #include "wencoding_test.moc"

--- a/tests/L3/Data/String/wencoding_test.cpp
+++ b/tests/L3/Data/String/wencoding_test.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * MODULE     : wencoding_test.cpp
  * DESCRIPTION: Tests on wencoding
- * COPYRIGHT  : (C) 2019-2024  ATQlove
+ * COPYRIGHT  : (C) 2024  ATQlove
  *******************************************************************************
  * This software falls under the GNU general public license version 3 or later.
  * It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Added wencoding test, suspected problems with wencoding.
## Why
Testing for the function mogan\src\Data\String\wencoding.cpp. Specifically, when testing the guess_wencoding function, it misjudged strings encoded in ISO_8859. When only ascii or utf8 is recognized, the test passes normally. The other two tests, western_to_utf8 and western_to_cork, both failed.
针对mogan\src\Data\String\wencoding.cpp这个功能进行测试。具体来说是在测试guess_wencoding函数的时候，对iso_8859编码的字符串进行了误判。只对ascii或者utf8判别的时候，测试是能正常通过的。另外就是western_to_utf8和western_to_cork两个测试都没能正常通过。
## How to test your changes?
Put it in "mogan\tests\L3\Data\String\wencoding_test.cpp", and then run "xmake build wencoding_test" and "xmake run wencoding_test"
