### PR TITLE
[61_16] Education: fix typo in edu-edit

### DIFF
--- a/TeXmacs/progs/education/edu-edit.scm
+++ b/TeXmacs/progs/education/edu-edit.scm
@@ -314,7 +314,7 @@
 
 (tm-define (structured-insert-vertical t downwards?)
   (:require (mc-context? t))
-  (insert-mc-field t forwards?))
+  (insert-mc-field t downwards?))
 
 (define (remove-mc-field t forwards? structured?)
   (let* ((i (tree-down-index t))
@@ -353,7 +353,7 @@
 
 (tm-define (structured-remove-vertical t downwards?)
   (:require (mc-context? t))
-  (remove-mc-field t forwards? #t))
+  (remove-mc-field t downwards? #t))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Toggling buttons


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What

fix mismatched parameter names

## Why
```
;unbound variable forwards? in (if (mc-context? t) (insert-mc-field t forwards?) (former t downwards?))
;    (if (mc-context? t) (insert-mc-field...
;    C:\Users\jingkaimori\Documents\Source\mogan\build\packages\app.mogan\data\progs\education\edu-edit.scm, line 316, position: 0
; (if (mc-context? t) (insert-mc-field t fo... ; t: <tree <mc|<mc-field|false|\<#67...
;                                              downwards?: #t
; ((r (cpp-get-preference which (if s? def ...
; ((with after? (in-inactive-reference?) (w... ; before?: #f
```

## How to test your changes?

In course style, insert multichoice box, then insert item vertically (only possible with shortcuts, i.e. alt+uparrow on windows)
