### PR TITLE
[70_12] Revert: Language: add current ip for advance

### DIFF
--- a/src/Data/Tree/tree_analyze.cpp
+++ b/src/Data/Tree/tree_analyze.cpp
@@ -30,7 +30,7 @@ concat_tokenize (tree t) {
     int i= 0;
     while (i < N (t->label)) {
       int start= i;
-      (void) lan->advance (t, i, path ());
+      (void) lan->advance (t, i);
       r << tree (t->label (start, i));
     }
   }
@@ -145,7 +145,7 @@ symbol_type (tree t) {
   }
   else if (is_atomic (t)) {
     int           pos = 0;
-    text_property prop= lan->advance (t, pos, path ());
+    text_property prop= lan->advance (t, pos);
     switch (prop->op_type) {
     case OP_UNKNOWN:
     case OP_TEXT:

--- a/src/Edit/Modify/edit_delete.cpp
+++ b/src/Edit/Modify/edit_delete.cpp
@@ -313,12 +313,12 @@ edit_text_rep::remove_structure (bool forward) {
     while (true) {
       if (forward) {
         pos= start;
-        (void) lan->advance (t, pos, p);
+        (void) lan->advance (t, pos);
         if (pos <= last) break;
       }
       else {
         int pos= max (start - 1, 0);
-        (void) lan->advance (t, pos, p);
+        (void) lan->advance (t, pos);
         if (pos < last) break;
       }
       end= pos;

--- a/src/System/Language/impl_language.hpp
+++ b/src/System/Language/impl_language.hpp
@@ -70,7 +70,7 @@ struct abstract_language_rep : language_rep {
 
 struct verb_language_rep : language_rep {
   verb_language_rep (string name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
   string        get_color (tree t, int start, int end);
@@ -78,7 +78,7 @@ struct verb_language_rep : language_rep {
 
 struct prog_language_rep : abstract_language_rep {
   prog_language_rep (string name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
   string        get_color (tree t, int start, int end);
@@ -96,7 +96,7 @@ struct prog_language_rep : abstract_language_rep {
 struct scheme_language_rep : language_rep {
   hashmap<string, string> colored;
   scheme_language_rep (string name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
   string        get_color (tree t, int start, int end);
@@ -104,7 +104,7 @@ struct scheme_language_rep : language_rep {
 
 struct cpp_language_rep : abstract_language_rep {
   cpp_language_rep (string name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
   string        get_color (tree t, int start, int end);

--- a/src/System/Language/language.cpp
+++ b/src/System/Language/language.cpp
@@ -331,7 +331,7 @@ decode_color (string lan_name, int c) {
 struct hyphenless_language_rep : language_rep {
   language base;
   hyphenless_language_rep (string lan_name, language lan);
-  text_property advance (tree t, int& pos, path ip);
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
 };
@@ -340,8 +340,8 @@ hyphenless_language_rep::hyphenless_language_rep (string nm, language lan)
     : language_rep (nm), base (lan) {}
 
 text_property
-hyphenless_language_rep::advance (tree t, int& pos, path ip) {
-  return base->advance (t, pos, ip);
+hyphenless_language_rep::advance (tree t, int& pos) {
+  return base->advance (t, pos);
 }
 
 array<int>
@@ -376,7 +376,7 @@ struct ad_hoc_language_rep : language_rep {
   hashmap<string, string> hyphens;
 
   ad_hoc_language_rep (string lan_name, language lan, tree hyphs);
-  text_property advance (tree t, int& pos, path ip);
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
 };
@@ -391,8 +391,8 @@ ad_hoc_language_rep::ad_hoc_language_rep (string nm, language lan, tree hyphs)
 }
 
 text_property
-ad_hoc_language_rep::advance (tree t, int& pos, path ip) {
-  return base->advance (t, pos, ip);
+ad_hoc_language_rep::advance (tree t, int& pos) {
+  return base->advance (t, pos);
 }
 
 array<int>

--- a/src/System/Language/language.hpp
+++ b/src/System/Language/language.hpp
@@ -141,11 +141,9 @@ struct language_rep : rep<language> {
   int                         hl_lan;
   static hashmap<string, int> color_encoding;
   hashmap<int, string>        color_decoding;
-  tree                        parent_tree= tree ();
-  path                        parent_ip  = path ();
 
   language_rep (string s);
-  virtual text_property advance (tree t, int& pos, path ip)           = 0;
+  virtual text_property advance (tree t, int& pos)                    = 0;
   virtual array<int>    get_hyphens (string s)                        = 0;
   virtual void   hyphenate (string s, int after, string& l, string& r)= 0;
   virtual string get_group (string s);

--- a/src/System/Language/math_language.cpp
+++ b/src/System/Language/math_language.cpp
@@ -41,7 +41,7 @@ struct math_language_rep : language_rep {
 
   void          skip_spaces (string s, int& pos, space fn_spc, space& spc);
   string        next_word (string s, int& pos);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
   string        get_group (string s);
@@ -237,7 +237,7 @@ math_language_rep::next_word (string s, int& pos) {
 }
 
 text_property
-math_language_rep::advance (tree t, int& pos, path ip) {
+math_language_rep::advance (tree t, int& pos) {
   string s       = t->label;
   bool   op_flag1= (pos == 0) ||
                  ((pos >= 2) && is_alpha (s[pos - 2]) && is_alpha (s[pos - 1]));
@@ -329,7 +329,7 @@ string
 math_symbol_type (string sym, string lang) {
   int           pos = 0;
   language      lan = math_language (lang);
-  text_property prop= lan->advance (tree (sym), pos, path ());
+  text_property prop= lan->advance (tree (sym), pos);
   switch (prop->op_type) {
   case OP_UNKNOWN:
     return "unknown";

--- a/src/System/Language/prog_language.cpp
+++ b/src/System/Language/prog_language.cpp
@@ -219,9 +219,7 @@ prog_language_rep::customize_preprocessor (tree config) {
 }
 
 text_property
-prog_language_rep::advance (tree t, int& pos, path ip) {
-  // cout << "current ip: " << ip << LF;
-  // cout << "current tree: " << t << LF;
+prog_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos >= N (s)) return &tp_normal_rep;
 

--- a/src/System/Language/scheme_language.cpp
+++ b/src/System/Language/scheme_language.cpp
@@ -25,7 +25,7 @@ scheme_language_rep::scheme_language_rep (string name)
 }
 
 text_property
-scheme_language_rep::advance (tree t, int& pos, path ip) {
+scheme_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos == N (s)) return &tp_normal_rep;
   switch (s[pos]) {

--- a/src/System/Language/text_language.cpp
+++ b/src/System/Language/text_language.cpp
@@ -26,7 +26,7 @@ struct text_language_rep : language_rep {
   hashmap<string, string> hyphenations;
 
   text_language_rep (string lan_name, string hyph_name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
 };
@@ -37,7 +37,7 @@ text_language_rep::text_language_rep (string lan_name, string hyph_name)
 }
 
 text_property
-text_language_rep::advance (tree t, int& pos, path ip) {
+text_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos >= N (s)) return &tp_normal_rep;
 
@@ -127,7 +127,7 @@ struct french_language_rep : language_rep {
   hashmap<string, string> hyphenations;
 
   french_language_rep (string lan_name, string hyph_name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
 };
@@ -143,7 +143,7 @@ is_french_punctuation (char c) {
 }
 
 text_property
-french_language_rep::advance (tree t, int& pos, path ip) {
+french_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos >= N (s)) return &tp_normal_rep;
 
@@ -235,7 +235,7 @@ struct ucs_text_language_rep : language_rep {
   hashmap<string, string> hyphenations;
 
   ucs_text_language_rep (string lan_name, string hyph_name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
   bool          unicode;
@@ -247,7 +247,7 @@ ucs_text_language_rep::ucs_text_language_rep (string lan_name, string hyph_name)
 }
 
 text_property
-ucs_text_language_rep::advance (tree t, int& pos, path ip) {
+ucs_text_language_rep::advance (tree t, int& pos) {
   // TODO: replace methods is_punctuation (), is_iso_alpha () and is_numeric (),
   //       by equivalents taking into account unicode entities.
   string s= t->label;
@@ -330,7 +330,7 @@ struct oriental_language_rep : language_rep {
   hashmap<string, bool> punct;
   hashmap<string, bool> wide_punct;
   oriental_language_rep (string lan_name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
 };
@@ -394,7 +394,7 @@ oriental_language_rep::oriental_language_rep (string lan_name)
 }
 
 text_property
-oriental_language_rep::advance (tree t, int& pos, path ip) {
+oriental_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos >= N (s)) return &tp_normal_rep;
 
@@ -463,7 +463,7 @@ struct chinese_language_rep : language_rep {
   hashset<string> do_not_start;
   hashset<string> do_not_end;
   chinese_language_rep (string lan_name);
-  text_property advance (tree t, int& pos, path ip= path ());
+  text_property advance (tree t, int& pos);
   array<int>    get_hyphens (string s);
   void          hyphenate (string s, int after, string& left, string& right);
 };
@@ -502,7 +502,7 @@ chinese_language_rep::chinese_language_rep (string lan_name)
 }
 
 text_property
-chinese_language_rep::advance (tree t, int& pos, path ip) {
+chinese_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos >= N (s)) return &tp_normal_rep;
 

--- a/src/System/Language/verb_language.cpp
+++ b/src/System/Language/verb_language.cpp
@@ -25,7 +25,7 @@ is_sep_char (char c) {
 }
 
 text_property
-verb_language_rep::advance (tree t, int& pos, path ip) {
+verb_language_rep::advance (tree t, int& pos) {
   string s= t->label;
   if (pos == N (s)) return &tp_normal_rep;
   if (s[pos] == ' ') {

--- a/src/Typeset/Concat/concat_text.cpp
+++ b/src/Typeset/Concat/concat_text.cpp
@@ -91,7 +91,7 @@ concater_rep::typeset_text_string (tree t, path ip, int pos, int end) {
 
   do {
     start           = pos;
-    text_property tp= env->lan->advance (t, pos, ip);
+    text_property tp= env->lan->advance (t, pos);
     if (pos > end) pos= end;
     if ((pos > start) && (s[start] == ' ')) { // spaces
       if (start == 0) typeset_substring ("", ip, 0);
@@ -127,7 +127,7 @@ concater_rep::typeset_math_string (tree t, path ip, int pos, int end) {
 
   do {
     start           = pos;
-    text_property tp= env->lan->advance (t, pos, ip);
+    text_property tp= env->lan->advance (t, pos);
     int           k = N (a);
     while (k > 0 && a[k - 1]->op_type == OP_SKIP)
       k--;
@@ -185,7 +185,7 @@ concater_rep::typeset_prog_string (tree t, path ip, int pos, int end) {
 
   do {
     start           = pos;
-    text_property tp= env->lan->advance (t, pos, ip);
+    text_property tp= env->lan->advance (t, pos);
     if (pos > end) pos= end;
     if ((pos - start == 1) && (s[start] == ' ')) { // spaces
       if (start == 0) typeset_substring ("", ip, 0);
@@ -239,9 +239,8 @@ concater_rep::typeset_surround (tree t, path ip) {
 void
 concater_rep::typeset_concat (tree t, path ip) {
   int i, n= N (t);
-  for (i= 0; i < n; i++) {
+  for (i= 0; i < n; i++)
     typeset (t[i], descend (ip, i));
-  }
 }
 
 void
@@ -280,7 +279,7 @@ concater_rep::print_semantic (box b, tree sem) {
                      env->display_style && env->nesting_level == 0);
     int           pos= 0;
     string        s  = sem->label;
-    text_property tp = env->lan->advance (s, pos, path ());
+    text_property tp = env->lan->advance (s, pos);
     int           k  = N (a);
     while (k > 0 && a[k - 1]->op_type == OP_SKIP)
       k--;

--- a/src/Typeset/Concat/concater.cpp
+++ b/src/Typeset/Concat/concater.cpp
@@ -190,7 +190,6 @@ void
 concater_rep::typeset (tree t, path ip) {
   // cout << "Typeset " << t << "\n";
   // cout << "Typeset " << t << ", " << ip << ", " << obtain_ip (t) << "\n";
-  // cout << "L(t): " << L(t) << "\t" << to_string (L(t)) << LF;
 
   /*
   if (obtain_ip (t) != ip)


### PR DESCRIPTION
This reverts commit 361f1c14f74895ade3c59f4c1e9c1ece3596121f.

<!-- Thank you for your contribution! -->
## What

## Why

inverse path get from argument is the same as ones obtained by `obtain_ip`, thus change is unnecessary.

## How to test your changes?
