### PR TITLE
[70_18] Fix the inaccurate method of obtaining line_hash

### DIFF
--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -62,8 +62,13 @@ lang_parser::add_brackets_pair (string forward, string backward) {
 
 bool
 lang_parser::check_line_changed (tree t) {
+  int line_length= N (t->label);
+  if (line_length != current_line_length) {
+    current_line_length= line_length;
+    return true;
+  }
   // hash(t) does not take IP changes into account
-  int line_hash= hash (obtain_ip (t)) ^ hash (t->label) ^ N (t);
+  int line_hash= hash (obtain_ip (t)) ^ hash (t->label);
   // cout << "t: [" << t << "] line_hash: " << line_hash << " hash (t->label): "
   // << hash (t->label) << " current_line_hash: " << current_line_hash <<"\n";
 

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -63,9 +63,10 @@ lang_parser::add_brackets_pair (string forward, string backward) {
 bool
 lang_parser::check_line_changed (tree t) {
   // hash(t) does not take IP changes into account
-  int line_hash= hash (obtain_ip (t)) + hash (t->label) / 2;
-  // cout << "t->label: " << t->label << " obtain_ip (t): " << obtain_ip (t)
-  // <<"\n";
+  int line_hash= hash (obtain_ip (t)) ^ hash (t->label);
+  // cout << "t: [" << t << "] line_hash: " << line_hash
+  //      << " current_line_hash: " << current_line_hash <<"\n";
+
   if (line_hash != current_line_hash) {
     current_line_hash= line_hash;
     return true;

--- a/src/Plugins/Treesitter/lang_parser.cpp
+++ b/src/Plugins/Treesitter/lang_parser.cpp
@@ -63,9 +63,9 @@ lang_parser::add_brackets_pair (string forward, string backward) {
 bool
 lang_parser::check_line_changed (tree t) {
   // hash(t) does not take IP changes into account
-  int line_hash= hash (obtain_ip (t)) ^ hash (t->label);
-  // cout << "t: [" << t << "] line_hash: " << line_hash
-  //      << " current_line_hash: " << current_line_hash <<"\n";
+  int line_hash= hash (obtain_ip (t)) ^ hash (t->label) ^ N (t);
+  // cout << "t: [" << t << "] line_hash: " << line_hash << " hash (t->label): "
+  // << hash (t->label) << " current_line_hash: " << current_line_hash <<"\n";
 
   if (line_hash != current_line_hash) {
     current_line_hash= line_hash;
@@ -115,7 +115,7 @@ lang_parser::get_root_node (tree t, int& start_index, int& hash_code) {
 
   // Add this to avoid wrong hash code
   if (N (change_line_pos) > 0) {
-    hash_code+= change_line_pos[N (change_line_pos) - 1];
+    hash_code^= change_line_pos[N (change_line_pos) - 1];
   }
 
   return root;

--- a/src/Plugins/Treesitter/lang_parser.hpp
+++ b/src/Plugins/Treesitter/lang_parser.hpp
@@ -91,8 +91,9 @@ public:
 private:
   TSParser*         ast_parser;
   const TSLanguage* ts_lang;
-  int               current_code_hash= 0;
-  int               current_line_hash= 0;
+  int               current_code_hash  = 0;
+  int               current_line_hash  = 0;
+  int               current_line_length= 0;
 
   int real_code_len    = 0;
   int fix_pos_moved    = 0;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
The inaccurate line_hash sometimes prevents the code from being re-rendered correctly. The old line_hash for four spaces and three spaces is the same.