### PR TITLE
[11_31] Import font to $TEXMACS_HOME_PATH/fonts/truetype

### DIFF
--- a/TeXmacs/fonts/font-database.scm
+++ b/TeXmacs/fonts/font-database.scm
@@ -896,8 +896,6 @@
 ((Futura Condensed\ Medium) ((Futura.ttc 2 321740) (Futura.ttc 2 288740) (Futura.ttc 2 315748) (Futura.ttc 3 486592) (Futura.ttc 3 488604)))
 ((Futura Medium) ((Futura.ttc 0 321740) (Futura.ttc 0 288740) (Futura.ttc 0 315748) (Futura.ttc 0 486592) (Futura.ttc 0 488604)))
 ((Futura Medium\ Italic) ((Futura.ttc 1 321740) (Futura.ttc 1 288740) (Futura.ttc 1 315748) (Futura.ttc 1 486592) (Futura.ttc 1 488604)))
-((FZXiaoBiaoSong-B05S Regular) ((方正小标宋简.ttf 0 3835244)))
-((FZXiaoBiaoSong-B05S Regular) ((方正小标宋简.TTF 0 3835244)))
 ((Gabriola Regular) ((Gabriola.ttf 0 1806004)))
 ((Gadugi Bold) ((gadugib.ttf 0 244912)))
 ((Gadugi Regular) ((gadugi.ttf 0 247240)))

--- a/TeXmacs/fonts/font-database.scm
+++ b/TeXmacs/fonts/font-database.scm
@@ -897,6 +897,7 @@
 ((Futura Medium) ((Futura.ttc 0 321740) (Futura.ttc 0 288740) (Futura.ttc 0 315748) (Futura.ttc 0 486592) (Futura.ttc 0 488604)))
 ((Futura Medium\ Italic) ((Futura.ttc 1 321740) (Futura.ttc 1 288740) (Futura.ttc 1 315748) (Futura.ttc 1 486592) (Futura.ttc 1 488604)))
 ((FZXiaoBiaoSong-B05S Regular) ((方正小标宋简.ttf 0 3835244)))
+((FZXiaoBiaoSong-B05S Regular) ((方正小标宋简.TTF 0 3835244)))
 ((Gabriola Regular) ((Gabriola.ttf 0 1806004)))
 ((Gadugi Bold) ((gadugib.ttf 0 244912)))
 ((Gadugi Regular) ((gadugi.ttf 0 247240)))

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -236,7 +236,6 @@ url           fontdb_local_path (string name);
 void          font_database_build (url u);
 void          font_database_build_local ();
 void          font_database_extend_local (url u);
-void          font_database_extend (url u);
 void          font_database_build_global ();
 void          font_database_build_global (url u);
 void          font_database_build_characteristics (bool force);

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -236,6 +236,7 @@ url           fontdb_local_path (string name);
 void          font_database_build (url u);
 void          font_database_build_local ();
 void          font_database_extend_local (url u);
+void          font_database_extend (url u);
 void          font_database_build_global ();
 void          font_database_build_global (url u);
 void          font_database_build_characteristics (bool force);

--- a/src/Graphics/Fonts/font_database.cpp
+++ b/src/Graphics/Fonts/font_database.cpp
@@ -401,13 +401,13 @@ font_database_extend_local (url u) {
 
 void
 font_database_extend (url u) {
-  if (is_none (u))
-    ;
-  else if (is_or (u)) {
+  if (is_or (u)) {
     font_database_extend (u[1]);
     font_database_extend (u[2]);
   }
-  if (is_regular (u)) font_database_extend_local (u);
+  else if (is_regular (u)) {
+    font_database_extend_local (u);
+  }
 }
 
 void

--- a/src/Graphics/Fonts/font_database.cpp
+++ b/src/Graphics/Fonts/font_database.cpp
@@ -273,7 +273,8 @@ font_database_load () {
   if (N (font_table) == 0) {
     font_database_load_database (GLOBAL_DATABASE);
     font_database_filter ();
-    font_database_extend (search_sub_dirs (get_tm_cache_path () * url("fonts/truetype")));
+    font_database_extend (
+        search_sub_dirs (get_tm_cache_path () * url ("fonts/truetype")));
     font_database_save_database (fontdb_local_path (LOCAL_DATABASE));
     font_database_load_suffixes_sub (fontdb_local_path (LOCAL_DATABASE));
   }

--- a/src/Graphics/Fonts/font_database.cpp
+++ b/src/Graphics/Fonts/font_database.cpp
@@ -273,6 +273,7 @@ font_database_load () {
   if (N (font_table) == 0) {
     font_database_load_database (GLOBAL_DATABASE);
     font_database_filter ();
+    font_database_extend (search_sub_dirs (get_tm_cache_path () * url("fonts/truetype")));
     font_database_save_database (fontdb_local_path (LOCAL_DATABASE));
     font_database_load_suffixes_sub (fontdb_local_path (LOCAL_DATABASE));
   }
@@ -389,12 +390,23 @@ font_database_build_local () {
 
 void
 font_database_extend_local (url u) {
-  tt_extend_font_path (u);
+  url new_u= tt_add_to_font_path (u);
   font_database_load ();
-  font_database_build (u);
+  font_database_build (new_u);
   font_database_build_characteristics (false);
   font_database_guess_features ();
   font_database_save ();
+}
+
+void
+font_database_extend (url u) {
+  if (is_none (u))
+    ;
+  else if (is_or (u)) {
+    font_database_extend (u[1]);
+    font_database_extend (u[2]);
+  }
+  if (is_regular (u)) font_database_extend_local (u);
 }
 
 void

--- a/src/Graphics/Fonts/font_database.cpp
+++ b/src/Graphics/Fonts/font_database.cpp
@@ -274,7 +274,7 @@ font_database_load () {
     font_database_load_database (GLOBAL_DATABASE);
     font_database_filter ();
     font_database_extend (
-        search_sub_dirs (get_tm_cache_path () * url ("fonts/truetype")));
+        search_sub_dirs (get_texmacs_home_path () * url ("fonts/truetype")));
     font_database_save_database (fontdb_local_path (LOCAL_DATABASE));
     font_database_load_suffixes_sub (fontdb_local_path (LOCAL_DATABASE));
   }

--- a/src/Graphics/Fonts/font_database.cpp
+++ b/src/Graphics/Fonts/font_database.cpp
@@ -273,7 +273,7 @@ font_database_load () {
   if (N (font_table) == 0) {
     font_database_load_database (GLOBAL_DATABASE);
     font_database_filter ();
-    font_database_extend (
+    font_database_extend_local (
         search_sub_dirs (get_texmacs_home_path () * url ("fonts/truetype")));
     font_database_save_database (fontdb_local_path (LOCAL_DATABASE));
     font_database_load_suffixes_sub (fontdb_local_path (LOCAL_DATABASE));
@@ -391,23 +391,29 @@ font_database_build_local () {
 
 void
 font_database_extend_local (url u) {
-  url new_u= tt_add_to_font_path (u);
-  font_database_load ();
-  font_database_build (new_u);
+  array<url> all_fonts;
+  if (is_regular (u)) {
+    all_fonts << u;
+  }
+  else if (is_directory (u)) {
+    bool          err= false;
+    array<string> a  = read_directory (u, err);
+    int           a_N= N (a);
+    for (int i= 0; i < a_N; i++) {
+      all_fonts << u * a[i];
+    }
+  }
+
+  int all_fonts_N= N (all_fonts);
+  if (all_fonts_N <= 0) return;
+  for (int i= 0; i < all_fonts_N; i++) {
+    url new_u= tt_add_to_font_path (all_fonts[i]);
+    font_database_load ();
+    font_database_build (new_u);
+  }
   font_database_build_characteristics (false);
   font_database_guess_features ();
   font_database_save ();
-}
-
-void
-font_database_extend (url u) {
-  if (is_or (u)) {
-    font_database_extend (u[1]);
-    font_database_extend (u[2]);
-  }
-  else if (is_regular (u)) {
-    font_database_extend_local (u);
-  }
 }
 
 void

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -94,12 +94,11 @@ tt_font_search_path () {
   }
   ret= ret | url ("$TEXMACS_HOME_PATH/fonts/truetype") |
        url ("$TEXMACS_PATH/fonts/truetype");
-  ret= ret | (get_tm_cache_path () * "fonts" * "truetype");
   if (os_win () || os_mingw ()) {
     ret= ret | url_system ("$windir/Fonts");
   }
   else if (os_macos ()) {
-    ret= ret | url ("$HOME/Library/Fonts") | url ("/Library/Fonts") |
+    ret= ret | url ("/Library/Fonts") |
          url ("/Library/Application Support/Apple/Fonts/iLife") |
          url ("/Library/Application Support/Apple/Fonts/iWork") |
          url ("/System/Library/Fonts") |
@@ -129,12 +128,6 @@ tt_font_search_path () {
 #else
     ret= ret | url ("/usr/share/fonts/truetype") |
          url ("/usr/share/fonts/opentype");
-    if (exists (url_system ("$HOME/.local/share/fonts"))) {
-      ret= ret | url_system ("$HOME/.local/share/fonts");
-    }
-    if (exists (url_system ("$HOME/.fonts"))) {
-      ret= ret | url_system ("$HOME/.fonts");
-    }
 #endif
     ret= ret | url ("/usr/share/texlive/texmf-dist/fonts/opentype") |
          url ("/usr/share/texlive/texmf-dist/fonts/truetype");

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -69,7 +69,7 @@ add_to_path (url u, url d) {
 url
 tt_add_to_font_path (url u) {
   if (!is_directory (u)) {
-    url font_path= get_tm_cache_path () * url ("fonts") * url ("truetype") *
+    url font_path= get_texmacs_home_path () * url ("fonts") * url ("truetype") *
                    (lolly::hash::md5_hexdigest (u) * "." * suffix (u));
     if (u != font_path) {
       if (exists (font_path)) remove (font_path);

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -69,8 +69,8 @@ add_to_path (url u, url d) {
 url
 tt_add_to_font_path (url u) {
   if (!is_directory (u)) {
-    url font_path= get_tm_cache_path () * url("fonts") * url("truetype") *
-      (lolly::hash::md5_hexdigest (u) * "." * suffix(u));
+    url font_path= get_tm_cache_path () * url ("fonts") * url ("truetype") *
+                   (lolly::hash::md5_hexdigest (u) * "." * suffix (u));
     if (u != font_path) {
       copy (u, font_path);
     }
@@ -93,6 +93,7 @@ tt_font_search_path () {
   }
   ret= ret | url ("$TEXMACS_HOME_PATH/fonts/truetype") |
        url ("$TEXMACS_PATH/fonts/truetype");
+  ret= ret | (get_tm_cache_path () * "fonts" * "truetype");
   if (os_win () || os_mingw ()) {
     ret= ret | url_system ("$windir/Fonts");
   }

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -72,6 +72,7 @@ tt_add_to_font_path (url u) {
     url font_path= get_tm_cache_path () * url ("fonts") * url ("truetype") *
                    (lolly::hash::md5_hexdigest (u) * "." * suffix (u));
     if (u != font_path) {
+      if (exists (font_path)) remove (font_path);
       copy (u, font_path);
     }
     // Sync font info to tt_fonts and tt_font_location

--- a/src/Plugins/Freetype/tt_file.cpp
+++ b/src/Plugins/Freetype/tt_file.cpp
@@ -231,7 +231,7 @@ tt_font_find (string font_basename) {
     array<string> suffixes     = font_database_suffixes (font_basename);
     for (int i= 0; i < N (suffixes); i++) {
       string suf= suffixes[i];
-      if (!contains (suf, tt_allowed_suffixes)) {
+      if (!contains (locase_all (suf), tt_allowed_suffixes)) {
         flag_truetype= false;
       }
       if (flag_truetype) {

--- a/src/Plugins/Freetype/tt_file.hpp
+++ b/src/Plugins/Freetype/tt_file.hpp
@@ -17,7 +17,7 @@
 
 url        tt_font_path ();
 array<url> tt_font_paths ();
-void       tt_extend_font_path (url u);
+url        tt_add_to_font_path (url u);
 bool       tt_font_exists (string font_basename);
 url        tt_font_find (string font_basename);
 string     tt_find_name (string name, int size);


### PR DESCRIPTION
## What
+ Import the font to $TEXMACS_HOME_PATH/fonts/truetype
  - Use the md5 digest as the font file name
  - No longer loading fonts from the font local path on macOS/Linux/Windows
+ Collect the font info when loading the font database
+ Fix the bug of tt_fint_font when the font file is using TTF/TTC/OTC as the suffix

TODO: in later pull request: the dialogue to import font should only allow ttf/ttc/otc

## Why
`ft_load_face` does not work on windows when the font path contains Chinese characters (eg. `方正小标宋简.ttf`). To avoid Chinese font path name, we use the content md5 digest as the file name when import the font.

The goal of this pull request is to support `方正小标宋简.ttf`, and because of the bug of ft_load_face, we have to re-impl the mechanism of font importing.

## How to test your changes?
+ [x] Linux
+ [ ] macOS
+ [x] Windows

1. Open `Document -> Fonts` and click `Import...` to Import font.
2. Click `Tools -> Fonts -> Clear font cache`, and restart Mogan, the imported fonts should still work
