### PR TITLE
[78_8] Fix warning: remove unused

### DIFF
--- a/devel/78.tmu
+++ b/devel/78.tmu
@@ -7,7 +7,7 @@
 
   <section|Tasks>
 
-  <tabular|<tformat|<twith|table-width|1par>|<twith|table-hmode|exact>|<cwith|6|6|5|5|cell-hyphen|t>|<cwith|5|5|5|5|cell-hyphen|t>|<table|<row|<cell|Chore>|<cell|78_7>|<cell|<value|da>>|<cell|v1.2.6>|<cell|Minor: Fix missing return in <cpp|font_spacing>>>|<row|<cell|Chore>|<cell|78_6>|<cell|<value|jk>>|<cell|v1.2.6>|<cell|remove unnecessary cpp check>>|<row|<cell|Chore>|<cell|78_5>|<cell|<value|da>>|<cell|v1.2.6>|<cell|Avoid dangling else in src/Plugins/Qt/qt_utilities.cpp>>|<row|<cell|Chore>|<cell|78_4>|<cell|<value|da>>|<cell|v1.2.6>|<cell|Fix missing return in QTMPixmapOrImage>>|<row|<cell|Chore>|<cell|78_3>|<cell|<value|da>>|<cell|v1.2.6>|<\cell>
+  <tabular|<tformat|<twith|table-width|1par>|<twith|table-hmode|exact>|<cwith|7|7|5|5|cell-hyphen|t>|<cwith|6|6|5|5|cell-hyphen|t>|<table|<row|<cell|Chore>|<cell|78_8>|<cell|Yu>|<cell|v1.2.9>|<cell|Remove unused variable and unrecognized character escape>>|<row|<cell|Chore>|<cell|78_7>|<cell|<value|da>>|<cell|v1.2.6>|<cell|Minor: Fix missing return in <cpp|font_spacing>>>|<row|<cell|Chore>|<cell|78_6>|<cell|<value|jk>>|<cell|v1.2.6>|<cell|remove unnecessary cpp check>>|<row|<cell|Chore>|<cell|78_5>|<cell|<value|da>>|<cell|v1.2.6>|<cell|Avoid dangling else in src/Plugins/Qt/qt_utilities.cpp>>|<row|<cell|Chore>|<cell|78_4>|<cell|<value|da>>|<cell|v1.2.6>|<cell|Fix missing return in QTMPixmapOrImage>>|<row|<cell|Chore>|<cell|78_3>|<cell|<value|da>>|<cell|v1.2.6>|<\cell>
     Fix non-void function does not return a value in all control paths in tree_cursor
   </cell>>|<row|<cell|Chore>|<cell|78_2>|<cell|<value|da>>|<cell|v1.2.5>|<\cell>
     Gitee Scan Rule 025: Effective C++, item 30: understand the ins and outs of inlining

--- a/src/Plugins/Tex/fromtex.cpp
+++ b/src/Plugins/Tex/fromtex.cpp
@@ -2632,7 +2632,7 @@ latex_command_to_tree (tree t) {
   if (is_tuple (t, "\\cases", 1)) {
     tree u= l2e (t[1]);
     tree r= tree (CONCAT);
-    r << tree (LEFT, "\{") << tree (BEGIN, "array", "lll") << u
+    r << tree (LEFT, "{") << tree (BEGIN, "array", "lll") << u
       << tree (END, "array") << tree (RIGHT, ".");
     return r;
   }

--- a/src/Typeset/Boxes/Basic/boxes.cpp
+++ b/src/Typeset/Boxes/Basic/boxes.cpp
@@ -895,7 +895,6 @@ tree
 box_rep::message (tree t, SI x, SI y, rectangles& rs) {
   (void) x;
   (void) y;
-  (void) delta;
   (void) t;
   (void) rs;
   return "";


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What

Fix warnings

`src\Typeset\Boxes\Basic\boxes.cpp(898): warning C4551: function call missing argument list`

`src\Plugins\Tex\fromtex.cpp(2635): warning C4129: '{': unrecognized character escape sequence`

## Why

## How to test your changes?

import latex file test.tex: `123{123}\{123\}\cases{123}` shows that `"\{"` in fromtex.cpp should be `"{"` instead of `"\\{"`.
