### PR TITLE
[2_18] S7: Fix tm->html with ornament

### DIFF
--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -1407,7 +1407,9 @@
                         ,@(if h `((height ,h)) '()))))))))
 
 (define (tmhtml-ornament-get-env-style)
-  (let* ((l0 (hash-map->list list tmhtml-env))
+  (display* "tmhtml-env:\n" tmhtml-env "\n")
+  (display* "list:\n" (ahash-table->list tmhtml-env) "\n")
+  (let* ((l0 (ahash-table->list tmhtml-env))
          (l1 (filter (lambda (x)
                        (and (list>0? (car x))
                             (cadr x)

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -1406,10 +1406,13 @@
                         ,@(if w `((width ,w)) '())
                         ,@(if h `((height ,h)) '()))))))))
 
+(define-public (hash-map->list h)
+  (map (lambda (x)
+         (list (car x) (cdr x)))
+    (map values h)))
+
 (define (tmhtml-ornament-get-env-style)
-  (display* "tmhtml-env:\n" tmhtml-env "\n")
-  (display* "list:\n" (ahash-table->list tmhtml-env) "\n")
-  (let* ((l0 (ahash-table->list tmhtml-env))
+  (let* ((l0 (hash-map->list tmhtml-env))
          (l1 (filter (lambda (x)
                        (and (list>0? (car x))
                             (cadr x)

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -1413,11 +1413,12 @@
 
 (define (tmhtml-ornament-get-env-style)
   (let* ((l0 (hash-map->list tmhtml-env))
-         (l1 (filter (lambda (x)
-                       (and (list>0? (car x))
-                            (cadr x)
-                            (string-starts? "#:ornament-"
-                                            (object->string (caar x))))) l0))
+         (l1 (filter
+               (lambda (x)
+                 (and (list>0? (car x))
+                      (cadr x)
+                      (string-starts? (object->string (caar x)) ":ornament-")))
+               l0))
          (l2   (map car l1))
          (args (map cadr l1))
          (funs (map cAr l2))

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -1416,7 +1416,7 @@
          (l1 (filter (lambda (x)
                        (and (list>0? (car x))
                             (cadr x)
-                            (string-prefix? "#:ornament-"
+                            (string-starts? "#:ornament-"
                                             (object->string (caar x))))) l0))
          (l2   (map car l1))
          (args (map cadr l1))

--- a/TeXmacs/tests/html/2_18.html
+++ b/TeXmacs/tests/html/2_18.html
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1999/xhtml" xmlns:x="https://www.texmacs.org/2002/extensions">
+  <head>
+    <title>No title</title>
+    <meta content="TeXmacs 2.1.2" name="generator"></meta>
+    <style type="text/css">
+      body { text-align: justify } h5 { display: inline; padding-right: 1em }
+      h6 { display: inline; padding-right: 1em } table { border-collapse:
+      collapse } td { padding: 0.2em; vertical-align: baseline } dt { float:
+      left; min-width: 1.75em; text-align: right; padding-right: 0.75em;
+      font-weight: bold; } dd { margin-left: 2.75em; padding-bottom: 0.25em; }
+      dd p { padding-top: 0em; } .subsup { display: inline; vertical-align:
+      -0.2em } .subsup td { padding: 0px; text-align: left} .fraction {
+      display: inline; vertical-align: -0.8em } .fraction td { padding: 0px;
+      text-align: center } .wide { position: relative; margin-left: -0.4em }
+      .accent { position: relative; margin-left: -0.4em; top: -0.1em }
+      .title-block { width: 100%; text-align: center } .title-block p {
+      margin: 0px } .compact-block p { margin-top: 0px; margin-bottom: 0px }
+      .left-tab { text-align: left } .center-tab { text-align: center }
+      .balloon-anchor { border-bottom: 1px dotted #000000; outline: none;
+      cursor: help; position: relative; } .balloon-anchor [hidden] {
+      margin-left: -999em; position: absolute; display: none; }
+      .balloon-anchor: hover [hidden] { position: absolute; left: 1em; top:
+      2em; z-index: 99; margin-left: 0; width: 500px; display: inline-block; }
+      .balloon-body { } .ornament { border-width: 1px; border-style: solid;
+      border-color: black; display: inline-block; padding: 0.2em; } .right-tab
+      { float: right; position: relative; top: -1em; } .no-breaks {
+      white-space: nowrap; } .underline { text-decoration: underline; }
+      .overline { text-decoration: overline; } .strike-through {
+      text-decoration: line-through; } del { text-decoration: line-through
+      wavy red; } .fill-out { text-decoration: underline dotted; } 
+    </style>
+  </head>
+  <body>
+    <div style="margin-top: 0.5em; margin-bottom: 0.5em">
+      <font color="black"><div class="ornament" style=";display:block;">
+        <p style="margin-top: 1em; margin-bottom: 1em">
+          <strong>Note. </strong>Convert this tm document to html, you will
+          reproduce the bug.
+        </p>
+      </div></font>
+    </div>
+  </body>
+</html>

--- a/TeXmacs/tests/html/2_18.html
+++ b/TeXmacs/tests/html/2_18.html
@@ -34,7 +34,7 @@
   </head>
   <body>
     <div style="margin-top: 0.5em; margin-bottom: 0.5em">
-      <font color="black"><div class="ornament" style=";display:block;">
+      <font color="black"><div class="ornament" style="background-color:#aff;display:block;">
         <p style="margin-top: 1em; margin-bottom: 1em">
           <strong>Note. </strong>Convert this tm document to html, you will
           reproduce the bug.

--- a/TeXmacs/tests/tm/2_18.tm
+++ b/TeXmacs/tests/tm/2_18.tm
@@ -1,0 +1,18 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|british>>
+
+<\body>
+  <with|ornament-color|#aff|<\ornamented>
+    <\note*>
+      Convert this tm document to html, you will reproduce the bug.
+    </note*>
+  </ornamented>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>


### PR DESCRIPTION
## What
+ `hash-map->list` is missing in S7 (it is a routine in GNU Guile, and the behavior in GNU Guile 1.8 and GNU Guile 3.x is not the same)
+ `string-prefix?` is missing in S7 and Mogan

## Why
To make `Tools->Create website` works!

## How to test
Manually convert `2_18.tm` to `2_18.html`

