### PR TITLE
[24_10] Change header to HTML5 standard

### DIFF
--- a/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
@@ -109,13 +109,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (htmlout-doctype l)
-  (define (helper x)
-    (if (string? x) (string-append "\"" x "\"") (symbol->string x)))
-  (let* ((l1 (map (lambda (x) (list " " (helper x))) l))
-         (l2 (apply append l1))
-         (l3 (append '("<!DOCTYPE") l2 '(">"))))
-    (apply output-lf-verbatim l3)
-    (output-lf)))
+  (output-lf-verbatim "<!DOCTYPE html>")  ; change to HTML5 Header
+  (output-lf))
 
 (define (htmlout x)
   (cond ((string? x) (htmlout-text x))

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -292,22 +292,8 @@
 (define (tmhtml-finalize-document top)
   ;; @top must be a node produced by tmhtml-file
   "Prepare a XML document for serialization"
-  (define xmlns-attrs
-    '((xmlns "http://www.w3.org/1999/xhtml")
-      (xmlns:m "http://www.w3.org/1998/Math/MathML")
-      (xmlns:x "https://www.texmacs.org/2002/extensions")))
-  (define doctype-list
-    (let ((html       "-//W3C//DTD XHTML 1.1//EN")
-          (mathml     "-//W3C//DTD XHTML 1.1 plus MathML 2.0//EN")
-          (html-drd   "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd")
-          (mathml-drd (string-append
-                        "http://www.w3.org/2002/04/xhtml-math-svg/"
-                        "xhtml-math-svg.dtd")))
-      (if tmhtml-mathml? (list mathml mathml-drd) (list html html-drd))))
-  `(*TOP* (*PI* xml "version=\"1.0\" encoding=\"UTF-8\"")
-          (*DOCTYPE* html PUBLIC ,@doctype-list)
-          ,((cut sxml-set-attrs <> xmlns-attrs)
-            (sxml-strip-ns-prefix "h" (sxml-strip-ns-prefix "m" top)))))
+    `(*TOP* (*DOCTYPE* html)  ;; change to HTML5 header
+          ,(sxml-strip-ns-prefix "h" (sxml-strip-ns-prefix "m" top))))
 
 (define (tmhtml-finalize-selection l)
   ;; @l is a nodeset produced by any handler _but_ tmhtml-file


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Change header to HTML5 standard

## Why
1. Simplify DOCTYPE Declaration: HTML5 uses a much simpler <!DOCTYPE html> declaration compared to XHTML. This eliminates the need for additional identifiers and URLs.
2. Remove XML Namespaces: HTML5 doesn't require XML namespace declarations (xmlns). These were necessary for XHTML but are redundant in HTML5.
3. Streamline Header Information: HTML5 does not need the XML processing instruction (<?xml version="1.0" encoding="UTF-8"?>) used in XHTML.
4. Improve Compatibility: Transitioning to HTML5 ensures better compatibility with modern web standards and browsers, simplifying maintenance and future development.
