### PR TITLE
[79_6] Performance tuning on vertex_occurrences in link.cpp

### DIFF
--- a/src/Data/Observers/link.cpp
+++ b/src/Data/Observers/link.cpp
@@ -63,12 +63,13 @@ unregister_pointer (string id, observer which) {
 
 void
 register_vertex (tree v, soft_link ln) {
-  if (vertex_occurrences->contains(v)) {
+  if (vertex_occurrences->contains (v)) {
     hashset<soft_link>& l= vertex_occurrences (v);
     l->insert (ln);
-  } else {
+  }
+  else {
     hashset<soft_link> l= hashset<soft_link> ();
-    l->insert(ln);
+    l->insert (ln);
     vertex_occurrences (v)= l;
   }
 }


### PR DESCRIPTION
## What
Use hashset instead list for faster insertion and removal.

## How to test your changes?
Use Goldfish.tmu as the test doc: https://github.com/LiiiLabs/goldfish/blob/main/Goldfish.tmu
