### PR TITLE
[66_7] Mogan Scheme data format (.mgs)

### DIFF
--- a/TeXmacs/plugins/mgs/progs/data/mgs.scm
+++ b/TeXmacs/plugins/mgs/progs/data/mgs.scm
@@ -26,13 +26,13 @@
   (:must-recognize mgs-recognizes?))
 
 (define (texmacs->mgs t)
-  (texmacs->stm (cork-tree->u8-tree t)))
+  (texmacs->stm (cork-tree->utf8-tree t)))
 
 (define (mgs->texmacs text)
-  (u8-tree->cork-tree (stm->texmacs text)))
+  (utf8-tree->cork-tree (stm->texmacs text)))
 
 (define (mgs-snippet->texmacs text)
-  (u8-tree->cork-tree (stm-snippet->texmacs text)))
+  (utf8-tree->cork-tree (stm-snippet->texmacs text)))
 
 (converter texmacs-tree mgs-document
   (:function texmacs->mgs))

--- a/TeXmacs/plugins/mgs/progs/data/mgs.scm
+++ b/TeXmacs/plugins/mgs/progs/data/mgs.scm
@@ -1,0 +1,42 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : data/mgs.scm
+;; DESCRIPTION : Mogan Scheme (.mgs) data format
+;; COPYRIGHT   : (C) 2003  Joris van der Hoeven
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (data mgs))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Scheme format for TeXmacs (no information loss)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (mgs-recognizes? s)
+  (and (string? s) (string-starts? s "(document (TeXmacs")))
+
+(define-format mgs
+  (:name "Mogan Scheme")
+  (:suffix "mgs")
+  (:must-recognize mgs-recognizes?))
+
+(define (texmacs->mgs t)
+)
+
+(converter texmacs-tree mgs-document
+  (:function texmacs->stm))
+
+(converter mgs-document texmacs-tree
+  (:function stm->texmacs))
+
+(converter texmacs-tree mgs-snippet
+  (:function texmacs->stm))
+
+(converter mgs-snippet texmacs-tree
+  (:function stm-snippet->texmacs))
+

--- a/TeXmacs/plugins/mgs/progs/data/mgs.scm
+++ b/TeXmacs/plugins/mgs/progs/data/mgs.scm
@@ -26,17 +26,22 @@
   (:must-recognize mgs-recognizes?))
 
 (define (texmacs->mgs t)
-)
+  (texmacs->stm (cork-tree->u8-tree t)))
+
+(define (mgs->texmacs text)
+  (u8-tree->cork-tree (stm->texmacs text)))
+
+(define (mgs-snippet->texmacs text)
+  (u8-tree->cork-tree (stm-snippet->texmacs text)))
 
 (converter texmacs-tree mgs-document
-  (:function texmacs->stm))
+  (:function texmacs->mgs))
 
 (converter mgs-document texmacs-tree
-  (:function stm->texmacs))
+  (:function mgs->texmacs))
 
 (converter texmacs-tree mgs-snippet
-  (:function texmacs->stm))
+  (:function texmacs->mgs))
 
 (converter mgs-snippet texmacs-tree
-  (:function stm-snippet->texmacs))
-
+  (:function mgs-snippet->texmacs))

--- a/TeXmacs/progs/init-research.scm
+++ b/TeXmacs/progs/init-research.scm
@@ -336,6 +336,7 @@
 
 (lazy-format (convert rewrite init-rewrite) texmacs verbatim)
 (lazy-format (data stm) stm)
+(lazy-format (data mgs) mgs)
 (lazy-format (convert latex init-latex) latex)
 (lazy-format (convert html init-html) html)
 (lazy-format (convert bibtex init-bibtex) bibtex)

--- a/src/Data/Tree/tree_traverse.cpp
+++ b/src/Data/Tree/tree_traverse.cpp
@@ -737,10 +737,24 @@ tree_utf8_to_cork (tree_u8 t) {
     return tree (utf8_to_cork (t->label));
   }
   else {
-    int  i, n= N (t);
-    tree t2 (t, n);
-    for (i= 0; i < n; i++)
+    int  t_N= N (t);
+    tree t2 (t, t_N);
+    for (int i= 0; i < t_N; i++)
       t2[i]= tree_utf8_to_cork (t[i]);
+    return t2;
+  }
+}
+
+tree_u8
+tree_cork_to_utf8 (tree t) {
+  if (is_atomic (t)) {
+    return tree (cork_to_utf8 (t->label));
+  }
+  else {
+    int  t_N= N (t);
+    tree t2 (t, t_N);
+    for (int i= 0; i < t_N; i++)
+      t2[i]= tree_cork_to_utf8 (t[i]);
     return t2;
   }
 }

--- a/src/Data/Tree/tree_traverse.hpp
+++ b/src/Data/Tree/tree_traverse.hpp
@@ -68,6 +68,7 @@ bool inside_contiguous_document (tree t, path op, path oq);
 array<tree> search_sections (tree t);
 path        previous_section (tree t, path p);
 
-tree tree_utf8_to_cork (tree_u8 t);
+tree    tree_utf8_to_cork (tree_u8 t);
+tree_u8 tree_cork_to_utf8 (tree t);
 
 #endif // defined TREE_TRAVERSE_H

--- a/src/Scheme/L4/glue_tree.lua
+++ b/src/Scheme/L4/glue_tree.lua
@@ -929,7 +929,7 @@ function main()
                 }
             },
             {
-                scm_name = "cork-tree->u8-tree",
+                scm_name = "cork-tree->utf8-tree",
                 cpp_name = "tree_cork_to_utf8",
                 ret_type = "tree",
                 arg_list = {
@@ -937,7 +937,7 @@ function main()
                 }
             },
             {
-                scm_name = "u8-tree->cork-tree",
+                scm_name = "utf8-tree->cork-tree",
                 cpp_name = "tree_utf8_to_cork",
                 ret_type = "tree",
                 arg_list = {

--- a/src/Scheme/L4/glue_tree.lua
+++ b/src/Scheme/L4/glue_tree.lua
@@ -928,6 +928,22 @@ function main()
                     "path"
                 }
             },
+            {
+                scm_name = "cork-tree->u8-tree",
+                cpp_name = "tree_cork_to_utf8",
+                ret_type = "tree",
+                arg_list = {
+                    "tree"
+                }
+            },
+            {
+                scm_name = "u8-tree->cork-tree",
+                cpp_name = "tree_utf8_to_cork",
+                ret_type = "tree",
+                arg_list = {
+                    "tree"
+                }
+            },
         }
     }
 end


### PR DESCRIPTION
## What
Mogan Scheme is serialized in UTF-8 while TeXmacs Scheme is serialized in cork.

## Why
Mogan Scheme format (.mgs) is the frontier of TMU format.

## How to test your changes?
Manually save a document to Mogan Scheme format.

The conversion between TeXmacs scheme and Mogan scheme depends on the conversion between Cork and UTF-8.
