### PR TITLE
[81_6] Quickly hide the active tab after closing

### DIFF
--- a/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
+++ b/TeXmacs/progs/texmacs/menus/tabpage-menu.scm
@@ -25,7 +25,7 @@
         (active?   (== (current-buffer) buf)))
       (tab-page
         (eval buf)
-        ((balloon (eval tab-title) (eval doc-path)) (switch-to-buffer* buf))
+        ((balloon (eval `(verbatim ,tab-title)) (eval `(verbatim ,doc-path))) (switch-to-buffer* buf))
         ((balloon (icon "tm_cancel.xpm") "Close") (safely-kill-buffer-by-url buf))
         (eval active?)
       ))))

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -43,6 +43,7 @@ deleted. You can see this behavior in the source code of QWidgetAction.
  */
 class QTMTabPageAction : public QAction {
   Q_OBJECT
+
 public:
   explicit QTMTabPageAction (QWidget* p_widget) : m_widget (p_widget) {}
   QWidget* const m_widget;
@@ -64,7 +65,7 @@ public:
   inline void setRowHeight (int p_height) { m_rowHeight= p_height; }
   void        replaceTabPages (QList<QAction*>* p_src);
 
-protected:
+private:
   void removeAllTabPages ();
   void extractTabPages (QList<QAction*>* p_src);
   void adjustHeight (int p_rowCount);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Quickly hide the active tab after closing
## Why
![image](https://github.com/user-attachments/assets/52a158e7-e740-4082-b032-54dd145d7449)

## How to test your changes?
### Before
![2024-08-04143504-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/173c7580-4c9f-45bb-91e9-fd291c00a808)
### After
![2024-08-04143106-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ca33ee32-c79e-4704-8006-9acd88330e75)


