### PR TITLE
[66_9] TMU: switch to tmu for Save and Save as

### DIFF
--- a/TeXmacs/progs/texmacs/menus/file-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/file-menu.scm
@@ -177,7 +177,7 @@
 
 (menu-bind save-menu
   ("Save" (save-buffer))
-  ("Save as" (choose-file save-buffer-as "Save TeXmacs file" "texmacs"))
+  ("Save as" (choose-file save-buffer-as "Save TeXmacs file" "tmu"))
   ---
   (link export-top-menu)
   ---
@@ -266,7 +266,7 @@
         ("Clear menu" (forget-interactive "recent-buffer"))))
   ---
   ("Save" (save-buffer))
-  ("Save as" (choose-file save-buffer-as "Save TeXmacs file" "texmacs"))
+  ("Save as" (choose-file save-buffer-as "Save TeXmacs file" "tmu"))
   ---
   (link print-menu)
   ---

--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -190,7 +190,7 @@
     (cond ((url-scratch? name)
            (choose-file
              (lambda (x) (apply save-buffer-as-main (cons x opts)))
-             "Save TeXmacs file" "texmacs"))
+             "Save TeXmacs file" "tmu"))
           ((not (buffer-exists? name))
            (with msg `(concat "The buffer " ,vname " does not exist")
              (set-message msg "Save file")))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Temporarily switch to TMU for `File->Save` and `File->Save as`

## Why
Let the developers test tmu, and for v1.2.8, we will switch it back.

## How to test your changes?
Try `File->Save` or `File->Save as`.
