### PR TITLE
[24_14] Fix unhandled slots in headless mode

### DIFF
--- a/TeXmacs/tests/24_14.scm
+++ b/TeXmacs/tests/24_14.scm
@@ -2,7 +2,7 @@
   (display* "load-buffer: " tm-file "\n")
   (load-buffer tm-file)
   (display* "buffer-loaded: " tm-file "\n")
-  (export-buffer-main (current-buffer) (html-file) "html" ()))
+  (export-buffer-main (current-buffer) html-file "html" ()))
 
 (define (test_24_14)
   (tm->html "$TEXMACS_PATH/tests/tm/24_14.tm" "/tmp/test.html"))

--- a/TeXmacs/tests/24_14.scm
+++ b/TeXmacs/tests/24_14.scm
@@ -1,9 +1,39 @@
-(define (tm->html tm-file html-file)
-  (display* "load-buffer: " tm-file "\n")
-  (load-buffer tm-file)
-  (display* "buffer-loaded: " tm-file "\n")
-  (export-buffer-main (current-buffer) html-file "html" ()))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 24_14.scm
+;; DESCRIPTION : Test for 24_14
+;; COPYRIGHT   : (C) 2024  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (srfi srfi-78))
+
+(define (tm->html tm-file-url html-file-url)
+  ; Step 1: load the tm file
+  (display* "load-buffer: " tm-file-url "\n")
+  (load-buffer tm-file-url)
+  ; it will crash when loading the buffer in beamer style before this pull request
+  (display* "buffer-loaded: " tm-file-url "\n")
+
+  ; Step 2: cleaning for the html file url
+  (when (url-exists? html-file-url) (system-remove html-file-url))
+
+  ; Step 3: Export the buffer to the html file url
+  (display* "export buffer to: " html-file-url)
+  (export-buffer-main (current-buffer) html-file-url "html" ())
+
+  #t)
 
 (define (test_24_14)
   (debug-set "qt" #t)
-  (tm->html "$TEXMACS_PATH/tests/tm/24_14.tm" "/tmp/test.html"))
+  (let ((result
+         (tm->html (system->url "$TEXMACS_PATH/tests/tm/24_14.tm")
+                   (url-glue (url-temp) ".html"))))
+    (check result => #t)
+    (check-report)
+    (if (check-failed?) (exit -1))))

--- a/TeXmacs/tests/24_14.scm
+++ b/TeXmacs/tests/24_14.scm
@@ -1,5 +1,7 @@
 (define (tm->html tm-file html-file)
+  (display* "load-buffer: " tm-file "\n")
   (load-buffer tm-file)
+  (display* "buffer-loaded: " tm-file "\n")
   (export-buffer-main (current-buffer) (html-file) "html" ()))
 
 (define (test_24_14)

--- a/TeXmacs/tests/24_14.scm
+++ b/TeXmacs/tests/24_14.scm
@@ -5,4 +5,5 @@
   (export-buffer-main (current-buffer) html-file "html" ()))
 
 (define (test_24_14)
+  (debug-set "qt" #t)
   (tm->html "$TEXMACS_PATH/tests/tm/24_14.tm" "/tmp/test.html"))

--- a/TeXmacs/tests/24_14.scm
+++ b/TeXmacs/tests/24_14.scm
@@ -1,0 +1,6 @@
+(define (tm->html tm-file html-file)
+  (load-buffer tm-file)
+  (export-buffer-main (current-buffer) (html-file) "html" ()))
+
+(define (test_24_14)
+  (tm->html "$TEXMACS_PATH/tests/tm/24_14.tm" "/tmp/test.html"))

--- a/TeXmacs/tests/tm/24_14.tm
+++ b/TeXmacs/tests/tm/24_14.tm
@@ -1,36 +1,38 @@
 <TeXmacs|2.1.2>
 
-<style|<tuple|generic|chinese|doc>>
+<style|<tuple|beamer|chinese|doc>>
 
 <\body>
-  <tit|\<#7B2C\>0\<#8BB2\>\<#FF1A\>\<#521D\>\<#8BC6\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>>
+  <screens|<\shown>
+    <tit|\<#7B2C\>0\<#8BB2\>\<#FF1A\>\<#521D\>\<#8BC6\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>>
 
-  <\overlays|2|2>
-    <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-halign|c>|<cwith|2|-1|2|2|cell-halign|r>|<table|<row|<cell|\<#83DC\>\<#5355\>>|<cell|\<#5FEB\>\<#6377\>\<#952E\>>>|<row|<cell|<menu|Insert|Math|Inline
-    formula>>|<cell|<key|$>>>|<row|<cell|<menu|Insert|Math|Displayed
-    formula>>|<cell|<key|A-$>>>|<row|<cell|<menu|Insert|Math|Several
-    equations>>|<cell|<key|A-&>>>>>>>
-      \<#8FDB\>\<#5165\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>
-    </big-table>
-
-    \<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#6BB5\>\<#843D\>\<#FF0C\>\<#5B83\>\<#53EF\>\<#80FD\>\<#662F\>\<#4E00\>\<#884C\>\<#4E5F\>\<#53EF\>\<#80FD\>\<#662F\>\<#591A\>\<#884C\>\<#3002\>\<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#884C\>\<#5185\>\<#516C\>\<#5F0F\><math|\<alpha\>+\<beta\>>\<#FF0C\>\<#5B83\>\<#53EF\>\<#4EE5\>\<#88AB\>\<#5D4C\>\<#5165\>\<#5728\>\<#6BB5\>\<#843D\>\<#4E2D\>\<#3002\>
-
-    <\overlay-this|2>
-      <\big-table|<tabular|<tformat|<cwith|2|2|3|3|cell-row-span|1>|<cwith|2|2|3|3|cell-col-span|2>|<cwith|1|-1|3|4|cell-halign|c>|<table|<row|<cell|\<#7ED3\>\<#6784\>\<#53D8\>\<#5143\>\<#7684\>\<#8F6E\>\<#6362\>>|<cell|\<#884C\>\<#5185\>\<rightarrow\>\<#5355\>\<#884C\>>|<cell|<key|A-S-up>>|<cell|<key|A-S-down>>>|<row|<cell|\<#5207\>\<#6362\>>|<cell|\<#5355\>\<#884C\><math|\<rightarrow\>>\<#591A\>\<#884C\>>|<cell|<key|C-&>>|<cell|>>>>>>
-        \<#8F6E\>\<#6362\>\<#548C\>\<#5207\>\<#6362\>
+    <\overlays|2|2>
+      <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-halign|c>|<cwith|2|-1|2|2|cell-halign|r>|<table|<row|<cell|\<#83DC\>\<#5355\>>|<cell|\<#5FEB\>\<#6377\>\<#952E\>>>|<row|<cell|<menu|Insert|Math|Inline
+      formula>>|<cell|<key|$>>>|<row|<cell|<menu|Insert|Math|Displayed
+      formula>>|<cell|<key|A-$>>>|<row|<cell|<menu|Insert|Math|Several
+      equations>>|<cell|<key|A-&>>>>>>>
+        \<#8FDB\>\<#5165\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>
       </big-table>
 
-      <equation*|<around*|(|x+1|)><rsup|3>=<around*|(|x<rsup|2>+2*x+1|)>*<around*|(|x+1|)>=x<rsup|3>+3*x<rsup|2>+3*x+1>
-    </overlay-this|>
-  </overlays>
+      \<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#6BB5\>\<#843D\>\<#FF0C\>\<#5B83\>\<#53EF\>\<#80FD\>\<#662F\>\<#4E00\>\<#884C\>\<#4E5F\>\<#53EF\>\<#80FD\>\<#662F\>\<#591A\>\<#884C\>\<#3002\>\<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#884C\>\<#5185\>\<#516C\>\<#5F0F\><math|\<alpha\>+\<beta\>>\<#FF0C\>\<#5B83\>\<#53EF\>\<#4EE5\>\<#88AB\>\<#5D4C\>\<#5165\>\<#5728\>\<#6BB5\>\<#843D\>\<#4E2D\>\<#3002\>
 
-  \<#672C\>\<#9875\>\<#5E7B\>\<#706F\>\<#7247\>\<#FF1A\>\<#70B9\>\<#51FB\><strong|<menu|Help|Planet>>\<#FF0C\>\<#70B9\>\<#51FB\><strong|\<#4ECE\>\<#96F6\>\<#5F00\>\<#59CB\>\<#5B66\>\<#58A8\>\<#5E72\>\<#7406\>\<#5DE5\>\<#5957\>\<#4EF6\>>\<#5373\>\<#53EF\>\<#627E\>\<#5230\>
+      <\overlay-this|2>
+        <\big-table|<tabular|<tformat|<cwith|2|2|3|3|cell-row-span|1>|<cwith|2|2|3|3|cell-col-span|2>|<cwith|1|-1|3|4|cell-halign|c>|<table|<row|<cell|\<#7ED3\>\<#6784\>\<#53D8\>\<#5143\>\<#7684\>\<#8F6E\>\<#6362\>>|<cell|\<#884C\>\<#5185\>\<rightarrow\>\<#5355\>\<#884C\>>|<cell|<key|A-S-up>>|<cell|<key|A-S-down>>>|<row|<cell|\<#5207\>\<#6362\>>|<cell|\<#5355\>\<#884C\><math|\<rightarrow\>>\<#591A\>\<#884C\>>|<cell|<key|C-&>>|<cell|>>>>>>
+          \<#8F6E\>\<#6362\>\<#548C\>\<#5207\>\<#6362\>
+        </big-table>
 
-  \;
+        <equation*|<around*|(|x+1|)><rsup|3>=<around*|(|x<rsup|2>+2*x+1|)>*<around*|(|x+1|)>=x<rsup|3>+3*x<rsup|2>+3*x+1>
+      </overlay-this|>
+    </overlays>
 
-  \;
+    \<#672C\>\<#9875\>\<#5E7B\>\<#706F\>\<#7247\>\<#FF1A\>\<#70B9\>\<#51FB\><strong|<menu|Help|Planet>>\<#FF0C\>\<#70B9\>\<#51FB\><strong|\<#4ECE\>\<#96F6\>\<#5F00\>\<#59CB\>\<#5B66\>\<#58A8\>\<#5E72\>\<#7406\>\<#5DE5\>\<#5957\>\<#4EF6\>>\<#5373\>\<#53EF\>\<#627E\>\<#5230\>
 
-  \;
+    \;
+
+    \;
+
+    \;
+  </shown>>
 </body>
 
 <\initial>
@@ -48,10 +50,10 @@
   <\collection>
     <associate|auto-1|<tuple|1|1>>
     <associate|auto-2|<tuple|1|1>>
-    <associate|auto-3|<tuple|1|?>>
-    <associate|auto-4|<tuple|1|?>>
-    <associate|auto-5|<tuple|2|?>>
-    <associate|auto-6|<tuple|2|?>>
+    <associate|auto-3|<tuple|1|1>>
+    <associate|auto-4|<tuple|1|1>>
+    <associate|auto-5|<tuple|2|2>>
+    <associate|auto-6|<tuple|2|2>>
   </collection>
 </references>
 

--- a/TeXmacs/tests/tm/24_14.tm
+++ b/TeXmacs/tests/tm/24_14.tm
@@ -1,38 +1,36 @@
 <TeXmacs|2.1.2>
 
-<style|<tuple|beamer|chinese|doc>>
+<style|<tuple|generic|chinese|doc>>
 
 <\body>
-  <screens|<\shown>
-    <tit|\<#7B2C\>0\<#8BB2\>\<#FF1A\>\<#521D\>\<#8BC6\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>>
+  <tit|\<#7B2C\>0\<#8BB2\>\<#FF1A\>\<#521D\>\<#8BC6\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>>
 
-    <\overlays|2|2>
-      <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-halign|c>|<cwith|2|-1|2|2|cell-halign|r>|<table|<row|<cell|\<#83DC\>\<#5355\>>|<cell|\<#5FEB\>\<#6377\>\<#952E\>>>|<row|<cell|<menu|Insert|Math|Inline
-      formula>>|<cell|<key|$>>>|<row|<cell|<menu|Insert|Math|Displayed
-      formula>>|<cell|<key|A-$>>>|<row|<cell|<menu|Insert|Math|Several
-      equations>>|<cell|<key|A-&>>>>>>>
-        \<#8FDB\>\<#5165\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>
+  <\overlays|2|2>
+    <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-halign|c>|<cwith|2|-1|2|2|cell-halign|r>|<table|<row|<cell|\<#83DC\>\<#5355\>>|<cell|\<#5FEB\>\<#6377\>\<#952E\>>>|<row|<cell|<menu|Insert|Math|Inline
+    formula>>|<cell|<key|$>>>|<row|<cell|<menu|Insert|Math|Displayed
+    formula>>|<cell|<key|A-$>>>|<row|<cell|<menu|Insert|Math|Several
+    equations>>|<cell|<key|A-&>>>>>>>
+      \<#8FDB\>\<#5165\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>
+    </big-table>
+
+    \<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#6BB5\>\<#843D\>\<#FF0C\>\<#5B83\>\<#53EF\>\<#80FD\>\<#662F\>\<#4E00\>\<#884C\>\<#4E5F\>\<#53EF\>\<#80FD\>\<#662F\>\<#591A\>\<#884C\>\<#3002\>\<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#884C\>\<#5185\>\<#516C\>\<#5F0F\><math|\<alpha\>+\<beta\>>\<#FF0C\>\<#5B83\>\<#53EF\>\<#4EE5\>\<#88AB\>\<#5D4C\>\<#5165\>\<#5728\>\<#6BB5\>\<#843D\>\<#4E2D\>\<#3002\>
+
+    <\overlay-this|2>
+      <\big-table|<tabular|<tformat|<cwith|2|2|3|3|cell-row-span|1>|<cwith|2|2|3|3|cell-col-span|2>|<cwith|1|-1|3|4|cell-halign|c>|<table|<row|<cell|\<#7ED3\>\<#6784\>\<#53D8\>\<#5143\>\<#7684\>\<#8F6E\>\<#6362\>>|<cell|\<#884C\>\<#5185\>\<rightarrow\>\<#5355\>\<#884C\>>|<cell|<key|A-S-up>>|<cell|<key|A-S-down>>>|<row|<cell|\<#5207\>\<#6362\>>|<cell|\<#5355\>\<#884C\><math|\<rightarrow\>>\<#591A\>\<#884C\>>|<cell|<key|C-&>>|<cell|>>>>>>
+        \<#8F6E\>\<#6362\>\<#548C\>\<#5207\>\<#6362\>
       </big-table>
 
-      \<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#6BB5\>\<#843D\>\<#FF0C\>\<#5B83\>\<#53EF\>\<#80FD\>\<#662F\>\<#4E00\>\<#884C\>\<#4E5F\>\<#53EF\>\<#80FD\>\<#662F\>\<#591A\>\<#884C\>\<#3002\>\<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#884C\>\<#5185\>\<#516C\>\<#5F0F\><math|\<alpha\>+\<beta\>>\<#FF0C\>\<#5B83\>\<#53EF\>\<#4EE5\>\<#88AB\>\<#5D4C\>\<#5165\>\<#5728\>\<#6BB5\>\<#843D\>\<#4E2D\>\<#3002\>
+      <equation*|<around*|(|x+1|)><rsup|3>=<around*|(|x<rsup|2>+2*x+1|)>*<around*|(|x+1|)>=x<rsup|3>+3*x<rsup|2>+3*x+1>
+    </overlay-this|>
+  </overlays>
 
-      <\overlay-this|2>
-        <\big-table|<tabular|<tformat|<cwith|2|2|3|3|cell-row-span|1>|<cwith|2|2|3|3|cell-col-span|2>|<cwith|1|-1|3|4|cell-halign|c>|<table|<row|<cell|\<#7ED3\>\<#6784\>\<#53D8\>\<#5143\>\<#7684\>\<#8F6E\>\<#6362\>>|<cell|\<#884C\>\<#5185\>\<rightarrow\>\<#5355\>\<#884C\>>|<cell|<key|A-S-up>>|<cell|<key|A-S-down>>>|<row|<cell|\<#5207\>\<#6362\>>|<cell|\<#5355\>\<#884C\><math|\<rightarrow\>>\<#591A\>\<#884C\>>|<cell|<key|C-&>>|<cell|>>>>>>
-          \<#8F6E\>\<#6362\>\<#548C\>\<#5207\>\<#6362\>
-        </big-table>
+  \<#672C\>\<#9875\>\<#5E7B\>\<#706F\>\<#7247\>\<#FF1A\>\<#70B9\>\<#51FB\><strong|<menu|Help|Planet>>\<#FF0C\>\<#70B9\>\<#51FB\><strong|\<#4ECE\>\<#96F6\>\<#5F00\>\<#59CB\>\<#5B66\>\<#58A8\>\<#5E72\>\<#7406\>\<#5DE5\>\<#5957\>\<#4EF6\>>\<#5373\>\<#53EF\>\<#627E\>\<#5230\>
 
-        <equation*|<around*|(|x+1|)><rsup|3>=<around*|(|x<rsup|2>+2*x+1|)>*<around*|(|x+1|)>=x<rsup|3>+3*x<rsup|2>+3*x+1>
-      </overlay-this|>
-    </overlays>
+  \;
 
-    \<#672C\>\<#9875\>\<#5E7B\>\<#706F\>\<#7247\>\<#FF1A\>\<#70B9\>\<#51FB\><strong|<menu|Help|Planet>>\<#FF0C\>\<#70B9\>\<#51FB\><strong|\<#4ECE\>\<#96F6\>\<#5F00\>\<#59CB\>\<#5B66\>\<#58A8\>\<#5E72\>\<#7406\>\<#5DE5\>\<#5957\>\<#4EF6\>>\<#5373\>\<#53EF\>\<#627E\>\<#5230\>
+  \;
 
-    \;
-
-    \;
-
-    \;
-  </shown>>
+  \;
 </body>
 
 <\initial>

--- a/TeXmacs/tests/tm/24_14.tm
+++ b/TeXmacs/tests/tm/24_14.tm
@@ -1,0 +1,81 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|beamer|chinese|doc>>
+
+<\body>
+  <screens|<\shown>
+    <tit|\<#7B2C\>0\<#8BB2\>\<#FF1A\>\<#521D\>\<#8BC6\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>>
+
+    <\overlays|2|2>
+      <\big-table|<tabular|<tformat|<cwith|1|1|1|-1|cell-halign|c>|<cwith|2|-1|2|2|cell-halign|r>|<table|<row|<cell|\<#83DC\>\<#5355\>>|<cell|\<#5FEB\>\<#6377\>\<#952E\>>>|<row|<cell|<menu|Insert|Math|Inline
+      formula>>|<cell|<key|$>>>|<row|<cell|<menu|Insert|Math|Displayed
+      formula>>|<cell|<key|A-$>>>|<row|<cell|<menu|Insert|Math|Several
+      equations>>|<cell|<key|A-&>>>>>>>
+        \<#8FDB\>\<#5165\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>
+      </big-table>
+
+      \<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#6BB5\>\<#843D\>\<#FF0C\>\<#5B83\>\<#53EF\>\<#80FD\>\<#662F\>\<#4E00\>\<#884C\>\<#4E5F\>\<#53EF\>\<#80FD\>\<#662F\>\<#591A\>\<#884C\>\<#3002\>\<#8FD9\>\<#662F\>\<#4E00\>\<#4E2A\>\<#884C\>\<#5185\>\<#516C\>\<#5F0F\><math|\<alpha\>+\<beta\>>\<#FF0C\>\<#5B83\>\<#53EF\>\<#4EE5\>\<#88AB\>\<#5D4C\>\<#5165\>\<#5728\>\<#6BB5\>\<#843D\>\<#4E2D\>\<#3002\>
+
+      <\overlay-this|2>
+        <\big-table|<tabular|<tformat|<cwith|2|2|3|3|cell-row-span|1>|<cwith|2|2|3|3|cell-col-span|2>|<cwith|1|-1|3|4|cell-halign|c>|<table|<row|<cell|\<#7ED3\>\<#6784\>\<#53D8\>\<#5143\>\<#7684\>\<#8F6E\>\<#6362\>>|<cell|\<#884C\>\<#5185\>\<rightarrow\>\<#5355\>\<#884C\>>|<cell|<key|A-S-up>>|<cell|<key|A-S-down>>>|<row|<cell|\<#5207\>\<#6362\>>|<cell|\<#5355\>\<#884C\><math|\<rightarrow\>>\<#591A\>\<#884C\>>|<cell|<key|C-&>>|<cell|>>>>>>
+          \<#8F6E\>\<#6362\>\<#548C\>\<#5207\>\<#6362\>
+        </big-table>
+
+        <equation*|<around*|(|x+1|)><rsup|3>=<around*|(|x<rsup|2>+2*x+1|)>*<around*|(|x+1|)>=x<rsup|3>+3*x<rsup|2>+3*x+1>
+      </overlay-this|>
+    </overlays>
+
+    \<#672C\>\<#9875\>\<#5E7B\>\<#706F\>\<#7247\>\<#FF1A\>\<#70B9\>\<#51FB\><strong|<menu|Help|Planet>>\<#FF0C\>\<#70B9\>\<#51FB\><strong|\<#4ECE\>\<#96F6\>\<#5F00\>\<#59CB\>\<#5B66\>\<#58A8\>\<#5E72\>\<#7406\>\<#5DE5\>\<#5957\>\<#4EF6\>>\<#5373\>\<#53EF\>\<#627E\>\<#5230\>
+
+    \;
+
+    \;
+
+    \;
+  </shown>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|info-flag|minimal>
+    <associate|page-height|auto>
+    <associate|page-medium|beamer>
+    <associate|page-screen-margin|false>
+    <associate|page-type|16:9>
+    <associate|page-width|auto>
+  </collection>
+</initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|1|1>>
+    <associate|auto-2|<tuple|1|1>>
+    <associate|auto-3|<tuple|1|?>>
+    <associate|auto-4|<tuple|1|?>>
+    <associate|auto-5|<tuple|2|?>>
+    <associate|auto-6|<tuple|2|?>>
+  </collection>
+</references>
+
+<\auxiliary>
+  <\collection>
+    <\associate|idx>
+      <tuple|<tuple|<with|font-family|<quote|ss>|\<#63D2\>\<#5165\>>|<with|font-family|<quote|ss>|\<#6570\>\<#5B66\>>|<with|font-family|<quote|ss>|\<#884C\>\<#5185\>\<#516C\>\<#5F0F\>>>|<pageref|auto-2>>
+
+      <tuple|<tuple|<with|font-family|<quote|ss>|\<#63D2\>\<#5165\>>|<with|font-family|<quote|ss>|\<#6570\>\<#5B66\>>|<with|font-family|<quote|ss>|\<#5355\>\<#884C\>\<#516C\>\<#5F0F\>>>|<pageref|auto-3>>
+
+      <tuple|<tuple|<with|font-family|<quote|ss>|\<#63D2\>\<#5165\>>|<with|font-family|<quote|ss>|\<#6570\>\<#5B66\>>|<with|font-family|<quote|ss>|\<#591A\>\<#884C\>\<#516C\>\<#5F0F\>>>|<pageref|auto-4>>
+
+      <tuple|<tuple|<with|font-family|<quote|ss>|\<#5E2E\>\<#52A9\>>|<with|font-family|<quote|ss>|\<#58A8\>\<#5BA2\>\<#661F\>\<#7403\>>>|<pageref|auto-6>>
+    </associate>
+    <\associate|table>
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|1>|>
+        \<#8FDB\>\<#5165\>\<#6570\>\<#5B66\>\<#6A21\>\<#5F0F\>
+      </surround>|<pageref|auto-1>>
+
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|2>|>
+        \<#8F6E\>\<#6362\>\<#548C\>\<#5207\>\<#6362\>
+      </surround>|<pageref|auto-5>>
+    </associate>
+  </collection>
+</auxiliary>

--- a/src/Plugins/Qt/qt_widget.hpp
+++ b/src/Plugins/Qt/qt_widget.hpp
@@ -328,6 +328,15 @@ public:
       check_type_id<int> (type_id, s);
       return close_box<int> (id++);
     }
+    case SLOT_MAIN_ICONS_VISIBILITY: {
+      return close_box<bool> (false);
+    }
+    case SLOT_POSITION: {
+      return close_box<coord2> (coord2 (0, 0));
+    }
+    case SLOT_SIZE: {
+      return close_box<coord2> (coord2 (800, 600));
+    }
     default:
       return qt_widget_rep::query (s, type_id);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Fix crash when exporting tm/tmu docs to HTML with the `-headless` option

## Why
When exporting TeXmacs/Mogan documents to html and using the `-headless` option, Mogan will crash for several documents in planet. That's why we added a blacklist in https://github.com/XmacsLabs/planet/pull/37/

## How to test your changes?
```
xmake r 24_14
```
