### PR TITLE
[70_9] Parser: improve number_parser and keyword_parser for S7 Scheme

### DIFF
--- a/TeXmacs/plugins/s7/progs/code/s7-lang.scm
+++ b/TeXmacs/plugins/s7/progs/code/s7-lang.scm
@@ -17,8 +17,8 @@
 (tm-define (parser-feature lan key)
   (:require (and (== lan "s7") (== key "keyword")))
   `(,(string->symbol key)
-    (constant
-     "#t" "#f" "pi")
+    (extra_chars "?" "-" "!" "*" ">" "=" "<")
+    (constant "pi")
     (declare_type
      "define" "set!" "lambda" "define-macro" "define-constant" "let")
     (keyword
@@ -97,14 +97,12 @@
 
 (define (s7-number-suffix)
   `(suffix
-    (imaginary "j" "J")))
+    (imaginary "i")))
 
 (tm-define (parser-feature lan key)
   (:require (and (== lan "s7") (== key "number")))
   `(,(string->symbol key)
-    (bool_features
-     "prefix_0x" "prefix_0b"
-     "sci_notation")
+    (bool_features "prefix_#")
     (separator "_")
     ,(s7-number-suffix)))
 

--- a/TeXmacs/plugins/s7/progs/code/s7-lang.scm
+++ b/TeXmacs/plugins/s7/progs/code/s7-lang.scm
@@ -20,7 +20,7 @@
     (extra_chars "?" "-" "!" "*" ">" "=" "<")
     (constant "pi")
     (declare_type
-     "define" "set!" "lambda" "define-macro" "define-constant" "let")
+     "define" "set!" "lambda" "define-macro" "define-constant" "let" "let*")
     (keyword
      "eq?" "bignum" "length" "append" "procedure-source"
      ; SRFI-1: List constructors

--- a/TeXmacs/tests/tm/70_9.tm
+++ b/TeXmacs/tests/tm/70_9.tm
@@ -1,0 +1,104 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|chinese|s7>>
+
+<\body>
+  <\session|s7|default>
+    <\output>
+      S7 Scheme 10.6 (14-Apr-2023)
+    </output>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      #t
+    <|unfolded-io>
+      #t
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      #f
+    <|unfolded-io>
+      #f
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      #o777
+    <|unfolded-io>
+      511
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      #b111
+    <|unfolded-io>
+      7
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      #xab1
+    <|unfolded-io>
+      2737
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      (number-\<gtr\>string 1)
+    <|unfolded-io>
+      "1"
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      (string? "1")
+    <|unfolded-io>
+      #t
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      (list-ref (list 1 2 3 4) 3)
+    <|unfolded-io>
+      4
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      (define x 1)
+    <|unfolded-io>
+      1
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      (set! x 2)
+    <|unfolded-io>
+      2
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\ 
+    <|input>
+      let*
+    </input>
+  </session>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Data/Parser/keyword_parser.cpp
+++ b/src/Data/Parser/keyword_parser.cpp
@@ -32,6 +32,7 @@ bool
 read_keyword (string s, int& i, string& result, array<char> extras) {
   int opos= i;
   int s_N = N (s);
+  // a keyword must start with alpha
   if (i < s_N && is_alpha (s[i])) i++;
   while (i < s_N && (is_alpha (s[i]) || contains (s[i], extras))) {
     i++;
@@ -70,6 +71,7 @@ keyword_parser_rep::use_keywords_of_lang (string lang_code) {
     int    group_words_N= N (group_words);
     for (int j= 0; j < group_words_N; j++) {
       string word= get_label (group_words[j]);
+      // number->string is actually number-<gtr>string
       put (utf8_to_cork (word), group);
     }
   }

--- a/src/Data/Parser/keyword_parser.hpp
+++ b/src/Data/Parser/keyword_parser.hpp
@@ -35,11 +35,13 @@ public:
   }
 
   void use_keywords_of_lang (string lang_code);
+  void insert_extra_char (char extra_char);
 
 private:
   void                    do_parse (string s, int& pos);
   hashmap<string, string> keyword_group;
   string                  current_keyword;
+  array<char>             extra_chars;
 };
 
 #endif

--- a/src/Data/Parser/number_parser.cpp
+++ b/src/Data/Parser/number_parser.cpp
@@ -14,7 +14,7 @@
 
 number_parser_rep::number_parser_rep ()
     : PREFIX_0B ("prefix_0b"), PREFIX_0O ("prefix_0o"), PREFIX_0X ("prefix_0x"),
-      NO_SUFFIX_WITH_BOX ("no_suffix_with_box"),
+      PREFIX_HASH ("prefix_#"), NO_SUFFIX_WITH_BOX ("no_suffix_with_box"),
       SCIENTIFIC_NOTATION ("sci_notation") {
   separator= '\0';
 }
@@ -45,34 +45,37 @@ number_parser_rep::parse_decimal (string s, int& pos) {
 }
 
 bool
-number_parser_rep::can_parse_prefix_0b (string s, int pos) {
-  return prefix_0b () && pos + 2 < N (s) && s[pos] == '0' &&
-         (s[pos + 1] == 'b' || s[pos + 1] == 'B');
+number_parser_rep::can_parse_prefix_b (string s, int pos) {
+  return pos + 2 < N (s) && (s[pos + 1] == 'b' || s[pos + 1] == 'B') &&
+         ((prefix_0b () && s[pos] == '0') || (prefix_hash () && s[pos] == '#'));
 }
 
 bool
-number_parser_rep::can_parse_prefix_0o (string s, int pos) {
-  return prefix_0o () && pos + 2 < N (s) && s[pos] == '0' &&
-         (s[pos + 1] == 'o' || s[pos + 1] == 'O');
+number_parser_rep::can_parse_prefix_o (string s, int pos) {
+  return pos + 2 < N (s) && (s[pos + 1] == 'o' || s[pos + 1] == 'O') &&
+         ((prefix_0o () && s[pos] == '0') || (prefix_hash () && s[pos] == '#'));
 }
 
 bool
-number_parser_rep::can_parse_prefix_0x (string s, int pos) {
-  return prefix_0x () && pos + 2 < N (s) && s[pos] == '0' &&
-         (s[pos + 1] == 'x' || s[pos + 1] == 'X');
+number_parser_rep::can_parse_prefix_x (string s, int pos) {
+  return pos + 2 < N (s) && (s[pos + 1] == 'x' || s[pos + 1] == 'X') &&
+         ((prefix_0x () && s[pos] == '0') || (prefix_hash () && s[pos] == '#'));
 }
 
 bool
 number_parser_rep::can_parse (string s, int pos) {
   // check on len >= 3
   if (pos + 2 < N (s)) {
-    if (can_parse_prefix_0b (s, pos) || can_parse_prefix_0x (s, pos) ||
-        can_parse_prefix_0o (s, pos))
+    if (can_parse_prefix_b (s, pos) || can_parse_prefix_x (s, pos) ||
+        can_parse_prefix_o (s, pos))
       return true;
   }
   // check on len >= 2
   if (pos + 1 < N (s)) {
     if (s[pos] == '.' && is_digit (s[pos + 1])) return true;
+    if (prefix_hash () && s[pos] == '#' &&
+        (s[pos + 1] == 't' || s[pos + 1] == 'f'))
+      return true;
   }
   // finally, check on len >= 1
   return pos < N (s) && is_digit (s[pos]);
@@ -82,22 +85,28 @@ void
 number_parser_rep::do_parse (string s, int& pos) {
   if (pos >= N (s)) return;
 
-  if (!is_digit (s[pos]) &&
+  if (!is_digit (s[pos]) && !(prefix_hash () && s[pos] == '#') &&
       !(s[pos] == '.' && pos + 1 < N (s) && is_digit (s[pos + 1])))
     return;
 
-  // Start with 0b, 0o, 0x
-  if (can_parse_prefix_0b (s, pos)) {
+  if (prefix_hash () && pos + 1 < N (s) && s[pos] == '#' &&
+      (s[pos + 1] == 't' || s[pos + 1] == 'f')) {
+    pos+= 2;
+    return;
+  }
+
+  // Start with 0b, 0o, 0x, #b, #o, #x
+  if (can_parse_prefix_b (s, pos)) {
     pos+= 2;
     parse_binary (s, pos);
     if (no_suffix_with_box ()) return;
   }
-  if (can_parse_prefix_0o (s, pos)) {
+  if (can_parse_prefix_o (s, pos)) {
     pos+= 2;
     parse_octal (s, pos);
     if (no_suffix_with_box ()) return;
   }
-  if (can_parse_prefix_0x (s, pos)) {
+  if (can_parse_prefix_x (s, pos)) {
     pos+= 2;
     parse_hex (s, pos);
     if (no_suffix_with_box ()) return;

--- a/src/Data/Parser/number_parser.cpp
+++ b/src/Data/Parser/number_parser.cpp
@@ -73,6 +73,7 @@ number_parser_rep::can_parse (string s, int pos) {
   // check on len >= 2
   if (pos + 1 < N (s)) {
     if (s[pos] == '.' && is_digit (s[pos + 1])) return true;
+    // for #t and #f
     if (prefix_hash () && s[pos] == '#' &&
         (s[pos + 1] == 't' || s[pos + 1] == 'f'))
       return true;
@@ -89,6 +90,7 @@ number_parser_rep::do_parse (string s, int& pos) {
       !(s[pos] == '.' && pos + 1 < N (s) && is_digit (s[pos + 1])))
     return;
 
+  // for #t and #f
   if (prefix_hash () && pos + 1 < N (s) && s[pos] == '#' &&
       (s[pos + 1] == 't' || s[pos + 1] == 'f')) {
     pos+= 2;

--- a/src/Data/Parser/number_parser.hpp
+++ b/src/Data/Parser/number_parser.hpp
@@ -21,6 +21,7 @@ public:
   string PREFIX_0B;
   string PREFIX_0O;
   string PREFIX_0X;
+  string PREFIX_HASH;
   string NO_SUFFIX_WITH_BOX;
   string SCIENTIFIC_NOTATION;
 
@@ -54,6 +55,12 @@ public:
   inline void support_prefix_0x (bool param) {
     if (param) insert_bool_feature (PREFIX_0X);
     else remove_bool_feature (PREFIX_0X);
+  }
+
+  inline bool prefix_hash () { return bool_features->contains (PREFIX_HASH); }
+  inline void support_prefix_hash (bool param) {
+    if (param) insert_bool_feature (PREFIX_HASH);
+    else remove_bool_feature (PREFIX_HASH);
   }
 
   inline bool no_suffix_with_box () {
@@ -92,9 +99,9 @@ private:
 
   void do_parse (string s, int& pos);
 
-  bool can_parse_prefix_0b (string s, int pos);
-  bool can_parse_prefix_0o (string s, int pos);
-  bool can_parse_prefix_0x (string s, int pos);
+  bool can_parse_prefix_b (string s, int pos);
+  bool can_parse_prefix_o (string s, int pos);
+  bool can_parse_prefix_x (string s, int pos);
 
   void parse_binary (string s, int& pos);
   void parse_hex (string s, int& pos);

--- a/src/System/Language/prog_language.cpp
+++ b/src/System/Language/prog_language.cpp
@@ -73,6 +73,7 @@ prog_language_rep::customize_keyword (keyword_parser_rep p_keyword_parser,
     else {
       for (int j= 0; j < group_of_keywords_N; j++) {
         string word= get_label (group_of_keywords[j]);
+        // number->string is actually number-<gtr>string
         p_keyword_parser.put (utf8_to_cork (word), group);
       }
     }

--- a/src/System/Language/prog_language.cpp
+++ b/src/System/Language/prog_language.cpp
@@ -12,6 +12,7 @@
 
 #include "analyze.hpp"
 #include "convert.hpp"
+#include "converter.hpp"
 #include "cork.hpp"
 #include "impl_language.hpp"
 #include "iterator.hpp"
@@ -56,12 +57,24 @@ prog_language_rep::get_parser_config (string lan, string key) {
 void
 prog_language_rep::customize_keyword (keyword_parser_rep p_keyword_parser,
                                       tree               config) {
-  for (int i= 0; i < N (config); i++) {
-    tree   group_of_keywords= config[i];
-    string group            = get_label (group_of_keywords);
-    for (int j= 0; j < N (group_of_keywords); j++) {
-      string word= get_label (group_of_keywords[j]);
-      p_keyword_parser.put (word, group);
+  int config_N= N (config);
+  for (int i= 0; i < config_N; i++) {
+    tree   group_of_keywords  = config[i];
+    int    group_of_keywords_N= N (group_of_keywords);
+    string group              = get_label (group_of_keywords);
+    if (group == "extra_chars") {
+      for (int j= 0; j < group_of_keywords_N; j++) {
+        string extra_char= get_label (group_of_keywords[j]);
+        if (N (extra_char) == 1) {
+          p_keyword_parser.insert_extra_char (extra_char[0]);
+        }
+      }
+    }
+    else {
+      for (int j= 0; j < group_of_keywords_N; j++) {
+        string word= get_label (group_of_keywords[j]);
+        p_keyword_parser.put (utf8_to_cork (word), group);
+      }
     }
   }
 }
@@ -202,12 +215,12 @@ prog_language_rep::advance (tree t, int& pos) {
     current_parser= number_parser.get_parser_name ();
     return &tp_normal_rep;
   }
-  if (operator_parser.parse (s, pos)) {
-    current_parser= operator_parser.get_parser_name ();
-    return &tp_normal_rep;
-  }
   if (keyword_parser.parse (s, pos)) {
     current_parser= keyword_parser.get_parser_name ();
+    return &tp_normal_rep;
+  }
+  if (operator_parser.parse (s, pos)) {
+    current_parser= operator_parser.get_parser_name ();
     return &tp_normal_rep;
   }
   if (identifier_parser.parse (s, pos)) {


### PR DESCRIPTION
## What
+ number_parser: support `#` prefix
+ keyword_parser: support customizing extra chars
+ improve s7-lang.scm

## Why
In S7 Scheme
``` scheme
#b001
#xab1
#o777
#t 
#f

string->number
string?
set!
```

## How to test your changes?
Launch Mogan Research and check `TeXmacs/tests/tm/70_9.tm`
