### PR TITLE
[61_7] Goldfish: deprecate --texmacs and find the load path via relative path

### DIFF
--- a/TeXmacs/plugins/goldfish/goldfish/scheme/boot.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/scheme/boot.scm
@@ -1,0 +1,89 @@
+; 0-clause BSD
+; Adapted from S7 Scheme's r7rs.scm
+
+(define-macro (define-library libname . body) ; |(lib name)| -> environment
+  `(define ,(symbol (object->string libname))
+     (with-let (sublet (unlet)
+                         (cons 'import import)
+                         (cons '*export* ())
+                         (cons 'export (define-macro (,(gensym) . names)
+                                         `(set! *export* (append ',names *export*)))))
+       ,@body
+       (apply inlet
+              (map (lambda (entry)
+                     (if (or (member (car entry) '(*export* export import))
+                             (and (pair? *export*)
+                                  (not (member (car entry) *export*))))
+                         (values)
+                         entry))
+                   (curlet))))))
+
+(unless (defined? 'r7rs-import-library-filename)
+  (define (r7rs-import-library-filename libs)
+    (when (pair? libs)
+      (let ((lib-filename (let loop ((lib (if (memq (caar libs) '(only except prefix rename))
+                                              (cadar libs)
+                                              (car libs)))
+                                     (name ""))
+                            (set! name (string-append name (symbol->string (car lib))))
+                            (if (null? (cdr lib))
+                                (string-append name ".scm")
+                                (begin
+                                  (set! name (string-append name "/"))
+                                  (loop (cdr lib) name))))))
+        (unless (member lib-filename (*s7* 'file-names))
+          (load lib-filename)))
+      (r7rs-import-library-filename (cdr libs)))))
+
+(define-macro (import . libs)
+  `(begin
+     (r7rs-import-library-filename ',libs)
+     (varlet (curlet)
+       ,@(map (lambda (lib)
+                (case (car lib)
+                  ((only)
+                   `((lambda (e names)
+                       (apply inlet
+                              (map (lambda (name)
+                                     (cons name (e name)))
+                                   names)))
+                     (symbol->value (symbol (object->string (cadr ',lib))))
+                     (cddr ',lib)))
+                  ((except)
+                   `((lambda (e names)
+                       (apply inlet
+                              (map (lambda (entry)
+                                     (if (member (car entry) names)
+                                         (values)
+                                         entry))
+                                   e)))
+                     (symbol->value (symbol (object->string (cadr ',lib))))
+                     (cddr ',lib)))
+                  ((prefix)
+                   `((lambda (e prefx)
+                       (apply inlet
+                              (map (lambda (entry)
+                                     (cons (string->symbol 
+                                            (string-append (symbol->string prefx) 
+                                                           (symbol->string (car entry)))) 
+                                           (cdr entry)))
+                                   e)))
+                     (symbol->value (symbol (object->string (cadr ',lib))))
+                     (caddr ',lib)))
+                  ((rename)
+                   `((lambda (e names)
+                       (apply inlet
+                              (map (lambda (entry)
+                                     (let ((info (assoc (car entry) names)))
+                                       (if info
+                                           (cons (cadr info) (cdr entry))
+                                           entry))) 
+                                   e)))
+                     (symbol->value (symbol (object->string (cadr ',lib))))
+                     (cddr ',lib)))
+                  (else
+                   `(let ((sym (symbol (object->string ',lib))))
+                      (if (not (defined? sym))
+                          (format () "~A not loaded~%" sym)
+                          (symbol->value sym))))))
+              libs))))

--- a/TeXmacs/plugins/goldfish/progs/init-goldfish.scm
+++ b/TeXmacs/plugins/goldfish/progs/init-goldfish.scm
@@ -24,7 +24,7 @@
 (define (goldfish-launcher)
   (string-append
     (string-quote (url->system (find-binary-goldfish)))
-    " --texmacs "
+    " "
     (string-quote
       (string-append (url->system (get-texmacs-path))
                      "/plugins/goldfish/goldfish/tm-goldfish.scm"))))

--- a/TeXmacs/plugins/goldfish/src/goldfish.cpp
+++ b/TeXmacs/plugins/goldfish/src/goldfish.cpp
@@ -1,125 +1,43 @@
 /* 0-clause BSD */
 
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+
 #ifndef _MSC_VER
 #include <errno.h>
 #include <unistd.h>
 #endif
 
-#include "s7.h"
+#include <s7.h>
 
-char* str_r7rs_define_library=
-    "(define-macro (define-library libname . body) ; |(lib name)| -> "
-    "environment\n"
-    "  `(define ,(symbol (object->string libname))\n"
-    "     (with-let (sublet (unlet)\n"
-    "                         (cons 'import import)\n"
-    "                         (cons '*export* ())\n"
-    "                         (cons 'export (define-macro (,(gensym) . names)\n"
-    "                                         `(set! *export* (append ',names "
-    "*export*)))))\n"
-    "       ,@body\n"
-    "       (apply inlet\n"
-    "              (map (lambda (entry)\n"
-    "                     (if (or (member (car entry) '(*export* export "
-    "import))\n"
-    "                             (and (pair? *export*)\n"
-    "                                  (not (member (car entry) *export*))))\n"
-    "                         (values)\n"
-    "                         entry))\n"
-    "                   (curlet))))))\n";
-char* str_r7rs_library_filename=
-    "(unless (defined? 'r7rs-import-library-filename)\n"
-    "  (define (r7rs-import-library-filename libs)\n"
-    "    (when (pair? libs)\n"
-    "      (let ((lib-filename (let loop ((lib (if (memq (caar libs) '(only "
-    "except prefix rename))\n"
-    "                                              (cadar libs)\n"
-    "                                              (car libs)))\n"
-    "                                     (name \"\"))\n"
-    "                            (set! name (string-append name "
-    "(symbol->string (car lib))))\n"
-    "                            (if (null? (cdr lib))\n"
-    "                                (string-append name \".scm\")\n"
-    "                                (begin\n"
-    "                                  (set! name (string-append name \"/\"))\n"
-    "                                  (loop (cdr lib) name))))))\n"
-    "        (unless (member lib-filename (*s7* 'file-names))\n"
-    "          (load lib-filename)))\n"
-    "      (r7rs-import-library-filename (cdr libs)))))\n";
-char* str_r7rs_import=
-    "(define-macro (import . libs)\n"
-    "  `(begin\n"
-    "     (r7rs-import-library-filename ',libs)\n"
-    "     (varlet (curlet)\n"
-    "       ,@(map (lambda (lib)\n"
-    "                (case (car lib)\n"
-    "                  ((only)\n"
-    "                   `((lambda (e names)\n"
-    "                       (apply inlet\n"
-    "                              (map (lambda (name)\n"
-    "                                     (cons name (e name)))\n"
-    "                                   names)))\n"
-    "                     (symbol->value (symbol (object->string (cadr "
-    "',lib))))\n"
-    "                     (cddr ',lib)))\n"
-    "                  ((except)\n"
-    "                   `((lambda (e names)\n"
-    "                       (apply inlet\n"
-    "                              (map (lambda (entry)\n"
-    "                                     (if (member (car entry) names)\n"
-    "                                         (values)\n"
-    "                                         entry))\n"
-    "                                   e)))\n"
-    "                     (symbol->value (symbol (object->string (cadr "
-    "',lib))))\n"
-    "                     (cddr ',lib)))\n"
-    "                  ((prefix)\n"
-    "                   `((lambda (e prefx)\n"
-    "                       (apply inlet\n"
-    "                              (map (lambda (entry)\n"
-    "                                     (cons (string->symbol \n"
-    "                                            (string-append "
-    "(symbol->string prefx) \n"
-    "                                                           "
-    "(symbol->string (car entry)))) \n"
-    "                                           (cdr entry)))\n"
-    "                                   e)))\n"
-    "                     (symbol->value (symbol (object->string (cadr "
-    "',lib))))\n"
-    "                     (caddr ',lib)))\n"
-    "                  ((rename)\n"
-    "                   `((lambda (e names)\n"
-    "                       (apply inlet\n"
-    "                              (map (lambda (entry)\n"
-    "                                     (let ((info (assoc (car entry) "
-    "names)))\n"
-    "                                       (if info\n"
-    "                                           (cons (cadr info) (cdr "
-    "entry))\n"
-    "                                           entry))) \n"
-    "                                   e)))\n"
-    "                     (symbol->value (symbol (object->string (cadr "
-    "',lib))))\n"
-    "                     (cddr ',lib)))\n"
-    "                  (else\n"
-    "                   `(let ((sym (symbol (object->string ',lib))))\n"
-    "                      (if (not (defined? sym))\n"
-    "                          (format () \"~A not loaded~%\" sym)\n"
-    "                          (symbol->value sym))))))\n"
-    "              libs))))\n";
+using std::filesystem::exists;
+using std::filesystem::path;
 
 int
 main (int argc, char** argv) {
+  const path gf_root=
+      std::filesystem::path (argv[0]).parent_path ().parent_path ();
+  const path gf_lib = gf_root / "goldfish";
+  const path gf_boot= gf_lib / "scheme" / "boot.scm";
+
+  if (!exists (gf_lib)) {
+    std::cerr
+        << "The load path for Goldfish Scheme Standard Library does not exist"
+        << std::endl;
+  }
+  if (!exists (gf_root)) {
+    std::cerr << "The boot.scm for Goldfish Scheme does not exist" << std::endl;
+  }
+
   s7_scheme* sc;
   sc= s7_init ();
+  s7_load (sc, gf_boot.c_str ());
+  s7_add_to_load_path (sc, gf_lib.c_str ());
 
-  s7_eval_c_string (sc, str_r7rs_define_library);
-  s7_eval_c_string (sc, str_r7rs_library_filename);
-  s7_eval_c_string (sc, str_r7rs_import);
   if (argc >= 2) {
     if (strcmp (argv[1], "-e") == 0) /* repl -e '(+ 1 2)' */
     {
@@ -133,22 +51,9 @@ main (int argc, char** argv) {
       return (0);
     }
     errno= 0;
-    if (strcmp (argv[1], "--texmacs") == 0) {
-      const char*       env_key  = "TEXMACS_PATH";
-      const char*       env_value= getenv (env_key);
-      std::stringstream load_path;
-      load_path << env_value << "/plugins/goldfish/goldfish/";
-      s7_add_to_load_path (sc, load_path.str ().c_str ());
-      if (!s7_load (sc, argv[2])) {
-        fprintf (stderr, "%s: %s\n", strerror (errno), argv[2]);
-        return (2);
-      }
-    }
-    else {
-      if (!s7_load (sc, argv[1])) {
-        fprintf (stderr, "%s: %s\n", strerror (errno), argv[1]);
-        return (2);
-      }
+    if (!s7_load (sc, argv[1])) {
+      fprintf (stderr, "%s: %s\n", strerror (errno), argv[1]);
+      return (2);
     }
   }
   return 0;


### PR DESCRIPTION
## What
+ Deprecate `--texmacs`
+ Find the load-path for standard library and SRFI by relative path

## Why
+ Simplify the command line
+ Do not depend on the environment variable `TEXMACS_PATH`

## How to test
Build and launch Mogan Research, and then insert the Goldfish session to test