### PR TITLE
[66_7] Data: stm data format as a plugin

### DIFF
--- a/TeXmacs/plugins/stm/progs/data/stm.scm
+++ b/TeXmacs/plugins/stm/progs/data/stm.scm
@@ -1,0 +1,38 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : data/stm.scm
+;; DESCRIPTION : stm data format
+;; COPYRIGHT   : (C) 2003  Joris van der Hoeven
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (data stm))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Scheme format for TeXmacs (no information loss)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (stm-recognizes? s)
+  (and (string? s) (string-starts? s "(document (TeXmacs")))
+
+(define-format stm
+  (:name "TeXmacs Scheme")
+  (:suffix "stm")
+  (:must-recognize stm-recognizes?))
+
+(converter texmacs-tree stm-document
+  (:function texmacs->stm))
+
+(converter stm-document texmacs-tree
+  (:function stm->texmacs))
+
+(converter texmacs-tree stm-snippet
+  (:function texmacs->stm))
+
+(converter stm-snippet texmacs-tree
+  (:function stm-snippet->texmacs))

--- a/TeXmacs/progs/convert/rewrite/init-rewrite.scm
+++ b/TeXmacs/progs/convert/rewrite/init-rewrite.scm
@@ -48,30 +48,6 @@
   (:function serialize-texmacs-snippet))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Scheme format for TeXmacs (no information loss)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define (stm-recognizes? s)
-  (and (string? s) (string-starts? s "(document (TeXmacs")))
-
-(define-format stm
-  (:name "TeXmacs Scheme")
-  (:suffix "stm")
-  (:must-recognize stm-recognizes?))
-
-(converter texmacs-tree stm-document
-  (:function texmacs->stm))
-
-(converter stm-document texmacs-tree
-  (:function stm->texmacs))
-
-(converter texmacs-tree stm-snippet
-  (:function texmacs->stm))
-
-(converter stm-snippet texmacs-tree
-  (:function stm-snippet->texmacs))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Generic source files
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -335,6 +335,7 @@
   gif jpeg png ppm tif webp xpm)
 
 (lazy-format (convert rewrite init-rewrite) texmacs verbatim)
+(lazy-format (data stm) stm)
 (lazy-format (convert latex init-latex) latex)
 (lazy-format (convert html init-html) html)
 (lazy-format (convert bibtex init-bibtex) bibtex)


### PR DESCRIPTION
## What
Move stm related format definition to plugin.

## Why
We need to implement the mgs format, which is similar to stm format.

## How to test
1. Launch Mogan Research
2. Open `Help->Welcome`
3. Save the doc as stm format