### PR TITLE
[43_2] Minor: Fix check count because of execution order

### DIFF
--- a/TeXmacs/tests/43_2.scm
+++ b/TeXmacs/tests/43_2.scm
@@ -24,12 +24,9 @@
   (with path (string-append "$TEXMACS_PATH/tests/tex/" path)
     (string-replace (string-load path)  "\r\n" "\n")))
 
-(tm-define (test_43_2)
-  (check
-    (export-as-latex-and-load "43_2.tm")
-    =>
-    (load-latex "43_2.tex"))
-
+(define (test_43_2)
+  (let ((exported (export-as-latex-and-load "43_2.tm"))
+        (expected (load-latex "43_2.tex")))
+    (check exported => expected))
   (check-report)
-  (if (check-failed?)
-    (exit -1)))
+  (if (check-failed?) (exit -1)))


### PR DESCRIPTION
## What
as title

## Why
The `load-buffer` glued scheme routines will result to a side effect on the S7 Scheme engine.

Use `let` to bind the evaluated value first, and then check. In other words, check after the side effect.

## How to test your changes?
```
xmake r 43_2
```
The success count should be 1 instead of 0.