### PR TITLE
[70_14] Fix the retrieval and processing of the root node in lang_parser

### DIFF
--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -25,23 +25,19 @@ using moebius::drd::the_drd;
 extern tree the_et;
 using moebius::make_tree_label;
 
-lang_parser::lang_parser (string lang, string lang_id) {
+lang_parser::lang_parser (string lang_id) {
   // TODO: Dynamic loading of shared lib and multilingual switching
-  ast_parser           = ts_parser_new ();
-  string code_node_name= "scm";
+  ast_parser= ts_parser_new ();
   if (lang_id == "cpp") {
-    ts_lang       = tree_sitter_cpp ();
-    code_node_name= "cpp";
+    ts_lang= tree_sitter_cpp ();
   }
   else if (lang_id == "scheme") {
-    ts_lang       = tree_sitter_scheme ();
-    code_node_name= "scm";
+    ts_lang= tree_sitter_scheme ();
   }
   else {
     // TODO: A fallback tree sitter impl is needed
     ts_lang= tree_sitter_scheme ();
   }
-  // cout << lang << " parser created\n";
 
   ts_parser_set_language (ast_parser, ts_lang);
 }

--- a/src/Plugins/Treesitter/lang_parser.hpp
+++ b/src/Plugins/Treesitter/lang_parser.hpp
@@ -99,8 +99,6 @@ private:
   int last_end_pos     = -1;
   int inner_token_index= 0;
 
-  int             lang_code_op= 0;
-  int             lang_op     = 0;
   array<TSSymbol> bracket_symbol_list;
   array<uint32_t> brackets_depths_cache;
   int             brackets_pairs_amount= 0;

--- a/src/Plugins/Treesitter/lang_parser.hpp
+++ b/src/Plugins/Treesitter/lang_parser.hpp
@@ -21,7 +21,7 @@ constexpr TSSymbol SpaceSymbol= 65534;
 
 class lang_parser {
 public:
-  lang_parser (string lang, string lang_id);
+  lang_parser (string lang_id);
 
   /**
    * @brief Check current line of code has changed or not.

--- a/src/System/Language/ast_language.cpp
+++ b/src/System/Language/ast_language.cpp
@@ -39,10 +39,10 @@ ast_language_rep::ast_language_rep (string name) : language_rep (name) {
   tree lang_id_config= get_parser_config (lan_name, "id");
   if (N (lang_id_config) > 0) {
     string lang_id = get_label (lang_id_config[0]);
-    lang_ast_parser= tm_new<lang_parser> (lan_name, lang_id);
+    lang_ast_parser= tm_new<lang_parser> (lang_id);
   }
   else {
-    lang_ast_parser= tm_new<lang_parser> (lan_name, lan_name);
+    lang_ast_parser= tm_new<lang_parser> (lan_name);
   }
 
   tree keytoken_config= get_parser_config (lan_name, "keytoken");

--- a/src/System/Language/ast_language.cpp
+++ b/src/System/Language/ast_language.cpp
@@ -166,8 +166,9 @@ ast_language_rep::advance (tree t, int& pos) {
 
   // Avoid Error (if the token index is incorrect, avoid throwing an error
   // directly and instead highlight the error)
-  if (lang_ast_parser->get_token_index () > lang_ast_parser->get_token_num ()) {
-    cout << "ERROR token index out of bounds\n";
+  if (lang_ast_parser->get_token_index () >=
+      lang_ast_parser->get_token_num ()) {
+    // cout << "ERROR token index out of bounds\n";
     token_type= "INNER_ERROR";
     pos+= 1;
     return &tp_normal_rep;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What

1. `get_root_node` relies on the result of `get_child_env` to determine whether it is a code node.
2. Fixed `get_code_from_root` and `get_data_from_root` to support string nodes.
3. Fixed a minor bug in `add_single_token`.

## Why
Incorrect code root node can lead to performance degradation, rendering errors, and PDF export failures.
## How to test your changes?
Use Syntax Highlight