### PR TITLE
[81_8] Set tab bar default visiable and align tab title to the left

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-view.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-view.scm
@@ -51,7 +51,7 @@
 (define-preferences
   ("header" "on" notify-header)
   ("main icon bar" "on" notify-icon-bar)
-  ("tab bar" "off" notify-icon-bar)
+  ("tab bar" "on" notify-icon-bar)
   ("mode dependent icons" "on" notify-icon-bar)
   ("focus dependent icons" "on" notify-icon-bar)
   ("user provided icons" "off" notify-icon-bar)

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -104,7 +104,7 @@ QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
     QTMTabPage* tab= m_tabPageList[i];
     if (g_mostRecentlyClosedTab == tab->m_bufferUrl) {
       // this tab has just been closed, don't display it
-      tab->hide();
+      tab->hide ();
       continue;
     }
 

--- a/src/Plugins/Qt/QTMTabPage.cpp
+++ b/src/Plugins/Qt/QTMTabPage.cpp
@@ -51,6 +51,24 @@ QTMTabPage::QTMTabPage (url p_url, QAction* p_title, QAction* p_closeBtn,
            [=] () { g_mostRecentlyClosedTab= m_bufferUrl; });
 }
 
+/* We can't align the text to the left of the button by QSS or other methods,
+ * so for now we achieve it by overriding the paintEvent. */
+void
+QTMTabPage::paintEvent (QPaintEvent*) {
+  QStylePainter          p (this);
+  QStyleOptionToolButton opt;
+  initStyleOption (&opt);
+  opt.text= "";                                      // don't draw the text now
+  p.drawComplexControl (QStyle::CC_ToolButton, opt); // base method
+
+  // draw the text now
+  QFontMetrics fm (opt.fontMetrics);
+  QRect        rect= fm.boundingRect (opt.rect, Qt::AlignVCenter, text ());
+  rect.moveLeft (10);
+  p.drawItemText (rect, Qt::AlignLeft, palette (), isEnabled (), text (),
+                  QPalette::ButtonText);
+}
+
 void
 QTMTabPage::resizeEvent (QResizeEvent* e) {
   int w= m_closeBtn->width ();
@@ -86,6 +104,7 @@ QTMTabPageContainer::replaceTabPages (QList<QAction*>* p_src) {
     QTMTabPage* tab= m_tabPageList[i];
     if (g_mostRecentlyClosedTab == tab->m_bufferUrl) {
       // this tab has just been closed, don't display it
+      tab->hide();
       continue;
     }
 

--- a/src/Plugins/Qt/QTMTabPage.hpp
+++ b/src/Plugins/Qt/QTMTabPage.hpp
@@ -12,6 +12,8 @@
 #define QTMTABPAGE_HPP
 
 #include <QMouseEvent>
+#include <QStyleOptionToolButton>
+#include <QStylePainter>
 #include <QToolBar>
 #include <QToolButton>
 #include <basic.hpp>
@@ -29,6 +31,7 @@ public:
 public:
   explicit QTMTabPage (url p_url, QAction* p_title, QAction* p_closeBtn,
                        bool p_isActive);
+  virtual void paintEvent (QPaintEvent*) override;
 
 protected:
   virtual void resizeEvent (QResizeEvent* e) override;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Set tab bar default visiable and align tab title to the left
## Why
Pretty😀
## How to test your changes?
### Before：
![image](https://github.com/user-attachments/assets/a1aabccb-041d-4032-a444-41214ed65c17)
### After：
![image](https://github.com/user-attachments/assets/3722dc18-86a5-4e8a-94a3-c6d96472cb0a)
