### PR TITLE
[70_13] Allow set lang_id for customized language

### DIFF
--- a/TeXmacs/plugins/code/progs/code/default-ast-lang.scm
+++ b/TeXmacs/plugins/code/progs/code/default-ast-lang.scm
@@ -17,6 +17,11 @@
   `(,(string->symbol key)))
 
 (tm-define (parser-feature lan key)
+  (:require (== key "id"))
+  `(,(string->symbol key)
+    ,lan))
+
+(tm-define (parser-feature lan key)
   (:require (== key "special_symbol"))
   `(,(string->symbol key)))
 

--- a/TeXmacs/plugins/goldfish/progs/code/goldfish-ast-lang.scm
+++ b/TeXmacs/plugins/goldfish/progs/code/goldfish-ast-lang.scm
@@ -1,7 +1,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; MODULE      : goldfish-lang.scm
+;; MODULE      : goldfish-ast-lang.scm
 ;; DESCRIPTION : the Goldfish Scheme Language
 ;; COPYRIGHT   : (C) 2024  Darcy Shen
 ;;
@@ -11,8 +11,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(texmacs-module (code goldfish-lang)
-  (:use (prog default-lang)
+(texmacs-module (code goldfish-ast-lang)
+  (:use (code default-ast-lang)
         (code r7rs-keyword)
         (code srfi-keyword)))
 
@@ -22,15 +22,13 @@
     "getlogin" "getpid" "access" "system" "os-linux?" "os-macos?" "os-windows?"))
 
 (tm-define (parser-feature lan key)
-  (:require (and (== lan "goldfish") (== key "identifier")))
+  (:require (and (== lan "goldfish") (== key "id")))
   `(,(string->symbol key)
-    (extra_chars "?" "+" "-" "." "!" "*" ">" "=" "<" "#")
-    (start_chars "?" "+" "-" "." "!" "*" ">" "=" "<" "#")))
+    "scheme"))
 
 (tm-define (parser-feature lan key)
-  (:require (and (== lan "goldfish") (== key "keyword")))
+  (:require (and (== lan "goldfish") (== key "keytoken")))
   `(,(string->symbol key)
-    (extra_chars "?" "+" "-" "." "!" "*" ">" "=" "<" "#")
     (constant
       ,@(r7rs-keywords-constant)
       "pi" "*stdin*" "*stdout*" "*stderr*"
@@ -67,53 +65,27 @@
     (keyword_control ,@(r7rs-keywords-exception) "catch")))
 
 (tm-define (parser-feature lan key)
-  (:require (and (== lan "goldfish") (== key "operator")))
+  (:require (and (== lan "goldfish") (== key "special_symbol")))
   `(,(string->symbol key)
-    (operator "=" "+" "-" "*" "/" "=>" "->" ">" "<" ">=" "<=")
-    (operator_special "@" "," "'" "`")
-    (operator_openclose "{" "[" "(" ")" "]" "}")))
+    (tokenize "symbol" "first_symbol")))
 
-(define (goldfish-number-suffix)
-  `(suffix
-    (imaginary "i")))
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Preferences for syntax highlighting
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (tm-define (parser-feature lan key)
-  (:require (and (== lan "goldfish") (== key "number")))
+  (:require (and (== lan "goldfish") (== key "light_theme")))
   `(,(string->symbol key)
-    (bool_features "prefix_#")
-    (separator "_")
-    ,(goldfish-number-suffix)))
+    ("#000000" "none")
+    ("#4040c0" "constant")
+    ("#204080" "keyword")
+    ("#30909" "keyword_conditional" "keyword_control" "declare_type")
+    ("#0000AB" "first_symbol")
+    ("#4040c0" "number" "boolean")
+    ("#267F99" "comment" "block_comment")
+    ("#D32F2F" "string_content" "string_quote" "character")
+    ("#BF2C2C" "escape_sequence")
+    ("#800080" "error")
+    ("#006400" "(0" ")0" "[0" "]0" "{0" "}0")
+    ("#00008B" "(1" ")1" "[1" "]1" "{1" "}1")
+    ("#654321" "(2" ")2" "[2" "]2" "{2" "}2")))
 
-(tm-define (parser-feature lan key)
-  (:require (and (== lan "goldfish") (== key "string")))
-  `(,(string->symbol key)
-    (bool_features
-     "hex_with_8_bits" "hex_with_16_bits"
-     "hex_with_32_bits" "octal_upto_3_digits")
-    (escape_sequences "\\" "\"" "a" "b" "f" "n" "r" "t" "v")
-    (pairs "\"")))
-
-; See: https://goldfish.org/doc/v6.1.0/Single-Line-Comments.html
-(tm-define (parser-feature lan key)
-  (:require (and (== lan "goldfish") (== key "comment")))
-  `(,(string->symbol key)
-    (inline ";")))
-
-(define (notify-goldfish-syntax var val)
-  (syntax-read-preferences "goldfish"))
-
-(define-preferences
-  ("syntax:goldfish:none" "red" notify-goldfish-syntax)
-  ("syntax:goldfish:comment" "brown" notify-goldfish-syntax)
-  ("syntax:goldfish:declare_type" "#309090" notify-goldfish-syntax)
-  ("syntax:goldfish:keyword_conditional" "#309090" notify-goldfish-syntax)
-  ("syntax:goldfish:keyword_control" "#309090" notify-goldfish-syntax)
-  ("syntax:goldfish:keyword" "#204080" notify-goldfish-syntax)
-  ("syntax:goldfish:error" "red" notify-goldfish-syntax)
-  ("syntax:goldfish:constant_number" "#4040c0" notify-goldfish-syntax)
-  ("syntax:goldfish:constant_string" "dark grey" notify-goldfish-syntax)
-  ("syntax:goldfish:constant_char" "#333333" notify-goldfish-syntax)
-  ("syntax:goldfish:operator_special" "dark magenta" notify-goldfish-syntax)
-  ("syntax:goldfish:operator_openclose" "dark" notify-goldfish-syntax)
-  ("syntax:goldfish:variable_identifier" "#204080" notify-goldfish-syntax)
-  ("syntax:goldfish:declare_category" "#d030d0" notify-goldfish-syntax))

--- a/TeXmacs/plugins/goldfish/progs/code/goldfish-lang.scm
+++ b/TeXmacs/plugins/goldfish/progs/code/goldfish-lang.scm
@@ -1,0 +1,119 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : goldfish-lang.scm
+;; DESCRIPTION : the Goldfish Scheme Language
+;; COPYRIGHT   : (C) 2024  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (code goldfish-lang)
+  (:use (prog default-lang)
+        (code r7rs-keyword)
+        (code srfi-keyword)))
+
+(define (liii-keywords)
+  '("==" "!=" "in?" "display*" "list-view" "argv"
+    "mkdir" "chdir" "rmdir" "getcwd" "listdir" "getenv" "putenv" "unsetenv"
+    "getlogin" "getpid" "access" "system" "os-linux?" "os-macos?" "os-windows?"))
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "goldfish") (== key "identifier")))
+  `(,(string->symbol key)
+    (extra_chars "?" "+" "-" "." "!" "*" ">" "=" "<" "#")
+    (start_chars "?" "+" "-" "." "!" "*" ">" "=" "<" "#")))
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "goldfish") (== key "keyword")))
+  `(,(string->symbol key)
+    (extra_chars "?" "+" "-" "." "!" "*" ">" "=" "<" "#")
+    (constant
+      ,@(r7rs-keywords-constant)
+      "pi" "*stdin*" "*stdout*" "*stderr*"
+      "*load-hook*" "*autoload-hook*" "*error-hook*" "*read-error-hook*"
+      "*rootlet-redefinition-hook*" "*unbound-variable-hook*"
+      "*missing-close-paren-hook*")
+    (declare_type
+      ,@(r7rs-keywords-define)
+      "defined?" "define-macro" "define-constant" "autoload" "require"
+      "provide" "define*" "lambda*" "eval-string" "let1")
+    (keyword
+      ,@(r7rs-keywords-others) ,@(srfi-1-keywords) ,@(srfi-8-keywords) ,@(srfi-13-keywords) ,@(srfi-60-keywords) ,@(srfi-78-keywords)
+      ,@(liii-keywords)
+
+      ; S7 built-ins
+      "*load-path*" "*goldfish*" "*features*" "*libraries*"
+      "*cload-directory*" "*#readers*"
+      "with-input-from-string" "with-output-to-string"
+
+      "equivalent?" "complex" "directory?" "getenv"
+      "help" "bignum" "append" "copy" "procedure-source"
+
+      ; MISC
+      "integer-decode-float" "random" "nan" "nan-payload" "format" "object->string" "immutable!" "immutable?" "make-hash-table" "hash-table" "hash-table?" "hash-table-ref" "hash-table-set!" "hash-table-entries" "hash-code"
+      )
+    (error
+      "syntax-error" "wrong-type-arg" "immutable-error" "out-of-range" "division-by-zero"
+      "unbound-variable" "read-error" "format-error" "missing-method" "out-of-memory"
+      "bad-result" "no-catch" "wrong-number-of-args" "io-error" "bignum-error"
+      ; (liii error)
+      "os-error" "file-not-found-error" "not-a-directory-error" "file-exists-error" "timeout-error"
+      "type-error" "value-error" "???" "not-implemented-error")
+    (keyword_conditional ,@(r7rs-keywords-branch))
+    (keyword_control ,@(r7rs-keywords-exception) "catch")))
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "goldfish") (== key "operator")))
+  `(,(string->symbol key)
+    (operator "=" "+" "-" "*" "/" "=>" "->" ">" "<" ">=" "<=")
+    (operator_special "@" "," "'" "`")
+    (operator_openclose "{" "[" "(" ")" "]" "}")))
+
+(define (goldfish-number-suffix)
+  `(suffix
+    (imaginary "i")))
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "goldfish") (== key "number")))
+  `(,(string->symbol key)
+    (bool_features "prefix_#")
+    (separator "_")
+    ,(goldfish-number-suffix)))
+
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "goldfish") (== key "string")))
+  `(,(string->symbol key)
+    (bool_features
+     "hex_with_8_bits" "hex_with_16_bits"
+     "hex_with_32_bits" "octal_upto_3_digits")
+    (escape_sequences "\\" "\"" "a" "b" "f" "n" "r" "t" "v")
+    (pairs "\"")))
+
+; See: https://goldfish.org/doc/v6.1.0/Single-Line-Comments.html
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "goldfish") (== key "comment")))
+  `(,(string->symbol key)
+    (inline ";")))
+
+(define (notify-goldfish-syntax var val)
+  (syntax-read-preferences "goldfish"))
+
+(define-preferences
+  ("syntax:goldfish:none" "red" notify-goldfish-syntax)
+  ("syntax:goldfish:comment" "brown" notify-goldfish-syntax)
+  ("syntax:goldfish:declare_type" "#309090" notify-goldfish-syntax)
+  ("syntax:goldfish:keyword_conditional" "#309090" notify-goldfish-syntax)
+  ("syntax:goldfish:keyword_control" "#309090" notify-goldfish-syntax)
+  ("syntax:goldfish:keyword" "#204080" notify-goldfish-syntax)
+  ("syntax:goldfish:error" "red" notify-goldfish-syntax)
+  ("syntax:goldfish:constant_number" "#4040c0" notify-goldfish-syntax)
+  ("syntax:goldfish:constant_string" "dark grey" notify-goldfish-syntax)
+  ("syntax:goldfish:constant_char" "#333333" notify-goldfish-syntax)
+  ("syntax:goldfish:operator_special" "dark magenta" notify-goldfish-syntax)
+  ("syntax:goldfish:operator_openclose" "dark" notify-goldfish-syntax)
+  ("syntax:goldfish:variable_identifier" "#204080" notify-goldfish-syntax)
+  ("syntax:goldfish:declare_category" "#d030d0" notify-goldfish-syntax))

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -19,11 +19,14 @@
 extern tree the_et;
 using moebius::make_tree_label;
 
-lang_parser::lang_parser (string lang) {
+lang_parser::lang_parser (string lang, string lang_id) {
   // TODO: Dynamic loading of shared lib and multilingual switching
   ast_parser= ts_parser_new ();
-  if (lang == "cpp") ts_lang= tree_sitter_cpp ();
-  if (lang == "scheme") ts_lang= tree_sitter_scheme ();
+  if (lang_id == "cpp") ts_lang= tree_sitter_cpp ();
+  else if (lang_id == "scheme") ts_lang= tree_sitter_scheme ();
+  else {
+    ts_lang= tree_sitter_scheme ();
+  }
   // cout << lang << " parser created\n";
 
   ts_parser_set_language (ast_parser, ts_lang);

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -25,6 +25,7 @@ lang_parser::lang_parser (string lang, string lang_id) {
   if (lang_id == "cpp") ts_lang= tree_sitter_cpp ();
   else if (lang_id == "scheme") ts_lang= tree_sitter_scheme ();
   else {
+    // TODO: A fallback tree sitter impl is needed
     ts_lang= tree_sitter_scheme ();
   }
   // cout << lang << " parser created\n";

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -305,7 +305,8 @@ lang_parser::add_token (TSSymbol token_type, string token_literal,
       add_single_token ("(Before Cross)Node type: ", token_type, token_literal,
                         start_1, end_1, token_lang_pro);
     }
-    if (end_1 + 1 < start_2 && !(end_1+1 == start_pos && start_2==end_pos)) {
+    if (end_1 + 1 < start_2 &&
+        !(end_1 + 1 == start_pos && start_2 == end_pos)) {
       // cout << "Mid Split\n";
       add_token (token_type,
                  token_literal (end_1 - start_1 + 1, N (token_literal)),

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -305,7 +305,7 @@ lang_parser::add_token (TSSymbol token_type, string token_literal,
       add_single_token ("(Before Cross)Node type: ", token_type, token_literal,
                         start_1, end_1, token_lang_pro);
     }
-    if (end_1 + 1 < start_2) {
+    if (end_1 + 1 < start_2 && !(end_1+1 == start_pos && start_2==end_pos)) {
       // cout << "Mid Split\n";
       add_token (token_type,
                  token_literal (end_1 - start_1 + 1, N (token_literal)),

--- a/src/Plugins/Treesitter/lang_parser.hpp
+++ b/src/Plugins/Treesitter/lang_parser.hpp
@@ -21,7 +21,7 @@ constexpr TSSymbol SpaceSymbol= 65534;
 
 class lang_parser {
 public:
-  lang_parser (string lang);
+  lang_parser (string lang, string lang_id);
 
   /**
    * @brief Check current line of code has changed or not.

--- a/src/System/Language/ast_language.cpp
+++ b/src/System/Language/ast_language.cpp
@@ -30,8 +30,8 @@ using moebius::make_tree_label;
 ast_language_rep::ast_language_rep (string name) : language_rep (name) {
   string lan_name= name (0, N (name) - 4);
 
-  // if (DEBUG_PARSER)
-  debug_packrat << "Building the " * name * " language parser" << LF;
+  if (DEBUG_PARSER)
+    debug_packrat << "Building the " * name * " language parser" << LF;
 
   string use_modules= "(use-modules (code " * name * "-lang))";
   eval (use_modules);

--- a/src/System/Language/ast_language.cpp
+++ b/src/System/Language/ast_language.cpp
@@ -29,13 +29,21 @@ using moebius::make_tree_label;
 
 ast_language_rep::ast_language_rep (string name) : language_rep (name) {
   string lan_name= name (0, N (name) - 4);
-  lang_ast_parser= tm_new<lang_parser> (lan_name);
 
-  if (DEBUG_PARSER)
-    debug_packrat << "Building the " * name * " language parser" << LF;
+  // if (DEBUG_PARSER)
+  debug_packrat << "Building the " * name * " language parser" << LF;
 
   string use_modules= "(use-modules (code " * name * "-lang))";
   eval (use_modules);
+
+  tree lang_id_config= get_parser_config (lan_name, "id");
+  if (N (lang_id_config) > 0) {
+    string lang_id = get_label (lang_id_config[0]);
+    lang_ast_parser= tm_new<lang_parser> (lan_name, lang_id);
+  }
+  else {
+    lang_ast_parser= tm_new<lang_parser> (lan_name, lan_name);
+  }
 
   tree keytoken_config= get_parser_config (lan_name, "keytoken");
   customize_keytokens (keytoken_config);

--- a/src/System/Language/prog_language.cpp
+++ b/src/System/Language/prog_language.cpp
@@ -389,8 +389,7 @@ prog_language (string s) {
     return make (language, s, tm_new<prog_language_rep> (s));
 
   if (format_exists (s) && ast_prog_lang_exists (s))
-    return make (language, s * "-ast",
-                 tm_new<ast_prog_language_rep> (s * "-ast"));
+    return make (language, s * "-ast", tm_new<ast_language_rep> (s * "-ast"));
 
   return make (language, s, tm_new<verb_language_rep> (s));
 }

--- a/src/System/Language/prog_language.cpp
+++ b/src/System/Language/prog_language.cpp
@@ -352,18 +352,33 @@ prog_lang_exists (string s) {
                              "-lang.scm"));
 }
 
+bool
+ast_prog_lang_exists (string s) {
+  return exists (
+             url_system ("$TEXMACS_PATH/progs/prog/" * s * "-ast-lang.scm")) ||
+         exists (url_system ("$TEXMACS_PATH/plugins/" * s * "/progs/code/" * s *
+                             "-ast-lang.scm")) ||
+         exists (url_system ("$TEXMACS_PATH/plugins/code/progs/code/" * s *
+                             "-ast-lang.scm")) ||
+         exists (url_system ("$TEXMACS_HOME_PATH/plugins/" * s *
+                             "/progs/code/" * s * "-ast-lang.scm")) ||
+         exists (url_system ("$TEXMACS_HOME_PATH/plugins/code/progs/code/" * s *
+                             "-ast-lang.scm"));
+}
+
 /******************************************************************************
  * Interface
  ******************************************************************************/
 language
 prog_language (string s) {
   string use_ast= get_user_preference ("ast-syntax-highlighting");
-  // cout << "Load prog_language " << s << " use_ast: " << use_ast << "\n";
   if (use_ast == "on") {
+    // cout << "Load prog_language " << s << " use_ast: " << use_ast << "\n";
     if (language::instances->contains (s * "-ast"))
       return language (s * "-ast");
-    if (format_exists (s) && prog_lang_exists (s * "-ast"))
+    if (format_exists (s) && ast_prog_lang_exists (s)) {
       return make (language, s * "-ast", tm_new<ast_language_rep> (s * "-ast"));
+    }
   }
 
   if (language::instances->contains (s)) return language (s);
@@ -372,6 +387,10 @@ prog_language (string s) {
 
   if (format_exists (s) && prog_lang_exists (s))
     return make (language, s, tm_new<prog_language_rep> (s));
+
+  if (format_exists (s) && ast_prog_lang_exists (s))
+    return make (language, s * "-ast",
+                 tm_new<ast_prog_language_rep> (s * "-ast"));
 
   return make (language, s, tm_new<verb_language_rep> (s));
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Goldfish Scheme is a scheme dialect.

We introduce:
```
(tm-define (parser-feature lan key)
  (:require (and (== lan "goldfish") (== key "id")))
  `(,(string->symbol key)
    "scheme"))
```
To make goldfish dependes on the `scheme` tree-sitter parser. The only difference between the scheme language and the goldfish language lies on the keywords.

## Why
For customized language.

## How to test your changes?
Check the ast option, and insert a Goldfish session.
