### PR TITLE
[70_9] Improve keyword_parser for +inf.0 and -inf.0

### DIFF
--- a/TeXmacs/plugins/s7/progs/code/s7-lang.scm
+++ b/TeXmacs/plugins/s7/progs/code/s7-lang.scm
@@ -69,8 +69,8 @@
 (tm-define (parser-feature lan key)
   (:require (and (== lan "s7") (== key "keyword")))
   `(,(string->symbol key)
-    (extra_chars "?" "-" "!" "*" ">" "=" "<")
-    (constant "pi")
+    (extra_chars "?" "+" "-" "." "!" "*" ">" "=" "<")
+    (constant "pi" "+inf.0" "-inf.0")
     (declare_type
      "define" "defined?" "set!" "lambda" "define-macro"
      "define-constant" "let" "let*" "apply" "eval"

--- a/src/Data/Parser/keyword_parser.cpp
+++ b/src/Data/Parser/keyword_parser.cpp
@@ -32,9 +32,11 @@ bool
 read_keyword (string s, int& i, string& result, array<char> extras) {
   int opos= i;
   int s_N = N (s);
-  // a keyword must start with alpha
-  if (i < s_N && is_alpha (s[i])) i++;
-  while (i < s_N && (is_alpha (s[i]) || contains (s[i], extras))) {
+  // a keyword must start with alpha or start with extra chars
+  if (i < s_N && (is_alpha (s[i] || contains (s[i], extras)))) i++;
+  // a keyword is consist of alpha/number/extra chars
+  while (i < s_N &&
+         (is_alpha (s[i]) || is_digit (s[i]) || contains (s[i], extras))) {
     i++;
   }
   result= s (opos, i);


### PR DESCRIPTION
## What
+ keyword_parser:
  - keyword should start with alpha or extra chars
  - keyword should be consist of alpha/extra chars/digits
+ Add `+inf.0`, `+inf.0` to S7 Scheme keywords as constant