### PR TITLE
[24_22] Add documentation to remind users to use the installed version of pandoc

### DIFF
--- a/TeXmacs/plugins/docx/progs/data/docx.scm
+++ b/TeXmacs/plugins/docx/progs/data/docx.scm
@@ -50,7 +50,7 @@
                                   (url->string html-temp-url)
                                   " -o "
                                   (url->string docx-temp-url))))
-          ; (display cmd) ;; For debugging
+          (display (string-append "debug: cmd for Pandoc: " cmd)) ;; For debugging
           (system cmd)
           (with result (string-load docx-temp-url)
             (system-remove html-temp-url)

--- a/TeXmacs/plugins/docx/progs/data/docx.scm
+++ b/TeXmacs/plugins/docx/progs/data/docx.scm
@@ -50,7 +50,7 @@
                                   (url->string html-temp-url)
                                   " -o "
                                   (url->string docx-temp-url))))
-          (display (string-append "debug: cmd for Pandoc: " cmd)) ;; For debugging
+          (debug-message "debug-io" (string-append "debug: cmd for Pandoc: " cmd)) ;; For debugging
           (system cmd)
           (with result (string-load docx-temp-url)
             (system-remove html-temp-url)

--- a/docs/guide/plugin_data_docx.md
+++ b/docs/guide/plugin_data_docx.md
@@ -5,4 +5,6 @@ Export method: The option to export to docx is in `File->Export->docx`.
 ### Prerequisite: `pandoc`
 The process of converting a TeXmacs document to a docx document relies on the third-party application `pandoc`. If `pandoc` is not available in the environment during export, an error will occur, and the export will fail.
 
+It is recommended to use the installed version of pandoc instead of the free version to circumvent problems caused by different PATH.
+
 For information on installing the `pandoc` plugin, please refer to [Pandoc Binary Plugin](./plugin_binary_pandoc.md).

--- a/docs/zh/guide/plugin_data_docx.md
+++ b/docs/zh/guide/plugin_data_docx.md
@@ -5,4 +5,6 @@
 ### 前置必要条件：`pandoc`
 TeXmacs文档转换为docx文档的过程依赖于第三方应用`pandoc`，如果导出时环境内不包含`pandoc`，则会报错而无法导出。
 
+推荐使用安装版的pandoc而不是免安装版，以规避因PATH不同而导致的问题。
+
 关于`pandoc`插件的安装请参考 [Pandoc 二进制插件](./plugin_binary_pandoc.md)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
As title

## Why
To call the no-install version of pandoc must get the pandoc path in the environment variable PATH, which is not recommended.
Added a debug information to inform user which pandoc is being used.