### PR TITLE
[75_32] Revert: Upgrade to lolly 1.4.27

### DIFF
--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -24,7 +24,7 @@ package("lolly")
 
     add_urls("https://github.com/XmacsLabs/lolly.git")
     add_urls("https://gitee.com/XmacsLabs/lolly.git")
-    add_versions("1.4.27", "v1.4.27")
+    add_versions("1.4.26", "v1.4.26")
 
     add_deps("tbox")
     if not is_plat("wasm") then

--- a/xmake/vars.lua
+++ b/xmake/vars.lua
@@ -19,7 +19,7 @@ STABLE_VERSION = TEXMACS_VERSION
 STABLE_RELEASE = 1
 
 -- XmacsLabs dependencies
-LOLLY_VERSION = "1.4.27"
+LOLLY_VERSION = "1.4.26"
 
 -- Third-party dependencies
 S7_VERSION = "20240702"


### PR DESCRIPTION
This reverts commit c5710ef08031c909e3f2f0a9e3a572af1bf91279.

