### PR TITLE
[80_3] Enhance sup/subscript kerning via OpenType math table

### DIFF
--- a/devel/80_3.tmu
+++ b/devel/80_3.tmu
@@ -1,0 +1,63 @@
+<TMU|<tuple|1.0.5|1.2.9.5>>
+
+<style|generic>
+
+<\body>
+  Asana Math:
+
+  <math|<big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>>
+
+  <\equation*>
+    <big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>
+  </equation*>
+
+  \;
+
+  Fira Math:
+
+  <\with|font|Fira Math>
+    <math|<big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>>
+
+    <\equation*>
+      <big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>
+    </equation*>
+  </with>
+
+  \;
+
+  TeX Gyre Pagella Math:
+
+  <\with|font|TeX Gyre Pagella Math>
+    <math|<big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>>
+
+    <\equation*>
+      <big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>
+    </equation*>
+
+    \;
+  </with>
+
+  TeX Gyre Schola Math:
+
+  <\with|font|TeX Gyre Schola Math>
+    <math|<big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>>
+
+    <\equation*>
+      <big|oint><rsub|1><rsup|1><big|int><rsub|1><rsup|1><big|iint><rsub|1><rsup|1>𝑒<rsup|𝑥>dx BA<rsub|1><rsup|1> UV<rsub|1><rsup|1>ZZ<rsub|1><rsup|1>PQ<rsub|1><rsup|1>\<Omega\><rsub|1><rsup|1>\<Lambda\><rsub|1><rsup|1>\<Delta\><rsub|4><rsup|4>\<alpha\><rsub|4><rsup|4>\<b-cal-M\><rsub|4><rsup|4>𝓐<rsub|4><rsup|4>𝓥<rsup|4><rsub|4>𝓦<rsub|4><rsup|4>
+    </equation*>
+  </with>
+
+  \;
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|font|Asana Math>
+    <associate|font-base-size|14>
+    <associate|font-family|rm>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Plugins/Freetype/tt_tools.cpp
+++ b/src/Plugins/Freetype/tt_tools.cpp
@@ -376,13 +376,13 @@ tt_font_name (url u) {
 unsigned int
 ot_mathtable_rep::get_init_glyphID (unsigned int glyphID) {
   // init cache
-  if (N (glyphID_to_init_glyphID) == 0) {
+  if (N (get_init_glyphID_cache) == 0) {
     auto it= iterate (ver_glyph_variants);
     while (it->busy ()) {
       unsigned int        gid= it->next ();
       array<unsigned int> v  = ver_glyph_variants (gid);
       for (unsigned vid : v) {
-        glyphID_to_init_glyphID (vid)= gid;
+        get_init_glyphID_cache (vid)= gid;
       }
     }
     it= iterate (hor_glyph_variants);
@@ -390,13 +390,14 @@ ot_mathtable_rep::get_init_glyphID (unsigned int glyphID) {
       unsigned int        gid= it->next ();
       array<unsigned int> v  = hor_glyph_variants (gid);
       for (unsigned vid : v) {
-        glyphID_to_init_glyphID (vid)= gid;
+        get_init_glyphID_cache (vid)= gid;
       }
     }
   }
 
-  if (glyphID_to_init_glyphID->contains (glyphID)) {
-    return glyphID_to_init_glyphID (glyphID);
+  // look up cache
+  if (get_init_glyphID_cache->contains (glyphID)) {
+    return get_init_glyphID_cache (glyphID);
   }
 
   return glyphID;

--- a/src/Plugins/Freetype/tt_tools.cpp
+++ b/src/Plugins/Freetype/tt_tools.cpp
@@ -438,8 +438,8 @@ MathKernInfoRecord::get_kerning (int height, bool top, bool left) {
       }
     }
   }
-  cout << "get_kerning : height " << height << " -> " << idx << " -> "
-       << kt.kernValues[idx] << LF;
+  // cout << "get_kerning : height " << height << " -> " << idx << " -> "
+  //  << kt.kernValues[idx] << LF;
   return kt.kernValues[idx];
 }
 

--- a/src/Plugins/Freetype/tt_tools.cpp
+++ b/src/Plugins/Freetype/tt_tools.cpp
@@ -12,6 +12,7 @@
 #include "tt_tools.hpp"
 #include "analyze.hpp"
 #include "file.hpp"
+#include "iterator.hpp"
 #include "tm_file.hpp"
 #include "tree_helper.hpp"
 #include "tt_file.hpp"
@@ -372,6 +373,35 @@ tt_font_name (url u) {
  * OpenType MATH table
  ******************************************************************************/
 
+unsigned int
+ot_mathtable_rep::get_init_glyphID (unsigned int glyphID) {
+  // init cache
+  if (N (glyphID_to_init_glyphID) == 0) {
+    auto it= iterate (ver_glyph_variants);
+    while (it->busy ()) {
+      unsigned int        gid= it->next ();
+      array<unsigned int> v  = ver_glyph_variants (gid);
+      for (unsigned vid : v) {
+        glyphID_to_init_glyphID (vid)= gid;
+      }
+    }
+    it= iterate (hor_glyph_variants);
+    while (it->busy ()) {
+      unsigned int        gid= it->next ();
+      array<unsigned int> v  = hor_glyph_variants (gid);
+      for (unsigned vid : v) {
+        glyphID_to_init_glyphID (vid)= gid;
+      }
+    }
+  }
+
+  if (glyphID_to_init_glyphID->contains (glyphID)) {
+    return glyphID_to_init_glyphID (glyphID);
+  }
+
+  return glyphID;
+}
+
 bool
 MathKernInfoRecord::has_kerning (bool top, bool left) {
   return (top ? (left ? hasTopLeft : hasTopRight)
@@ -407,6 +437,8 @@ MathKernInfoRecord::get_kerning (int height, bool top, bool left) {
       }
     }
   }
+  cout << "get_kerning : height " << height << " -> " << idx << " -> "
+       << kt.kernValues[idx] << LF;
   return kt.kernValues[idx];
 }
 

--- a/src/Plugins/Freetype/tt_tools.hpp
+++ b/src/Plugins/Freetype/tt_tools.hpp
@@ -13,6 +13,7 @@
 #define TT_TOOLS_H
 
 #include "basic.hpp"
+#include "hashmap.hpp"
 #include "hashset.hpp"
 #include "tm_debug.hpp"
 #include "tree.hpp"
@@ -215,7 +216,7 @@ struct MathKernInfoRecord {
   MathKernInfoRecord ()
       : hasTopRight (false), hasTopLeft (false), hasBottomRight (false),
         hasBottomLeft (false) {}
-        
+
   bool has_kerning (bool top, bool left);
   int  get_kerning (int height, bool top, bool left);
 };
@@ -247,6 +248,10 @@ struct ot_mathtable_rep : concrete_struct {
   hashmap<unsigned int, array<unsigned int>> hor_glyph_variants_adv;
   hashmap<unsigned int, GlyphAssembly>       ver_glyph_assembly;
   hashmap<unsigned int, GlyphAssembly>       hor_glyph_assembly;
+
+  // helper functions and data
+  hashmap<unsigned int, unsigned int> glyphID_to_init_glyphID;
+  unsigned int                        get_init_glyphID (unsigned int glyphID);
 
   bool has_kerning (unsigned int glyphID, bool top, bool left);
   int  get_kerning (unsigned int glyphID, int height, bool top, bool left);

--- a/src/Plugins/Freetype/tt_tools.hpp
+++ b/src/Plugins/Freetype/tt_tools.hpp
@@ -250,8 +250,9 @@ struct ot_mathtable_rep : concrete_struct {
   hashmap<unsigned int, GlyphAssembly>       hor_glyph_assembly;
 
   // helper functions and data
-  hashmap<unsigned int, unsigned int> glyphID_to_init_glyphID;
-  unsigned int                        get_init_glyphID (unsigned int glyphID);
+  hashmap<unsigned int, unsigned int> get_init_glyphID_cache;
+  // for variant glyph, get the glyphID of the base glyph
+  unsigned int get_init_glyphID (unsigned int glyphID);
 
   bool has_kerning (unsigned int glyphID, bool top, bool left);
   int  get_kerning (unsigned int glyphID, int height, bool top, bool left);

--- a/src/Plugins/Freetype/tt_tools.hpp
+++ b/src/Plugins/Freetype/tt_tools.hpp
@@ -215,6 +215,9 @@ struct MathKernInfoRecord {
   MathKernInfoRecord ()
       : hasTopRight (false), hasTopLeft (false), hasBottomRight (false),
         hasBottomLeft (false) {}
+        
+  bool has_kerning (bool top, bool left);
+  int  get_kerning (int height, bool top, bool left);
 };
 
 struct GlyphPartRecord {
@@ -244,6 +247,9 @@ struct ot_mathtable_rep : concrete_struct {
   hashmap<unsigned int, array<unsigned int>> hor_glyph_variants_adv;
   hashmap<unsigned int, GlyphAssembly>       ver_glyph_assembly;
   hashmap<unsigned int, GlyphAssembly>       hor_glyph_assembly;
+
+  bool has_kerning (unsigned int glyphID, bool top, bool left);
+  int  get_kerning (unsigned int glyphID, int height, bool top, bool left);
 };
 
 struct ot_mathtable {

--- a/src/Plugins/Freetype/unicode_font.cpp
+++ b/src/Plugins/Freetype/unicode_font.cpp
@@ -989,7 +989,7 @@ unicode_font_rep::get_rsup_correction (string s) {
 
     if (has_ic || has_kern) {
       // for integral signs, we use 2/5 of italic correction for rsup
-      if (is_ot_integral (s)) ic= (SI) (ic * 0.45);
+      if (is_ot_integral (s)) ic= (SI) (0.4 * ic);
       SI r= ic + kern;
       // cout << "get_rsup_correction for: " << s << " " << rr << LF;
       return r;

--- a/src/Plugins/Freetype/unicode_font.hpp
+++ b/src/Plugins/Freetype/unicode_font.hpp
@@ -37,7 +37,7 @@ struct unicode_font_rep : font_rep {
   ot_mathtable math_table;
   font         make_rubber_font (font base) override;
   bool get_ot_kerning (string s, SI height, bool top, bool left, SI& kerning);
-  bool get_ot_italic_correction (string s, bool left, SI& r);
+  bool get_ot_italic_correction (string s, SI& r);
   bool is_ot_integral (string s);
   hashset<unsigned int> ot_integral;
 

--- a/src/Plugins/Freetype/unicode_font.hpp
+++ b/src/Plugins/Freetype/unicode_font.hpp
@@ -36,10 +36,14 @@ struct unicode_font_rep : font_rep {
   tt_face      math_face;
   ot_mathtable math_table;
   font         make_rubber_font (font base) override;
+  bool get_ot_kerning (string s, SI height, bool top, bool left, SI& kerning);
+  bool get_ot_italic_correction (string s, bool left, SI& r);
+  bool is_ot_integral(string s);
 
   unicode_font_rep (string name, string family, int size, int hdpi, int vdpi);
   void tex_gyre_operators ();
 
+  unsigned int get_glyphID (string s);
   unsigned int read_unicode_char (string s, int& i);
   unsigned int ligature_replace (unsigned int c, string s, int& i);
   bool         supports (string c);

--- a/src/Plugins/Freetype/unicode_font.hpp
+++ b/src/Plugins/Freetype/unicode_font.hpp
@@ -38,7 +38,8 @@ struct unicode_font_rep : font_rep {
   font         make_rubber_font (font base) override;
   bool get_ot_kerning (string s, SI height, bool top, bool left, SI& kerning);
   bool get_ot_italic_correction (string s, bool left, SI& r);
-  bool is_ot_integral(string s);
+  bool is_ot_integral (string s);
+  hashset<unsigned int> ot_integral;
 
   unicode_font_rep (string name, string family, int size, int hdpi, int vdpi);
   void tex_gyre_operators ();


### PR DESCRIPTION
## What
We have utilized the italic correction table and kerning table in OpenType to optimize the typesetting of superscripts and subscripts.

However, it is important to note that this implementation is non-standard.

The italic correction table is used to improve the typesetting on the right side of glyphs. For general characters, the right subscript uses the default position, while the right superscript needs to be shifted to the right by this correction. For symbols like integral signs, the official documentation suggests that both the right superscript and right subscript should be moved by half the offset, while some documents recommend that the superscript remain stationary and the subscript be moved by the full offset. For aesthetic reasons, we have adopted a compromise solution here, where the subscript is shifted left by 0.6 times the offset and the superscript is shifted right by 0.4 times the offset.

For the kerning table, it provides correction values for the left and right superscripts and subscripts of a glyph based on their height. According to the OpenType standard recommendations, we should select an optimal correction value by considering both the base glyph and the superscript/subscript glyph at the two recommended correction heights. However, we are unable to handle this in the font's cpp file, so we have opted for a simpler approach, using `fn->y1` and `fn->y2` as the correction heights for the subscript and superscript, respectively, which also yields satisfactory results. 

Another fact is that many fonts do not provide a kerning table or only provide a very limited kerning table, and almost none of them provide correction values for left superscripts and subscripts. So it can be considered that this PR does not actually change any left-side typesetting.

## Why
For certain OpenType fonts, some symbols such as integral signs and superscripts/subscripts appear in incorrect positions. Now, we can improve this by utilizing the metrics provided in OpenType.

## How to test
Open `devel/80_3.tmu`.

Before:
![image](https://github.com/user-attachments/assets/ff0aef4c-5c5d-4c87-8853-60ef18732134)

After:
![image](https://github.com/user-attachments/assets/f3076b05-eae4-4dbc-848e-288340669288)

It can be seen that the first two Opentype fonts have been correctly improved, while the latter two have not changed because we used a hardcoded solution.