### PR TITLE
[71_41] UI: Improve the focus-section-menu

### DIFF
--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -845,6 +845,7 @@
   (:require (== l "appendix-prefix"))
   #f)
 
+
 (define (is-current-tree t)
   (== (tree->path t) (tree->path (focus-tree))))
 
@@ -856,44 +857,47 @@
     `(verbatim ,(string-append (tm/section-get-title-string s indent?) "        <="))
     `(verbatim ,(tm/section-get-title-string s indent?))))
 
-(define (section-list->nested l result)
-  (cond ((null? l) result)
-        ((null? result)
-         (section-list->nested
-           (cdr l)
-           (list (list (car l)))))
-        ((is-top-level (car l))
-         (section-list->nested
-           (cdr l)
-           (cons (list (car l)) result)))
-        ((and (not (is-top-level (car l)))
-              (is-top-level (car (car result))))
-         (section-list->nested
-           (cdr l)
-           (cons (append (car result) (list (car l)))
-                 (cdr result))))
-        (else
-         (section-list->nested
-           (cdr l)
-           (cons (list (car l))
-                 result)))))
+(define (filter-sections l f-is-current-tree f-is-top-level)
+  (define (section-list->nested l result)
+    (cond ((null? l) result)
+          ((null? result)
+           (section-list->nested
+             (cdr l)
+             (list (list (car l)))))
+          ((f-is-top-level (car l))
+           (section-list->nested
+             (cdr l)
+             (cons (list (car l)) result)))
+          ((and (not (f-is-top-level (car l)))
+                (f-is-top-level (car (car result))))
+           (section-list->nested
+             (cdr l)
+             (cons (append (car result) (list (car l)))
+                   (cdr result))))
+          (else
+           (section-list->nested
+             (cdr l)
+             (cons (list (car l))
+                   result)))))
+  
+  (define (nested->filtered l result)
+    (cond ((null? l) result)
+          ((list-any f-is-current-tree (car l))
+           (nested->filtered (cdr l) (append (car l) result)))
+          (else
+           (nested->filtered (cdr l) (append (list-filter (car l) f-is-top-level) result)))))
 
-(tm-define (nested->filtered l result)
-  (cond ((null? l) result)
-        ((list-any is-current-tree (car l))
-         (nested->filtered (cdr l) (append (car l) result)))
-        (else
-         (nested->filtered (cdr l) (append (list-filter (car l) is-top-level) result)))))
+  (with l2 (section-list->nested l '())
+    (nested->filtered l2 '())))
 
 ; If the number of sections bigger than 42
 ; we will only reserve chapter/part outside the focus
-(tm-define (all-sections)
+(define (all-sections)
   (with l1 (list-filter (tree-search-sections (buffer-tree))
              (lambda (x) (not (equal? (tree-label x) 'subparagraph))))
     (if (<= (length l1) 42)
         l1
-        (with l2 (section-list->nested l1 '())
-                 (nested->filtered l2 '())))))
+        (filter-sections l1 is-current-tree is-top-level))))
 
 (tm-menu (focus-section-menu)
   (for (s (all-sections))

--- a/TeXmacs/tests/43_3.scm
+++ b/TeXmacs/tests/43_3.scm
@@ -1,3 +1,15 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 43_3.scm
+;; DESCRIPTION : Tests for LaTeX conversion
+;; COPYRIGHT   : (C) 2024  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (load "./TeXmacs/plugins/latex/progs/init-latex.scm")
 
 (define (export-as-latex-and-load path)

--- a/TeXmacs/tests/71_41.scm
+++ b/TeXmacs/tests/71_41.scm
@@ -40,5 +40,6 @@
     => '("chapter current" "section 1.1" "section 1.2" "chapter 2")))
 
 (define (test_71_41)
+  (check-set-mode! 'report-failed)
   (test)
   (check-report))

--- a/TeXmacs/tests/71_41.scm
+++ b/TeXmacs/tests/71_41.scm
@@ -1,0 +1,44 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : 71_41.scm
+;; DESCRIPTION : Tests for sections
+;; COPYRIGHT   : (C) 2024  Darcy Shen
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(load "./TeXmacs/progs/text/text-menu.scm")
+(import (liii string)
+        (liii check))
+
+; override the subroutine
+(define (is-top-level2 x)
+  (string-prefix? "chapter" x))
+
+; override the subroutine
+(define (is-current-tree2 t)
+  (string-suffix? "current" t))
+
+(define (test)
+  (check (filter-sections
+           '() is-current-tree2 is-top-level2)
+    => '())
+  (check (filter-sections
+           '("chapter 1" "section current" "chapter 2" "section 2.1")
+           is-current-tree2 is-top-level2)
+    => '("chapter 1" "section current" "chapter 2"))
+  (check (filter-sections '("section 1" "section current" "chapter 2")
+           is-current-tree2 is-top-level2)
+    => '("section current" "chapter 2"))
+  (check (filter-sections
+          '("section 1" "chapter current" "section 1.1" "section 1.2"
+            "chapter 2" "section 2.1")
+           is-current-tree2 is-top-level2)
+    => '("chapter current" "section 1.1" "section 1.2" "chapter 2")))
+
+(define (test_71_41)
+  (test)
+  (check-report))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
1. Use `        <=` as an indicator of the current menu
2. If the section items is bigger than 42, only reserve the full items in the current focus, for others, only reserve chapter and part

## Why
We have a doc with too many section items.

## How to test your changes?
Manually test it.
