### PR TITLE
[24_11] HTML: Add encoding & self-close tags

### DIFF
--- a/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
@@ -86,15 +86,21 @@
   (with ll (ahash-table->list (list->ahash-table l))
     (htmlout-text "<" (symbol->string s))
     (for-each htmlout-tag ll)
-    (if (member s '(meta link img input br hr)) ;;Change <meta> tag to self-close
+    ;; If tag is a self-closing (void) element according to HTML5 spec, close it with "/>"
+    ;; "Void elements only have a start tag; end tags must not be specified for void elements."
+    ;; Reference: HTML5 spec, section 13.1.2 - Elements (https://html.spec.whatwg.org/multipage/syntax.html#void-elements)
+    (if (member s '(area base br col embed hr img input link meta source track wbr))
         (htmlout-text " />")
         (htmlout-text ">"))
     (htmlout-indent s 2)))
 
 (define (htmlout-close s)
-  (unless (member s '(meta link img input br hr)) ;;Change <meta> tag to self-close
-    (htmlout-indent-close s -2)
-    (htmlout-text "</" (symbol->string s) ">"))) 
+  ;; Do not close the tag if it is a self-closing (void) element
+  ;; Reference: HTML5 spec, section 13.1.2 - Elements (https://html.spec.whatwg.org/multipage/syntax.html#void-elements)
+  (if (not (member s '(area base br col embed hr img input link meta source track wbr)))
+      (begin
+        (htmlout-indent-close s -2)
+        (htmlout-text "</" (symbol->string s) ">"))))
 
 (define (htmlout-args-sub l big?)
   (if (nnull? l)

--- a/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/htmlout.scm
@@ -86,12 +86,15 @@
   (with ll (ahash-table->list (list->ahash-table l))
     (htmlout-text "<" (symbol->string s))
     (for-each htmlout-tag ll)
-    (htmlout-text ">")
+    (if (member s '(meta link img input br hr)) ;;Change <meta> tag to self-close
+        (htmlout-text " />")
+        (htmlout-text ">"))
     (htmlout-indent s 2)))
 
 (define (htmlout-close s)
-  (htmlout-indent-close s -2)
-  (htmlout-text "</" (symbol->string s) ">"))
+  (unless (member s '(meta link img input br hr)) ;;Change <meta> tag to self-close
+    (htmlout-indent-close s -2)
+    (htmlout-text "</" (symbol->string s) ">"))) 
 
 (define (htmlout-args-sub l big?)
   (if (nnull? l)

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -285,6 +285,7 @@
        (h:title ,@(tmhtml title))
        (h:meta (@ (name "generator")
                   (content ,(string-append "TeXmacs " (texmacs-version)))))
+       (h:meta (@ (charset "UTF-8")))
        ,css
        ,@xhead)
       (h:body ,@body))))

--- a/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
+++ b/TeXmacs/plugins/html/progs/convert/html/tmhtml.scm
@@ -284,7 +284,7 @@
       (h:head
        (h:title ,@(tmhtml title))
        (h:meta (@ (name "generator")
-                  (content ,(string-append "TeXmacs " (texmacs-version)))))
+                  (content ,(string-append "MoganSTEMSuite " (xmacs-version)))))
        (h:meta (@ (charset "UTF-8")))
        ,css
        ,@xhead)

--- a/TeXmacs/tests/24_10.scm
+++ b/TeXmacs/tests/24_10.scm
@@ -1,0 +1,151 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : test-htmlout.scm
+;; DESCRIPTION : Tests for htmlout.scm changes
+;; COPYRIGHT   : (C) 2024  ATQlove
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(load "./TeXmacs/plugins/html/progs/convert/html/htmlout.scm")
+(import (srfi srfi-78))
+
+;; Define a global variable to capture output
+(define *output* "")
+
+;; Define htmlout-text function to record output
+(define (htmlout-text . args)
+  (set! *output* (string-append *output* (apply string-append args))))
+
+(define (run-tests tests)
+  (for-each
+   (lambda (test)
+     (test))
+   tests))
+
+(define (assert-equal actual expected)
+  (if (equal? actual expected)
+      (display "Test passed.\n")
+      (begin
+        (display "Test failed.\n")
+        (display "Expected: ")
+        (display expected)
+        (display "\n")
+        (display "Actual: ")
+        (display actual)
+        (display "\n"))))
+
+;; Ensure attribute names are symbols and attribute values are strings
+(define (format-attributes attrs)
+  (map (lambda (attr) (list (car attr) (cdr attr))) attrs))
+
+(define tests
+  (list
+   ;; Group 1: Self-closing tags without attributes
+   ;; br
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'br '())
+     (htmlout-close 'br)
+     (assert-equal *output* "<br />\n"))
+   ;; hr
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'hr '())
+     (htmlout-close 'hr)
+     (assert-equal *output* "<hr />\n"))
+   ;; wbr
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'wbr '())
+     (htmlout-close 'wbr)
+     (assert-equal *output* "<wbr />\n"))
+
+
+   ;; Group 2: Self-closing tags with attributes
+   ;; area
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'area (format-attributes '((shape . "rect") (coords . "34,44,270,350") (alt . "Computer") (href . "computer.htm"))))
+     (htmlout-close 'area)
+     (assert-equal *output* "<area />\n"))
+   ;; base
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'base (format-attributes '((href . "https://example.com/"))))
+     (htmlout-close 'base)
+     (assert-equal *output* "<base />\n"))
+   ;; col
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'col (format-attributes '((span . "2") (class . "col-class"))))
+     (htmlout-close 'col)
+     (assert-equal *output* "<col />\n"))
+   ;; embed
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'embed (format-attributes '((src . "video.mp4") (type . "video/mp4"))))
+     (htmlout-close 'embed)
+     (assert-equal *output* "<embed />\n"))
+   ;; img
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'img (format-attributes '((src . "image.png") (alt . "image"))))
+     (htmlout-close 'img)
+     (assert-equal *output* "<img />\n"))
+   ;; input
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'input (format-attributes '((type . "text") (value . "sample input"))))
+     (htmlout-close 'input)
+     (assert-equal *output* "<input />\n"))
+   ;; link
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'link (format-attributes '((rel . "stylesheet") (href . "styles.css"))))
+     (htmlout-close 'link)
+     (assert-equal *output* "<link />\n"))
+   ;; meta
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'meta (format-attributes '((charset . "UTF-8"))))
+     (htmlout-close 'meta)
+     (assert-equal *output* "<meta />\n"))
+   ;; source
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'source (format-attributes '((src . "movie.mp4") (type . "video/mp4"))))
+     (htmlout-close 'source)
+     (assert-equal *output* "<source />\n"))
+   ;; track
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'track (format-attributes '((kind . "subtitles") (src . "subtitles_en.vtt") (srclang . "en") (label . "English"))))
+     (htmlout-close 'track)
+     (assert-equal *output* "<track />\n"))
+     
+
+   ;; Group 3: Non-self-closing tags example
+   ;; a
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'a (format-attributes '((href . "https://example.com") (title . "Example"))))
+     (htmlout-close 'a)
+     (assert-equal *output* "<a>\n\n</a>"))
+   ;; div
+   (lambda ()
+     (set! *output* "")  ; Reset output
+     (htmlout-open-tags 'div (format-attributes '((class . "container") (id . "main"))))
+     (htmlout-close 'div)
+     (assert-equal *output* "<div>\n\n</div>"))
+   ))
+
+(tm-define (test_24_10)
+  ;; Run all tests and count the number of tests
+  (let ((n (length tests)))
+    (run-tests tests)
+    (display* "Total: " (object->string n) " tests.\n")
+    (display "Test suite of 24_10: ok\n")))

--- a/TeXmacs/tests/24_11.scm
+++ b/TeXmacs/tests/24_11.scm
@@ -69,6 +69,9 @@
 
 
    ;; Group 2: Self-closing tags with attributes
+   ;; Tests for tags with attributes omit attributes in expected output because
+   ;; htmlout-open-tags and htmlout-close only handle tag opening/closing.
+   ;; Attributes are managed separately and have not been modified, so this test suite doesn't include attributes.
    ;; area
    (lambda ()
      (set! *output* "")  ; Reset output
@@ -200,3 +203,4 @@
   (if (check-failed?)
     (exit -1))
     (display "Test suite of 24_11 end\n"))
+    

--- a/TeXmacs/tests/24_11.scm
+++ b/TeXmacs/tests/24_11.scm
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; MODULE      : test-htmlout.scm
-;; DESCRIPTION : Tests for htmlout.scm changes
+;; MODULE      : 24_11.scm
+;; DESCRIPTION : Tests for self-close tags
 ;; COPYRIGHT   : (C) 2024  ATQlove
 ;;
 ;; This software falls under the GNU general public license version 3 or later.
@@ -10,13 +10,17 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Using (load ...) instead of (use-modules ...) allows overriding definitions 
+;; in the file. This lets us redefine functions like htmlout-text to capture 
+;; output for testing.
 (load "./TeXmacs/plugins/html/progs/convert/html/htmlout.scm")
 (import (srfi srfi-78))
 
 ;; Define a global variable to capture output
 (define *output* "")
 
-;; Define htmlout-text function to record output
+;; Override htmlout-text to capture output
+;; Necessary for testing by appending generated HTML to *output*
 (define (htmlout-text . args)
   (set! *output* (string-append *output* (apply string-append args))))
 
@@ -26,19 +30,6 @@
      (test))
    tests))
 
-(define (assert-equal actual expected)
-  (if (equal? actual expected)
-      (display "Test passed.\n")
-      (begin
-        (display "Test failed.\n")
-        (display "Expected: ")
-        (display expected)
-        (display "\n")
-        (display "Actual: ")
-        (display actual)
-        (display "\n"))))
-
-;; Ensure attribute names are symbols and attribute values are strings
 (define (format-attributes attrs)
   (map (lambda (attr) (list (car attr) (cdr attr))) attrs))
 
@@ -50,19 +41,31 @@
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'br '())
      (htmlout-close 'br)
-     (assert-equal *output* "<br />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<br />"))
    ;; hr
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'hr '())
      (htmlout-close 'hr)
-     (assert-equal *output* "<hr />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<hr />"))
    ;; wbr
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'wbr '())
      (htmlout-close 'wbr)
-     (assert-equal *output* "<wbr />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<wbr />"))
 
 
    ;; Group 2: Self-closing tags with attributes
@@ -71,61 +74,101 @@
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'area (format-attributes '((shape . "rect") (coords . "34,44,270,350") (alt . "Computer") (href . "computer.htm"))))
      (htmlout-close 'area)
-     (assert-equal *output* "<area />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<area />"))
    ;; base
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'base (format-attributes '((href . "https://example.com/"))))
      (htmlout-close 'base)
-     (assert-equal *output* "<base />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<base />"))
    ;; col
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'col (format-attributes '((span . "2") (class . "col-class"))))
      (htmlout-close 'col)
-     (assert-equal *output* "<col />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<col />"))
    ;; embed
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'embed (format-attributes '((src . "video.mp4") (type . "video/mp4"))))
      (htmlout-close 'embed)
-     (assert-equal *output* "<embed />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<embed />"))
    ;; img
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'img (format-attributes '((src . "image.png") (alt . "image"))))
      (htmlout-close 'img)
-     (assert-equal *output* "<img />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<img />"))
    ;; input
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'input (format-attributes '((type . "text") (value . "sample input"))))
      (htmlout-close 'input)
-     (assert-equal *output* "<input />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<input />"))
    ;; link
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'link (format-attributes '((rel . "stylesheet") (href . "styles.css"))))
      (htmlout-close 'link)
-     (assert-equal *output* "<link />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<link />"))
    ;; meta
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'meta (format-attributes '((charset . "UTF-8"))))
      (htmlout-close 'meta)
-     (assert-equal *output* "<meta />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<meta />"))
    ;; source
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'source (format-attributes '((src . "movie.mp4") (type . "video/mp4"))))
      (htmlout-close 'source)
-     (assert-equal *output* "<source />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<source />"))
    ;; track
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'track (format-attributes '((kind . "subtitles") (src . "subtitles_en.vtt") (srclang . "en") (label . "English"))))
      (htmlout-close 'track)
-     (assert-equal *output* "<track />\n"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<track />"))
      
 
    ;; Group 3: Non-self-closing tags example
@@ -134,18 +177,26 @@
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'a (format-attributes '((href . "https://example.com") (title . "Example"))))
      (htmlout-close 'a)
-     (assert-equal *output* "<a>\n\n</a>"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<a></a>"))
    ;; div
    (lambda ()
      (set! *output* "")  ; Reset output
      (htmlout-open-tags 'div (format-attributes '((class . "container") (id . "main"))))
      (htmlout-close 'div)
-     (assert-equal *output* "<div>\n\n</div>"))
+     (check
+      (begin
+        *output*)
+      =>
+      "<div></div>"))
    ))
 
-(tm-define (test_24_10)
-  ;; Run all tests and count the number of tests
-  (let ((n (length tests)))
-    (run-tests tests)
-    (display* "Total: " (object->string n) " tests.\n")
-    (display "Test suite of 24_10: ok\n")))
+(tm-define (test_24_11)
+  (run-tests tests)
+  (check-report)
+  (if (check-failed?)
+    (exit -1))
+    (display "Test suite of 24_11 end\n"))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
 Add encoding & meta tag self-close
## Why
TMU:
```
<TMU|<tuple|1.0.2|1.2.8-alpha2>>

<style|<tuple|generic|no-page-numbers>>

<\body>
  <doc-data|<doc-title|This is a title>>
</body>

<\initial>
  <\collection>
    <associate|page-medium|paper>
    <associate|page-screen-margin|false>
  </collection>
</initial>
```
Previous exported html:
```html
<title>This is a title</title>
    <meta content="TeXmacs 2.1.2" name="generator"></meta>
    <style type="text/css">
```
Now exported html:
```html
<title>This is a title</title>
    <meta content="TeXmacs 2.1.2" name="generator" />
    <meta charset="UTF-8" />
    <style type="text/css">
```
If you submit the previously exported XHTML standard html to w3c (https://validator.w3.org/), you will find the following error reported:
![图片](https://github.com/user-attachments/assets/cf9f43b1-5c95-4f31-85f5-46b9e6c7b20d)
![图片](https://github.com/user-attachments/assets/6c813668-11ef-4990-b00c-635d663f0ac3)

This error will not occur after the change.

