### PR TITLE
[66_8] TMU: Deprecate \0,\n,\t,\r escaping

### DIFF
--- a/TeXmacs/tests/tmu/66_8_escape_0.tmu
+++ b/TeXmacs/tests/tmu/66_8_escape_0.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.0.2|1.2.8-alpha>>
+
+<style|<tuple|generic|no-page-numbers>>
+
+<\body>
+  First line:\0
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tmu/66_8_escape_n.tmu
+++ b/TeXmacs/tests/tmu/66_8_escape_n.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.0.2|1.2.8-alpha>>
+
+<style|<tuple|generic|no-page-numbers>>
+
+<\body>
+  First line:\n
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tmu/66_8_escape_r.tmu
+++ b/TeXmacs/tests/tmu/66_8_escape_r.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.0.2|1.2.8-alpha>>
+
+<style|<tuple|generic|no-page-numbers>>
+
+<\body>
+  First line:\r
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tmu/66_8_escape_t.tmu
+++ b/TeXmacs/tests/tmu/66_8_escape_t.tmu
@@ -1,0 +1,13 @@
+<TMU|<tuple|1.0.2|1.2.8-alpha2>>
+
+<style|<tuple|generic|no-page-numbers>>
+
+<\body>
+  First line:\t
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Data/Convert/Mogan/from_tmu.cpp
+++ b/src/Data/Convert/Mogan/from_tmu.cpp
@@ -80,7 +80,6 @@ tmu_reader::decode (string s) {
       if (s[i] == ';')
         ;
       else if (s[i] == 't') r << '\t';
-      else if (s[i] == 'r') r << '\r';
       else if (s[i] == '\\') r << '\\';
       else r << s[i];
     }

--- a/src/Data/Convert/Mogan/from_tmu.cpp
+++ b/src/Data/Convert/Mogan/from_tmu.cpp
@@ -81,7 +81,6 @@ tmu_reader::decode (string s) {
         ;
       else if (s[i] == 't') r << '\t';
       else if (s[i] == 'r') r << '\r';
-      else if (s[i] == 'n') r << '\n';
       else if (s[i] == '\\') r << '\\';
       else r << s[i];
     }

--- a/src/Data/Convert/Mogan/from_tmu.cpp
+++ b/src/Data/Convert/Mogan/from_tmu.cpp
@@ -79,7 +79,6 @@ tmu_reader::decode (string s) {
       i++;
       if (s[i] == ';')
         ;
-      else if (s[i] == 't') r << '\t';
       else if (s[i] == '\\') r << '\\';
       else r << s[i];
     }

--- a/src/Data/Convert/Mogan/from_tmu.cpp
+++ b/src/Data/Convert/Mogan/from_tmu.cpp
@@ -79,7 +79,6 @@ tmu_reader::decode (string s) {
       i++;
       if (s[i] == ';')
         ;
-      else if (s[i] == '0') r << '\0';
       else if (s[i] == 't') r << '\t';
       else if (s[i] == 'r') r << '\r';
       else if (s[i] == 'n') r << '\n';

--- a/src/Data/Convert/Mogan/to_tmu.cpp
+++ b/src/Data/Convert/Mogan/to_tmu.cpp
@@ -114,7 +114,6 @@ tmu_writer::write (string s, bool flag, bool encode_space) {
       if ((c == ' ') && (!encode_space)) write_space ();
       else {
         if (c == ' ') tmp << "\\ ";
-        else if (c == '\n') tmp << "\\n";
         else if (c == '\t') tmp << "\\t";
         else if (c == '\\') tmp << "\\\\";
         else if (c == '<') tmp << "\\<";

--- a/src/Data/Convert/Mogan/to_tmu.cpp
+++ b/src/Data/Convert/Mogan/to_tmu.cpp
@@ -114,7 +114,6 @@ tmu_writer::write (string s, bool flag, bool encode_space) {
       if ((c == ' ') && (!encode_space)) write_space ();
       else {
         if (c == ' ') tmp << "\\ ";
-        else if (c == '\t') tmp << "\\t";
         else if (c == '\\') tmp << "\\\\";
         else if (c == '<') tmp << "\\<";
         else if (c == '|') tmp << "\\|";

--- a/src/Data/Convert/Mogan/to_tmu.cpp
+++ b/src/Data/Convert/Mogan/to_tmu.cpp
@@ -116,7 +116,6 @@ tmu_writer::write (string s, bool flag, bool encode_space) {
         if (c == ' ') tmp << "\\ ";
         else if (c == '\n') tmp << "\\n";
         else if (c == '\t') tmp << "\\t";
-        else if (c == '\0') tmp << "\\0";
         else if (c == '\\') tmp << "\\\\";
         else if (c == '<') tmp << "\\<";
         else if (c == '|') tmp << "\\|";


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Deprecate the handling of `\0`.

## Why
Simplify the TMU format.

## How to test your changes?
Open `66_8_escape_0.tmu`, insert `a` after `\0`, and save the TMU doc. You will find `\0` will be replaced by `.

After this pull request, `\0` will be replaced by `0`.
