### PR TITLE
[24_21] Set default export to docx to use MathML instead of image

### DIFF
--- a/TeXmacs/plugins/docx/progs/data/docx.scm
+++ b/TeXmacs/plugins/docx/progs/data/docx.scm
@@ -69,6 +69,6 @@
   (:function-with-options texmacs-tree->docx-string)
   (:option "texmacs->html:css" "on")
   (:option "texmacs->html:mathjax" "off")
-  (:option "texmacs->html:mathml" "off")
-  (:option "texmacs->html:images" "on")
+  (:option "texmacs->html:mathml" "on")
+  (:option "texmacs->html:images" "off")
   (:option "texmacs->html:css-stylesheet" "---"))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Set default export to docx to use MathML instead of image.

## Why
At present, the function of using MathML for export has been relatively perfect.