### PR TITLE
[24_19] Avoid converting CJK to hexadecimal when exporting html

### DIFF
--- a/TeXmacs/tests/24_19.scm
+++ b/TeXmacs/tests/24_19.scm
@@ -1,0 +1,29 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : test_24_19.scm
+;; DESCRIPTION : Test suite for utf8->html
+;; COPYRIGHT   : (C) 2024  ATQlove
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(import (liii check))
+
+(define (test-cjk-conversion)
+  (check (utf8->html "试试中文是否正常显示") => "试试中文是否正常显示")
+  (check (utf8->html "日本語の表示を確かめてみよう") => "日本語の表示を確かめてみよう")
+  (check (utf8->html "한국어가 정상적으로 표시되는지 확인해보자") => "한국어가 정상적으로 표시되는지 확인해보자")
+)
+
+(define (test-non-cjk-conversion)
+  (check (utf8->html "Try to see if the Chinese is displayed correctly") => "Try to see if the Chinese is displayed correctly")
+  (check (utf8->html "Check the English output") => "Check the English output")
+)
+
+(define (test_24_19)
+  (test-cjk-conversion)
+  (test-non-cjk-conversion)
+  (check-report))

--- a/src/Data/String/converter.cpp
+++ b/src/Data/String/converter.cpp
@@ -863,17 +863,19 @@ utf8_to_hex_entities (string_u8 s) {
     else {
       unsigned int code= decode_from_utf8 (s, i);
 
-      // If the code is within the Unicode range of the Chinese character, the original character is added directly.
-      if ((code >= 0x4e00 && code <= 0x9fff) ||  // commonly used Chinese characters
-          (code >= 0x3400 && code <= 0x4dbf) ||  // Extension A
+      // If the code is within the Unicode range of the Chinese character, the
+      // original character is added directly.
+      if ((code >= 0x4e00 &&
+           code <= 0x9fff) || // commonly used Chinese characters
+          (code >= 0x3400 && code <= 0x4dbf) ||   // Extension A
           (code >= 0x20000 && code <= 0x2a6df)) { // Extension B
-        int char_length = (code >= 0x10000) ? 4 : 3;
-        for (int j = 0; j < char_length; ++j) {
+        int char_length= (code >= 0x10000) ? 4 : 3;
+        for (int j= 0; j < char_length; ++j) {
           result << s[i - char_length + j];
         }
-      } 
+      }
       else {
-        string hex = to_Hex (code);
+        string hex= to_Hex (code);
         while (N (hex) < 4)
           hex= "0" * hex;
         // cout << "entity: " << hex << " (" << code << ")\n";

--- a/src/Data/String/converter.cpp
+++ b/src/Data/String/converter.cpp
@@ -862,11 +862,23 @@ utf8_to_hex_entities (string_u8 s) {
     }
     else {
       unsigned int code= decode_from_utf8 (s, i);
-      string       hex = to_Hex (code);
-      while (N (hex) < 4)
-        hex= "0" * hex;
-      // cout << "entity: " << hex << " (" << code << ")\n";
-      result << "&#x" << hex << ";";
+
+      // If the code is within the Unicode range of the Chinese character, the original character is added directly.
+      if ((code >= 0x4e00 && code <= 0x9fff) ||  // commonly used Chinese characters
+          (code >= 0x3400 && code <= 0x4dbf) ||  // Extension A
+          (code >= 0x20000 && code <= 0x2a6df)) { // Extension B
+        int char_length = (code >= 0x10000) ? 4 : 3;
+        for (int j = 0; j < char_length; ++j) {
+          result << s[i - char_length + j];
+        }
+      } 
+      else {
+        string hex = to_Hex (code);
+        while (N (hex) < 4)
+          hex= "0" * hex;
+        // cout << "entity: " << hex << " (" << code << ")\n";
+        result << "&#x" << hex << ";";
+      }
     }
   }
   return result;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Avoid converting Chinese to hexadecimal when exporting html.

## Why
When exported tm, tmu format to html before, Chinese was displayed in hexadecimal. After modification, Chinese can be displayed normally in html.

## How to test your changes?
Text in tmu:
![图片](https://github.com/user-attachments/assets/b4bfd170-effe-497b-bbe4-ff1442deca04)
Text in html:
![图片](https://github.com/user-attachments/assets/c215f4f0-f487-4f63-abef-17903bee527c)
Open html in browser:
![图片](https://github.com/user-attachments/assets/83b78127-81cb-47d1-8ad6-dab864bcb712)

