### PR TITLE
[66_5] TMU: starts with <TMU|<tuple|1.0.1|2.1.2>>

### DIFF
--- a/src/Data/Convert/Mogan/from_tmu.cpp
+++ b/src/Data/Convert/Mogan/from_tmu.cpp
@@ -361,22 +361,27 @@ tree
 tmu_document_to_tree (string s) {
   tree error (ERROR, "bad format or data");
 
-  if (starts (s, "<TeXmacs|")) {
-    int i;
-    for (i= 9; i < N (s); i++)
-      if (s[i] == '>') break;
-    string version= s (9, i);
-    tree   doc    = tmu_to_tree (s, version);
+  if (starts (s, "<TMU|<tuple|")) {
+    int           i              = index_of (s, '>');
+    string        version_tuple  = s (N ("<TMU|<tuple|"), i);
+    array<string> version_arr    = tokenize (version_tuple, "|");
+    string        tmu_version    = version_arr[0];
+    string        texmacs_version= version_arr[1];
+    tree          doc            = tmu_to_tree (s, texmacs_version);
+
     if (is_compound (doc, "TeXmacs", 1) || is_expand (doc, "TeXmacs", 1) ||
         is_apply (doc, "TeXmacs", 1))
       doc= tree (DOCUMENT, doc);
+
     if (!is_document (doc)) return error;
+
     if (N (doc) == 0 || !is_compound (doc[0], "TeXmacs", 1)) {
       tree d (DOCUMENT);
-      d << compound ("TeXmacs", version);
+      d << compound ("TeXmacs", texmacs_version);
       d << A (doc);
       doc= d;
     }
+
     return doc;
   }
   return error;

--- a/src/Data/Convert/Mogan/to_tmu.cpp
+++ b/src/Data/Convert/Mogan/to_tmu.cpp
@@ -19,6 +19,8 @@ using namespace moebius;
 using lolly::data::as_hexadecimal;
 using moebius::drd::std_contains;
 
+const string TMU_VERSION= "1.0.1";
+
 /******************************************************************************
  * Conversion of TeXmacs trees to the present TeXmacs string format
  ******************************************************************************/
@@ -337,9 +339,9 @@ tmu_writer::write (tree t) {
 string
 tree_to_tmu (tree t) {
   if (!is_snippet (t)) {
-    int  i, n= N (t);
-    tree r (t, n);
-    for (i= 0; i < n; i++)
+    int  t_N= N (t);
+    tree r (t, t_N);
+    for (int i= 0; i < t_N; i++) {
       if (is_compound (t[i], "style", 1)) {
         tree style= t[i][0];
         if (is_func (style, TUPLE, 1)) style= style[0];
@@ -347,6 +349,7 @@ tree_to_tmu (tree t) {
         r[i][0]= style;
       }
       else r[i]= t[i];
+    }
     t= r;
   }
 

--- a/src/Data/Convert/Mogan/to_tmu.cpp
+++ b/src/Data/Convert/Mogan/to_tmu.cpp
@@ -348,6 +348,10 @@ tree_to_tmu (tree t) {
         r[i]   = copy (t[i]);
         r[i][0]= style;
       }
+      else if (is_compound (t[i], "TeXmacs")) {
+        string texmacs_version= as_string (t[i][0]);
+        r[i]= compound ("TMU", tuple (TMU_VERSION, texmacs_version));
+      }
       else r[i]= t[i];
     }
     t= r;


### PR DESCRIPTION
Here is the simplest TMU doc containing Hello:
```
<TMU|<tuple|1.0.1|2.1.2>>

<style|generic>

<\body>
  Hello
</body>
```

`1.0.1` is the version of TMU.

`2.1.2` is the version of GNU TeXmacs.