### PR TITLE
[19_8] Language dic: fix for the UTF-8 encoding change

### DIFF
--- a/TeXmacs/tests/19_8.scm
+++ b/TeXmacs/tests/19_8.scm
@@ -1,0 +1,21 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 19_8.scm
+;; DESCRIPTION : Tests for translation
+;; COPYRIGHT   : (C) 2024  ATQlove
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(check-set-mode! 'report-failed)
+
+(check (translate-from-to "theorem" "english" "french") => (utf8->cork "théorème"))
+(check (translate-from-to "theorem" "english" "chinese") => (utf8->cork "定理"))
+
+(define (test_19_8)
+  (check-report))

--- a/TeXmacs/tests/tmu/19_8_french.tmu
+++ b/TeXmacs/tests/tmu/19_8_french.tmu
@@ -1,0 +1,30 @@
+<TMU|<tuple|1.0.3|1.2.9-rc3>>
+
+<style|<tuple|generic|no-page-numbers|french>>
+
+<\body>
+  Here is the bug:
+
+  <\theorem>
+    \;
+  </theorem>
+
+  <\session|scheme|default>
+    <\unfolded-io|Scheme] >
+      (translate-from-to "theorem" "english" "french")
+    <|unfolded-io>
+      théorème
+    </unfolded-io>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/System/Language/dictionary.cpp
+++ b/src/System/Language/dictionary.cpp
@@ -60,11 +60,7 @@ dictionary_rep::load (url u) {
       if (is_quoted (l)) l= scm_unquote (l);
       string r= t[i][1]->label;
       if (is_quoted (r)) r= scm_unquote (r);
-      if (to == "chinese" || to == "japanese" || to == "korean" ||
-          to == "taiwanese" || to == "russian" || to == "ukrainian" ||
-          to == "bulgarian" || to == "german" || to == "greek" ||
-          to == "slovak")
-        r= utf8_to_cork (r);
+      r        = utf8_to_cork (r);
       table (l)= r;
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
as title

## Why
The encoding change of the scheme file  breaks the translation mechanism.

## How to test your changes?
```
xmake r 19_8
```
or open 19_8_french.tmu
