### PR TITLE
[80_1] Fix math bracket fonts in Chinese docs

### DIFF
--- a/TeXmacs/tests/tm/80_1.tm
+++ b/TeXmacs/tests/tm/80_1.tm
@@ -1,0 +1,46 @@
+<TeXmacs|2.1.2>
+
+<style|<tuple|generic|no-page-numbers|chinese>>
+
+<\body>
+  <strong|Inline math mode:>
+
+  <math|sin<around*|(|x|)><rsup|2>+cos<around*|(|x|)><rsup|2>=1>
+
+  <\math>
+    e<rsup|i\<theta\>>=cos<around*|(|\<theta\>|)>+i
+    sin<around*|(|\<theta\>|)>
+  </math>
+
+  <math|<around*|[|n|]>=<around*|{|1,2,3,\<cdots\>,n|}>>
+
+  <strong|Display math mode:>
+
+  <\equation*>
+    <big|oint><rsub|\<gamma\>>f*<around*|(|z|)>d z=2\<pi\>
+    i<big|sum><rsub|k=1><rsup|n>I<around*|(|\<gamma\>,a<rsub|k>|)>Res<around*|(|f,a<rsub|k>|)>
+  </equation*>
+
+  <\equation*>
+    exp<around*|(|x|)>=<big|sum><rsub|k=0><rsup|\<infty\>><frac|x<rsup|k>|k!>
+  </equation*>
+
+  \;
+
+  <strong|Text:>
+
+  abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+  1234567890.:,;'"(!?)+-*/=
+
+  (The quick brown fox jumps over the lazy dog)\ 
+
+  \<#FF08\>\<#4E2D\>\<#56FD\>\<#667A\>\<#9020\>\<#FF0C\>\<#60E0\>\<#53CA\>\<#5168\>\<#7403\>\<#FF09\>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -1612,15 +1612,15 @@ smart_font_bis (string family, string variant, string series, string shape,
   if (starts (family, "sys-")) {
     if (family == "sys-chinese") {
       string name= default_chinese_font_name ();
-      family     = "cjk=" * name * ",roman";
+      family     = "math=roman,cjk=" * name * ",roman";
     }
     if (family == "sys-japanese") {
       string name= default_japanese_font_name ();
-      family     = "cjk=" * name * ",roman";
+      family     = "math=roman,cjk=" * name * ",roman";
     }
     if (family == "sys-korean") {
       string name= default_korean_font_name ();
-      family     = "cjk=" * name * ",roman";
+      family     = "math=roman,cjk=" * name * ",roman";
     }
   }
   family= tex_gyre_fix (family, series, shape);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Fix math bracket fonts in Chinese docs.
## Why
In Chinese documents, some math brackets display improperly.
## How to test your changes?
Open `TeXmacs/tests/tm/80_1.tm` file in mogan.

Before (wrong):
<img src="https://github.com/user-attachments/assets/fb443910-3bae-4d0b-b30c-2935d2b24b49" width="500" alt="image">
After (right):
<img src="https://github.com/user-attachments/assets/b4ed411f-4426-4d3e-9acb-70e2408a3321" width="500" alt="image">


