### PR TITLE
[70_16] Fix with node cause wrong root code and no prog root fallback

### DIFF
--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -95,7 +95,7 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
     if (!is_atomic (root)) {
       tree env_child= the_drd->get_env_child (root, tree_index, MODE, "");
       // tree prog_lan=
-      the_drd->get_env_child (root, tree_index, "prog-language", "");
+      // the_drd->get_env_child (root, tree_index, "prog-language", "");
       if (env_child == "prog") {
         root= root[tree_index];
         // cout << "Tree Index: " << tree_index << " Root: " << root << LF;

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -132,7 +132,8 @@ lang_parser::get_data_from_root (tree root, tree line, int& start_index) {
     change_line_pos << change_index;
   }
   else {
-    for (int i= 0; i < N (root); i++) {
+    int root_N= N (root);
+    for (int i= 0; i < root_N; i++) {
       tree child_node= root[i];
       if (the_drd->is_accessible_child (root, i)) {
         // cout << "Index: " << i << " Accessible Child: " << child_node << LF;
@@ -175,7 +176,8 @@ lang_parser::get_code_from_root (tree root, string& code, string_u8& code_u8) {
     }
   }
   else {
-    for (int i= 0; i < N (root); i++) {
+    int root_N= N (root);
+    for (int i= 0; i < root_N; i++) {
       tree child_node= root[i];
       if (the_drd->is_accessible_child (root, i)) {
         // cout << "Index: " << i << " Accessible Child: " << child_node << LF;

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -40,10 +40,6 @@ lang_parser::lang_parser (string lang_id) {
   }
 
   ts_parser_set_language (ast_parser, ts_lang);
-
-  // with(color, red, main), only "main" is the code part
-  tree with_tree (make_tree_label ("with"));
-  with_op= with_tree->op;
 }
 
 void
@@ -86,7 +82,7 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
   path last_ip   = father_ip;
   int  tree_index= 0;
 
-  while (N (father_ip) > 1) {
+  while (N (father_ip) > 0) {
     father_ip = father_ip->next;
     tree_index= reverse (last_ip)[N (father_ip)];
     if (tree_index < 0) {
@@ -107,7 +103,7 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
       }
     }
   }
-  if (N (father_ip) == 1) {
+  if (N (father_ip) == 0) {
     // cout << "Can not meet Prog " << t << " IP:" << obtain_ip(t) << LF;
     root= t; // Set Root To Self as Fallback
   }
@@ -118,7 +114,7 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
 
 void
 lang_parser::get_data_from_root (tree root, tree line, int& start_index) {
-  if (root->op == with_op) {
+  if (root->op == moebius::WITH) {
     root= root[N (root) - 1];
   }
   if (is_atomic (root)) {
@@ -165,7 +161,7 @@ lang_parser::get_code_str (tree root) {
 
 void
 lang_parser::get_code_from_root (tree root, string& code, string_u8& code_u8) {
-  if (root->op == with_op) {
+  if (root->op == moebius::WITH) {
     root= root[N (root) - 1];
   }
   if (is_atomic (root)) {

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -107,9 +107,10 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
       }
     }
   }
-  // if(N(father_ip) == 1){
-  //   cout << "Can not meet Prog " << t << " IP:" << obtain_ip(t) << LF;
-  // }
+  if (N (father_ip) == 1) {
+    // cout << "Can not meet Prog " << t << " IP:" << obtain_ip(t) << LF;
+    root= t; // Set Root To Self as Fallback
+  }
   hash_code= hash (root);
   get_data_from_root (root, t, start_index);
   return root;

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -40,6 +40,10 @@ lang_parser::lang_parser (string lang_id) {
   }
 
   ts_parser_set_language (ast_parser, ts_lang);
+
+  // with(color, red, main), only "main" is the code part
+  tree with_tree (make_tree_label ("with"));
+  with_op= with_tree->op;
 }
 
 void
@@ -113,6 +117,9 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
 
 void
 lang_parser::get_data_from_root (tree root, tree line, int& start_index) {
+  if (root->op == with_op) {
+    root= root[N (root) - 1];
+  }
   if (is_atomic (root)) {
     leaf_tree_nodes << root;
     int local_start_index= 0;
@@ -157,6 +164,9 @@ lang_parser::get_code_str (tree root) {
 
 void
 lang_parser::get_code_from_root (tree root, string& code, string_u8& code_u8) {
+  if (root->op == with_op) {
+    root= root[N (root) - 1];
+  }
   if (is_atomic (root)) {
     code << root->label;
     code_u8 << cork_to_utf8 (root->label);

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -94,8 +94,8 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
     // cout << "Father: " << father_ip << " Root:" << root << LF;
     if (!is_atomic (root)) {
       tree env_child= the_drd->get_env_child (root, tree_index, MODE, "");
-      // cout << "Env Child: " << env_child << " tree_index" << tree_index <<
-      // LF;
+      // tree prog_lan=
+      the_drd->get_env_child (root, tree_index, "prog-language", "");
       if (env_child == "prog") {
         root= root[tree_index];
         // cout << "Tree Index: " << tree_index << " Root: " << root << LF;
@@ -105,7 +105,7 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
   }
   if (N (father_ip) == 0) {
     // cout << "Can not meet Prog " << t << " IP:" << obtain_ip(t) << LF;
-    root= t; // Set Root To Self as Fallback
+    root= root[tree_index]; // Set Root To Self as Fallback
   }
   hash_code= hash (root);
   get_data_from_root (root, t, start_index);
@@ -114,9 +114,6 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
 
 void
 lang_parser::get_data_from_root (tree root, tree line, int& start_index) {
-  if (root->op == moebius::WITH) {
-    root= root[N (root) - 1];
-  }
   if (is_atomic (root)) {
     leaf_tree_nodes << root;
     int local_start_index= 0;
@@ -135,8 +132,12 @@ lang_parser::get_data_from_root (tree root, tree line, int& start_index) {
     change_line_pos << change_index;
   }
   else {
-    for (tree child_node : root) {
-      get_data_from_root (child_node, line, start_index);
+    for (int i= 0; i < N (root); i++) {
+      tree child_node= root[i];
+      if (the_drd->is_accessible_child (root, i)) {
+        // cout << "Index: " << i << " Accessible Child: " << child_node << LF;
+        get_data_from_root (child_node, line, start_index);
+      }
     }
   }
 }
@@ -161,9 +162,6 @@ lang_parser::get_code_str (tree root) {
 
 void
 lang_parser::get_code_from_root (tree root, string& code, string_u8& code_u8) {
-  if (root->op == moebius::WITH) {
-    root= root[N (root) - 1];
-  }
   if (is_atomic (root)) {
     code << root->label;
     code_u8 << cork_to_utf8 (root->label);
@@ -177,8 +175,12 @@ lang_parser::get_code_from_root (tree root, string& code, string_u8& code_u8) {
     }
   }
   else {
-    for (tree child_node : root) {
-      get_code_from_root (child_node, code, code_u8);
+    for (int i= 0; i < N (root); i++) {
+      tree child_node= root[i];
+      if (the_drd->is_accessible_child (root, i)) {
+        // cout << "Index: " << i << " Accessible Child: " << child_node << LF;
+        get_code_from_root (child_node, code, code_u8);
+      }
     }
   }
 }

--- a/src/Plugins/Treesitter/lang_parser.hpp
+++ b/src/Plugins/Treesitter/lang_parser.hpp
@@ -99,8 +99,6 @@ private:
   int last_end_pos     = -1;
   int inner_token_index= 0;
 
-  int with_op= 0;
-
   array<TSSymbol> bracket_symbol_list;
   array<uint32_t> brackets_depths_cache;
   int             brackets_pairs_amount= 0;

--- a/src/Plugins/Treesitter/lang_parser.hpp
+++ b/src/Plugins/Treesitter/lang_parser.hpp
@@ -99,6 +99,8 @@ private:
   int last_end_pos     = -1;
   int inner_token_index= 0;
 
+  int with_op= 0;
+
   array<TSSymbol> bracket_symbol_list;
   array<uint32_t> brackets_depths_cache;
   int             brackets_pairs_amount= 0;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What

1. With node may cause wrong root code
2. If a prog node is not encountered, the entire document will be rendered, leading to performance issues.

## Why

1. A with node has more than one string child node, and only the last child node is the one that is actually rendered as a string node.
2. When a prog node is not encountered, it uses its own string node for rendering.