### PR TITLE
[64_8] Fill printed raster image with FFFFFFFF

### DIFF
--- a/src/Plugins/Qt/qt_picture.cpp
+++ b/src/Plugins/Qt/qt_picture.cpp
@@ -182,7 +182,7 @@ qt_image_renderer_rep::qt_image_renderer_rep (picture p, double zoom)
 
   qt_picture_rep* handle= (qt_picture_rep*) pict->get_handle ();
   QImage&         im (handle->pict);
-  im.fill (QColor (0, 0, 0, 0));
+  im.fill (QColor (255, 255, 255, 0));
   painter->begin (&im);
 }
 

--- a/src/Plugins/Qt/qt_picture.cpp
+++ b/src/Plugins/Qt/qt_picture.cpp
@@ -182,7 +182,7 @@ qt_image_renderer_rep::qt_image_renderer_rep (picture p, double zoom)
 
   qt_picture_rep* handle= (qt_picture_rep*) pict->get_handle ();
   QImage&         im (handle->pict);
-  im.fill (QColor (255, 255, 255, 0));
+  im.fill (QColor (255, 255, 255, 255));
   painter->begin (&im);
 }
 


### PR DESCRIPTION
## What
`Edit->Copy as->Image` on windows will produce image with black background. Set the fill color to `QColor(255, 255, 255, 255)`, to fix the issue.

Affected:
+ qt_image_renderer_rep
  + picture_renderer
     + make_raster_image
       + `Edit->Copy as->Image`
     + renderer_rep::shadow 
       + Still need to be confirmed

## How to test your changes?
Select something and click `Edit->Copy as->Image` and paste the image somewhere else.
