### PR TITLE
[61_2] Python: move the python and python-code tag to python.ts

### DIFF
--- a/TeXmacs/packages/environment/env-program.ts
+++ b/TeXmacs/packages/environment/env-program.ts
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.13>
+<TeXmacs|2.1.2>
 
 <style|<tuple|source|std>>
 
@@ -164,15 +164,13 @@
   <assign|c++|<macro|<name|C++>>>
 
   <assign|python|<macro|<name|Python>>>
-  
+
   <assign|shell|<macro|body|<with|mode|prog|prog-language|shell|font-family|rm|<arg|body>>>>
 
   <assign|scm|<macro|body|<with|mode|prog|prog-language|scheme|font-family|rm|<arg|body>>>>
 
   <assign|cpp|<macro|body|<with|mode|prog|prog-language|cpp|font-family|rm|<arg|body>>>>
 
-  <assign|python|<macro|body|<with|mode|prog|prog-language|python|font-family|rm|<arg|body>>>>
-  
   <\active*>
     <\src-comment>
       Blocks of code for standard languages
@@ -209,12 +207,6 @@
     </pseudo-code>
   </macro>>
 
-  <assign|python-code|<\macro|body>
-    <\pseudo-code>
-      <python|<arg|body>>
-    </pseudo-code>
-  </macro>>
-  
   <\active*>
     <\src-comment>
       Deprecated markup for algorithms

--- a/TeXmacs/packages/environment/env-program.ts
+++ b/TeXmacs/packages/environment/env-program.ts
@@ -163,8 +163,6 @@
 
   <assign|c++|<macro|<name|C++>>>
 
-  <assign|python|<macro|<name|Python>>>
-
   <assign|shell|<macro|body|<with|mode|prog|prog-language|shell|font-family|rm|<arg|body>>>>
 
   <assign|scm|<macro|body|<with|mode|prog|prog-language|scheme|font-family|rm|<arg|body>>>>

--- a/TeXmacs/plugins/code/progs/prog/prog-kbd.scm
+++ b/TeXmacs/plugins/code/progs/prog/prog-kbd.scm
@@ -17,8 +17,7 @@
         (prog scheme-tools)
         (prog prog-mode)
         (code scheme-edit)
-        (code cpp-edit)
-        (code python-edit)))
+        (code cpp-edit)))
 
 (kbd-map
   (:mode in-prog?)

--- a/TeXmacs/plugins/python/packages/code/python.ts
+++ b/TeXmacs/plugins/python/packages/code/python.ts
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.19>
+<TeXmacs|2.1.2>
 
 <style|source>
 
@@ -10,7 +10,11 @@
       Markup for Python sessions.
     </src-purpose>
 
-    <src-copyright|2021|Joris van der Hoeven>
+    <\src-copyright|2021>
+      Joris van der Hoeven
+
+      \ \ \ \ 2024 by Darcy Shen
+    </src-copyright>
 
     <\src-license>
       This software falls under the <hlink|GNU general public license,
@@ -19,6 +23,14 @@
       which the software. If not, see <hlink|http://www.gnu.org/licenses/gpl-3.0.html|http://www.gnu.org/licenses/gpl-3.0.html>.
     </src-license>
   </src-title>>
+
+  <assign|python|<macro|body|<with|mode|prog|prog-language|python|font-family|rm|<arg|body>>>>
+
+  <assign|python-code|<\macro|body>
+    <\pseudo-code>
+      <python|<arg|body>>
+    </pseudo-code>
+  </macro>>
 
   <\active*>
     <\src-comment>

--- a/TeXmacs/plugins/python/packages/code/python.ts
+++ b/TeXmacs/plugins/python/packages/code/python.ts
@@ -26,6 +26,8 @@
 
   <use-module|(data python)>
 
+  <use-module|(code python-edit)>
+
   <assign|python|<macro|body|<with|mode|prog|prog-language|python|font-family|rm|<arg|body>>>>
 
   <assign|python-code|<\macro|body>

--- a/TeXmacs/plugins/python/packages/code/python.ts
+++ b/TeXmacs/plugins/python/packages/code/python.ts
@@ -24,6 +24,8 @@
     </src-license>
   </src-title>>
 
+  <use-module|(data python)>
+
   <assign|python|<macro|body|<with|mode|prog|prog-language|python|font-family|rm|<arg|body>>>>
 
   <assign|python-code|<\macro|body>

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -218,13 +218,11 @@
   ---
   (-> "Inline code"
       ("C++" (make 'cpp))
-      ("Python" (make 'python))
       ("Scheme" (make 'scm))
       ("Shell" (make 'shell))
       ("Verbatim" (make 'verbatim)))
   (-> "Block of code"
       ("C++" (make 'cpp-code))
-      ("Python" (make 'python-code))
       ("Scheme" (make 'scm-code))
       ("Shell" (make 'shell-code))
       ("Verbatim" (make 'verbatim-code))))

--- a/TeXmacs/tests/tmu/61_2_python_code.tmu
+++ b/TeXmacs/tests/tmu/61_2_python_code.tmu
@@ -1,0 +1,18 @@
+<TMU|<tuple|1.0.3|1.2.9.2-rc5>>
+
+<style|<tuple|generic|chinese>>
+
+<\body>
+  <\python-code>
+    import os
+
+    os.chdir("/tmp")
+  </python-code>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/TeXmacs/tests/tmu/61_2_python_code.tmu
+++ b/TeXmacs/tests/tmu/61_2_python_code.tmu
@@ -1,6 +1,6 @@
 <TMU|<tuple|1.0.3|1.2.9.2-rc5>>
 
-<style|<tuple|generic|chinese>>
+<style|<tuple|generic|chinese|python>>
 
 <\body>
   <\python-code>

--- a/src/Typeset/Concat/concat_text.cpp
+++ b/src/Typeset/Concat/concat_text.cpp
@@ -14,6 +14,7 @@
 #include "cork.hpp"
 #include "formatter.hpp"
 #include "preferences.hpp"
+#include "tm_debug.hpp"
 
 using namespace moebius;
 
@@ -199,8 +200,8 @@ concater_rep::typeset_prog_string (tree t, path ip, int pos, int end) {
       PRINT_SPACE (tp->spc_before)
       string color  = env->lan->get_color (t, start, pos);
       string content= s (start, pos);
-      // cout << "[" << start << "," << pos << ") "
-      //      << content << " (" << color << ")" << LF;
+      debug_automatic << "[" << start << "," << pos << ") "
+           << content << " (" << color << ")" << LF;
       typeset_colored_substring (content, ip, start, color);
       penalty_min (tp->pen_after);
       PRINT_SPACE (tp->spc_after)

--- a/src/Typeset/Concat/concat_text.cpp
+++ b/src/Typeset/Concat/concat_text.cpp
@@ -14,7 +14,6 @@
 #include "cork.hpp"
 #include "formatter.hpp"
 #include "preferences.hpp"
-#include "tm_debug.hpp"
 
 using namespace moebius;
 
@@ -200,8 +199,8 @@ concater_rep::typeset_prog_string (tree t, path ip, int pos, int end) {
       PRINT_SPACE (tp->spc_before)
       string color  = env->lan->get_color (t, start, pos);
       string content= s (start, pos);
-      debug_automatic << "[" << start << "," << pos << ") "
-           << content << " (" << color << ")" << LF;
+      // cout << "[" << start << "," << pos << ") "
+      //      << content << " (" << color << ")" << LF;
       typeset_colored_substring (content, ip, start, color);
       penalty_min (tp->pen_after);
       PRINT_SPACE (tp->spc_after)


### PR DESCRIPTION
## What
One must add the python.ts style file to use `python` and `python-code`.

## Why
To make python syntax highlight pluggable and stable.
