### PR TITLE
[61_5] Gnuplot: initial rework

### DIFF
--- a/TeXmacs/plugins/gnuplot/goldfish/tm-gnuplot.scm
+++ b/TeXmacs/plugins/gnuplot/goldfish/tm-gnuplot.scm
@@ -1,0 +1,76 @@
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(import (texmacs protocol)
+        (liii os)
+        (liii uuid))
+
+(define (gnuplot-welcome)
+  (flush-prompt "> ")
+  (flush-verbatim
+    (string-append
+      "Gnuplot session by XmacsLabs\n"
+      "implemented on Goldfish Scheme (" (version) ")")))
+
+(define (gnuplot-read-code)
+  (define (read-code code)
+    (let ((line (read-line)))
+      (if (string=? line "<EOF>\n")
+          code
+          (read-code (string-append code line)))))
+
+  (read-code ""))
+
+(define (gen-temp-path)
+  (string-append (os-temp-dir) "/" (uuid4)))
+
+(define (gen-png-precode png-path)
+  (string-append
+    "reset\n"
+    "set terminal pngcairo enhanced\n"
+    "set output\n"
+    "set output '" png-path "'\n"
+    "set size 1,1\n"))
+
+(define (gnuplot-dump-code code-path png-path code)
+  (with-output-to-file code-path
+    (lambda ()
+      (display (gen-png-precode png-path))
+      (display code))))
+
+(define (gnuplot-plot code-path)
+  (os-call (string-append "gnuplot" " " "-c" " " code-path)))
+
+(define (eval-and-print code)
+  (let* ((temp-path (gen-temp-path))
+         (png-path (string-append temp-path ".png"))
+         (code-path (string-append temp-path ".gnuplot")))
+    (gnuplot-dump-code code-path png-path code)
+    (gnuplot-plot code-path)
+    (flush-file png-path)))
+
+(define (read-eval-print)
+  (let ((code (gnuplot-read-code)))
+    (if (string=? code "")
+      #t
+      (eval-and-print code))))
+
+(define (gnuplot-repl)
+  (begin (read-eval-print)
+         (gnuplot-repl)))
+
+(gnuplot-welcome)
+(gnuplot-repl)

--- a/TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm
+++ b/TeXmacs/plugins/gnuplot/progs/init-gnuplot.scm
@@ -1,0 +1,37 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : init-gnuplot.scm
+;; DESCRIPTION : Initialize Goldfish plugin
+;; COPYRIGHT   : (C) 2024   Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (binary gnuplot)
+             (binary goldfish))
+
+(lazy-format (data r7rs) r7rs)
+
+(define (gnuplot-serialize lan t)
+  (let* ((u (pre-serialize lan t))
+         (s (texmacs->code (stree->tree u) "utf-8")))
+    (string-append s "\n<EOF>\n")))
+
+(define (gnuplot-launcher)
+  (string-append
+    (string-quote (url->system (find-binary-goldfish)))
+    " "
+    (string-quote
+      (string-append (url->system (get-texmacs-path))
+                     "/plugins/gnuplot/goldfish/tm-gnuplot.scm"))))
+
+(plugin-configure gnuplot
+  (:require (and (has-binary-goldfish?) (has-binary-gnuplot?)))
+  (:launch ,(gnuplot-launcher))
+  (:serializer ,gnuplot-serialize)
+  (:session "Gnuplot"))
+

--- a/TeXmacs/plugins/goldfish/goldfish/texmacs/protocol.scm
+++ b/TeXmacs/plugins/goldfish/goldfish/texmacs/protocol.scm
@@ -16,7 +16,7 @@
 
 (define-library (texmacs protocol)
 (export data-begin data-end data-escape 
-        flush-verbatim flush-prompt flush-scheme)
+        flush-verbatim flush-prompt flush-scheme flush-file)
 (begin
 
 (define (data-begin)
@@ -42,6 +42,9 @@
 
 (define (flush-prompt msg)
   (flush-any (string-append "prompt#" msg)))
+
+(define (flush-file path)
+  (flush-any (string-append "file:" path)))
 
 ) ; end of begin
 ) ; end of define-library


### PR DESCRIPTION
## What
Reimplement the Gnuplot plugin in Goldfish Scheme.

## Why
1. Some people have trouble installing Python on Windows, they are complaining that they failed to get the gnuplot plugin work on Windows
2. Less deps, because goldfish is built-in, we only need to install gnuplot

## How to test your changes?
Launch the gnuplot session.
