### PR TITLE
[80_4] Improving the Typesetting of Limit Boxes

### DIFF
--- a/devel/80_4.tmu
+++ b/devel/80_4.tmu
@@ -1,0 +1,18 @@
+<TMU|<tuple|1.0.3|1.2.9.2-rc5>>
+
+<style|<tuple|generic|chinese>>
+
+<\body>
+  <\equation*>
+    <big|sum><rsub|𝑘=0><rsup|\<infty\>><big|sum><rsub|k=<frac|1+<frac|1|2>|2>><rsup|<frac|2|2+<frac|1|2>>>lim<rsub|𝑘=0><rsup|\<infty\>>lim<rsub|k=<frac|1+<frac|1|2>|2>><rsup|<frac|2|2+<frac|1|2>>>
+  </equation*>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|font|Asana Math>
+    <associate|font-family|rm>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Graphics/Fonts/font.cpp
+++ b/src/Graphics/Fonts/font.cpp
@@ -94,6 +94,12 @@ font_rep::copy_math_pars (font fn) {
   wfn         = fn->wfn;
   wline       = fn->wline;
   wquad       = fn->wquad;
+
+  // opentype math parameters
+  upper_limit_gap_min          = fn->upper_limit_gap_min;
+  upper_limit_baseline_rise_min= fn->upper_limit_baseline_rise_min;
+  lower_limit_gap_min          = fn->lower_limit_gap_min;
+  lower_limit_baseline_drop_min= fn->lower_limit_baseline_drop_min;
 }
 
 void

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -34,6 +34,7 @@ struct font_glyphs;
 #define MATH_TYPE_NORMAL 0
 #define MATH_TYPE_STIX 1
 #define MATH_TYPE_TEX_GYRE 2
+#define MATH_TYPE_OPENTYPE 3
 
 #define START_OF_LINE 1
 #define END_OF_LINE 2
@@ -52,7 +53,7 @@ struct font_glyphs;
 
 struct font_rep : rep<font> {
   int    type;         // font type
-  int    math_type;    // For TeX Gyre math fonts and Stix
+  int    math_type;    // For TeX Gyre math fonts and Stix and OpenType fonts
   SI     size;         // requested size
   SI     design_size;  // design size in points/256
   SI     display_size; // display size in points/PIXEL
@@ -72,6 +73,12 @@ struct font_rep : rep<font> {
   SI ysup_lo_base; // base line for supscripts
   SI ysup_hi_lim;  // upper limit for supscripts
   SI yshift;       // vertical script shift inside fractions
+
+  // only for opentype fonts
+  SI upper_limit_gap_min;
+  SI upper_limit_baseline_rise_min;
+  SI lower_limit_gap_min;
+  SI lower_limit_baseline_drop_min;
 
   SI wpt;   // width of one point in font
   SI hpt;   // height of one point in font (usually wpt)

--- a/src/Plugins/Freetype/tt_face.cpp
+++ b/src/Plugins/Freetype/tt_face.cpp
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 #include "tt_face.hpp"
+#include "file.hpp"
 #include "font.hpp"
 #include "tm_debug.hpp"
 #include "tm_timer.hpp"
@@ -54,6 +55,17 @@ tt_face_rep::tt_face_rep (string name) : rep<tt_face> (name) {
   }
   ft_select_charmap (ft_face, ft_encoding_adobe_custom);
   bad_face= false;
+
+  // .ttf/.otf file may contain a math table
+  if (suffix (u) == "ttf" || suffix (u) == "otf") {
+    string buf;
+    if (!load_string (u, buf, false)) {
+      math_table= parse_mathtable (buf);
+    }
+    if (!is_nil (math_table) && DEBUG_STD) {
+      debug_fonts << "Math table loaded for " << name << "\n";
+    }
+  }
 }
 
 tt_face

--- a/src/Plugins/Freetype/tt_face.cpp
+++ b/src/Plugins/Freetype/tt_face.cpp
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 #include "tt_face.hpp"
+#include "analyze.hpp"
 #include "file.hpp"
 #include "font.hpp"
 #include "tm_debug.hpp"
@@ -57,7 +58,8 @@ tt_face_rep::tt_face_rep (string name) : rep<tt_face> (name) {
   bad_face= false;
 
   // .ttf/.otf file may contain a math table
-  if (suffix (u) == "ttf" || suffix (u) == "otf") {
+  string font_suffix= locase_all (suffix (u));
+  if (font_suffix == "ttf" || font_suffix == "otf") {
     string buf;
     if (!load_string (u, buf, false)) {
       math_table= parse_mathtable (buf);

--- a/src/Plugins/Freetype/tt_face.hpp
+++ b/src/Plugins/Freetype/tt_face.hpp
@@ -12,14 +12,16 @@
 #ifndef TT_FACE_H
 #define TT_FACE_H
 #include "Freetype/free_type.hpp"
+#include "Freetype/tt_tools.hpp"
 #include "bitmap_font.hpp"
 #include "hashmap.hpp"
 
 RESOURCE (tt_face);
 
 struct tt_face_rep : rep<tt_face> {
-  bool    bad_face;
-  FT_Face ft_face;
+  bool         bad_face;
+  FT_Face      ft_face;
+  ot_mathtable math_table;
   tt_face_rep (string name);
 };
 

--- a/src/Plugins/Freetype/tt_tools.hpp
+++ b/src/Plugins/Freetype/tt_tools.hpp
@@ -137,7 +137,12 @@ enum MathConstantRecordEnum {
   radicalExtraAscender,
   radicalKernBeforeDegree,
   radicalKernAfterDegree,
-  otmathConstantsRecordsEnd // keep at the end
+  otmathConstantsRecordsEnd, // count the number of records
+  scriptPercentScaleDown,
+  scriptScriptPercentScaleDown,
+  delimitedSubFormulaMinHeight,
+  displayOperatorMinHeight,
+  radicalDegreeBottomRaisePercent
 };
 
 struct DeviceTable {
@@ -152,6 +157,9 @@ struct MathValueRecord {
   bool        hasDevice;
   DeviceTable deviceTable;
   MathValueRecord () : hasDevice (false) {}
+
+  // cast to int
+  operator int () const { return value; }
 };
 
 struct MathConstantsTable {
@@ -161,7 +169,26 @@ struct MathConstantsTable {
   unsigned int           displayOperatorMinHeight;
   array<MathValueRecord> records;
   int                    radicalDegreeBottomRaisePercent;
-  MathConstantsTable () : records (otmathConstantsRecordsEnd){};
+  MathConstantsTable ()
+      : records (MathConstantRecordEnum::otmathConstantsRecordsEnd){};
+
+  int operator[] (int i) {
+    if (i < MathConstantRecordEnum::otmathConstantsRecordsEnd)
+      return records[i];
+    switch (i) {
+    case MathConstantRecordEnum::scriptPercentScaleDown:
+      return scriptPercentScaleDown;
+    case MathConstantRecordEnum::scriptScriptPercentScaleDown:
+      return scriptScriptPercentScaleDown;
+    case MathConstantRecordEnum::delimitedSubFormulaMinHeight:
+      return delimitedSubFormulaMinHeight;
+    case MathConstantRecordEnum::displayOperatorMinHeight:
+      return displayOperatorMinHeight;
+    case MathConstantRecordEnum::radicalDegreeBottomRaisePercent:
+      return radicalDegreeBottomRaisePercent;
+    }
+    return 0; // should never reach here
+  }
 };
 
 struct MathKernTable {

--- a/src/Plugins/Freetype/tt_tools.hpp
+++ b/src/Plugins/Freetype/tt_tools.hpp
@@ -12,7 +12,9 @@
 #ifndef TT_TOOLS_H
 #define TT_TOOLS_H
 
+#include "basic.hpp"
 #include "hashset.hpp"
+#include "tm_debug.hpp"
 #include "tree.hpp"
 #include "url.hpp"
 
@@ -173,7 +175,7 @@ struct MathConstantsTable {
       : records (MathConstantRecordEnum::otmathConstantsRecordsEnd){};
 
   int operator[] (int i) {
-    if (i < MathConstantRecordEnum::otmathConstantsRecordsEnd)
+    if (i >= 0 && i < MathConstantRecordEnum::otmathConstantsRecordsEnd)
       return records[i];
     switch (i) {
     case MathConstantRecordEnum::scriptPercentScaleDown:
@@ -187,6 +189,7 @@ struct MathConstantsTable {
     case MathConstantRecordEnum::radicalDegreeBottomRaisePercent:
       return radicalDegreeBottomRaisePercent;
     }
+    TM_FAILED ("MathConstantsTable: index out of range");
     return 0; // should never reach here
   }
 };

--- a/src/Typeset/Boxes/Composite/script_boxes.cpp
+++ b/src/Typeset/Boxes/Composite/script_boxes.cpp
@@ -12,6 +12,7 @@
 #include "Boxes/Composite/italic_correct.hpp"
 #include "Boxes/composite.hpp"
 #include "Boxes/construct.hpp"
+#include "font.hpp"
 
 /******************************************************************************
  * subroutine for scripts
@@ -86,11 +87,18 @@ lim_box_rep::lim_box_rep (path ip, box r2, box lo, box hi, font fn2, bool gl)
   type= 0;
   if (!is_nil (lo)) type+= 1;
   if (!is_nil (hi)) type+= 2;
+  bool use_opentype= (fn->math_type == MATH_TYPE_OPENTYPE) &&
+                     (fn->lower_limit_gap_min > 0) &&
+                     (fn->lower_limit_baseline_drop_min > 0);
   if (!is_nil (lo)) {
     SI top= max (lo->y2, fn->y2 * script (fn->size, 1) / fn->size) + sep_lo;
     Y     = ref->y1;
     X     = ((SI) (ref->right_slope () * (Y + top - lo->y1))) +
        ((ref->x1 + ref->x2) >> 1);
+    if (use_opentype) {
+      top= lo->y2 + fn->lower_limit_gap_min;
+      top= max (top, fn->lower_limit_baseline_drop_min);
+    }
     insert (lo, X - (lo->x2 >> 1), Y - top);
     italic_correct (lo);
   }
@@ -99,6 +107,10 @@ lim_box_rep::lim_box_rep (path ip, box r2, box lo, box hi, font fn2, bool gl)
     Y     = ref->y2;
     X     = ((SI) (ref->right_slope () * (Y + hi->y2 - bot))) +
        ((ref->x1 + ref->x2) >> 1);
+    if (use_opentype) {
+      bot= hi->y1 - fn->upper_limit_gap_min;
+      bot= min (bot, -fn->upper_limit_baseline_rise_min);
+    }
     insert (hi, X - (hi->x2 >> 1), Y - bot);
     italic_correct (hi);
   }


### PR DESCRIPTION
## What
Improving the Typesetting of Limit Boxes.

## Why
For some OpenType fonts, the heights of the upper and lower limits in the limit box environment are not suitable.

## How to test your changes?
Open `devel/80_4.tmu`.

Before (Anasa Math font), the upper limit is too high:
![image](https://github.com/user-attachments/assets/e5ac5e1c-d3dc-422f-82e5-723beeee16e3)

After:
![image](https://github.com/user-attachments/assets/03ff3b2e-33d1-41a1-ae68-a891402240fd)
