### PR TITLE
[24_x] Change HTML output from XHTML to HTML5

### DIFF
--- a/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
@@ -86,12 +86,15 @@
   (with ll (ahash-table->list (list->ahash-table l))
     (htmlout-text "<" (symbol->string s))
     (for-each htmlout-tag ll)
-    (htmlout-text ">")
+    (if (member s '(meta link img input br hr))
+        (htmlout-text " />")
+        (htmlout-text ">"))
     (htmlout-indent s 2)))
 
 (define (htmlout-close s)
-  (htmlout-indent-close s -2)
-  (htmlout-text "</" (symbol->string s) ">"))
+  (unless (member s '(meta link img input br hr))
+    (htmlout-indent-close s -2)
+    (htmlout-text "</" (symbol->string s) ">")))
 
 (define (htmlout-args-sub l big?)
   (if (nnull? l)
@@ -109,13 +112,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (htmlout-doctype l)
-  (define (helper x)
-    (if (string? x) (string-append "\"" x "\"") (symbol->string x)))
-  (let* ((l1 (map (lambda (x) (list " " (helper x))) l))
-         (l2 (apply append l1))
-         (l3 (append '("<!DOCTYPE") l2 '(">"))))
-    (apply output-lf-verbatim l3)
-    (output-lf)))
+  (output-lf-verbatim "<!DOCTYPE html>")
+  (output-lf))
 
 (define (htmlout x)
   (cond ((string? x) (htmlout-text x))
@@ -130,7 +128,7 @@
         ((func? x '*DOCTYPE*)
          (htmlout-doctype (cdr x)))
         ((== x '(br))
-         (htmlout-text "<br />"))
+         (htmlout-text "<br>"))
         ((null? (cdr x))
          (htmlout-open (car x))
          (htmlout-close (car x)))


### PR DESCRIPTION
## What
Change HTML output from XHTML to HTML5

## Why
Extended compatibility of exported HTML files

## How to test your changes?
You can export any tmu to HTML and put it in Google HTML5 validator to test  whether it is based on HTML5 or not.
Here is one of my test, and it has passed all the test. The HTML is include image, text, formula etc. :
![图片](https://github.com/user-attachments/assets/408ba5bf-a81e-4f97-bba0-5016aa48d0b4)
![图片](https://github.com/user-attachments/assets/4cb9ca03-da5d-4eff-bcfe-d25edfdddae9)

