### PR TITLE
[81_5] Keep tab-title and doc-path of tab pages untranslated

### DIFF
--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -25,7 +25,7 @@
         (active?   (== (current-buffer) buf)))
       (tab-page
         (eval buf)
-        ((balloon (eval tab-title) (eval doc-path)) (switch-to-buffer* buf))
+        ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path))) (switch-to-buffer* buf))
         ((balloon (icon "tm_cancel.xpm") "Close") (safely-kill-buffer-by-url buf))
         (eval active?)
       ))))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Keep tab-title and doc-path of tab pages untranslated.
## How to test your changes?
### Before:
The tab title and doc path of file `session.tm` are translated into Chinese which is not expected.
![屏幕截图 2024-08-03 202324](https://github.com/user-attachments/assets/4915ebca-517b-4c94-8020-f87244db16fa)

### After:
![屏幕截图 2024-08-03 202240](https://github.com/user-attachments/assets/895cc561-911b-419c-be65-29d5eb74c69b)
