### PR TITLE
[24_15] Refine test for docx.scm

### DIFF
--- a/TeXmacs/tests/24_15.scm
+++ b/TeXmacs/tests/24_15.scm
@@ -13,28 +13,22 @@
 (import (srfi srfi-78))
 (use-modules (data docx))
 
-(define (tm->docx tm-file-url docx-file-url)
+(define (tm->docx tm-file-url)
   ; Step 1: load the tm file
   ; (display* "load-buffer: " tm-file-url "\n")
   (load-buffer tm-file-url)
   ; (display* "buffer-loaded: " tm-file-url "\n")
 
-  ; Step 2: Export the buffer to the docx file url
-  ; (display* "export buffer to: " docx-file-url "\n")
-  (export-to-docx tm-file-url docx-file-url)
-
-  ; Check if the docx file exists
-  (if (url-exists? docx-file-url)
-      (display* "Export successful: " docx-file-url "\n")
-      (display* "Export failed: " docx-file-url "\n"))
-
-  (url-exists? docx-file-url))
+  ; Step 2: Export the buffer to the docx string
+  (let* ((result (texmacs-tree->docx-string tm-file-url `())) 
+         (result_len (string-length result)))
+    ; (display result) 
+    (> result_len 0)))
 
 (define (test_24_15)
   (display  (url-exists? (system->url "$TEXMACS_PATH/tests/tm/24_15.tm")))
   (let* ((tm-url "$TEXMACS_PATH/tests/tm/24_15.tm")
-         (docx-url "$TEXMACS_PATH/tests/tm/24_15.docx")
-         (result (tm->docx tm-url docx-url)))
+         (result (tm->docx tm-url)))
     (check result => #t)
     (check-report)
     (if (check-failed?) (exit -1))))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Refine test for docx.scm
## Why
The docx export logic has been changed, so the associated tests need to be altered as well.
## How to test your changes?
xmake r 24_15
![图片](https://github.com/user-attachments/assets/c9f27785-8173-458d-a863-148e0e5b2607)
