### PR TITLE
[80_5] Improving Fraction Box Typesetting

### DIFF
--- a/devel/80_5.tmu
+++ b/devel/80_5.tmu
@@ -1,0 +1,20 @@
+<TMU|<tuple|1.0.3|1.2.9>>
+
+<style|<tuple|generic|chinese>>
+
+<\body>
+  <math|<frac|1+3|2+4> <frac|1+<frac|1+<frac|1+<frac|1|2>|2+<frac|1|2>>|2+<frac|1+<frac|1|2>|2+<frac|1|2>>>|1+<frac|1+<frac|1+<frac|1|2>|2+<frac|1|2>>|2+<frac|1+<frac|1|2>|2+<frac|1|2>>>> >
+
+  <\equation*>
+    <frac|1|2> <frac|1+<frac|1+<frac|1+<frac|1|2>|2+<frac|1|2>>|2+<frac|1+<frac|1|2>|2+<frac|1|2>>>|1+<frac|1+<frac|1+<frac|1|2>|2+<frac|1|2>>|2+<frac|1+<frac|1|2>|2+<frac|1|2>>>>\ 
+  </equation*>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|font|Asana Math>
+    <associate|font-family|rm>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Graphics/Fonts/font.cpp
+++ b/src/Graphics/Fonts/font.cpp
@@ -100,6 +100,15 @@ font_rep::copy_math_pars (font fn) {
   upper_limit_baseline_rise_min= fn->upper_limit_baseline_rise_min;
   lower_limit_gap_min          = fn->lower_limit_gap_min;
   lower_limit_baseline_drop_min= fn->lower_limit_baseline_drop_min;
+  frac_rule_thickness          = fn->frac_rule_thickness;
+  frac_num_shift_up            = fn->frac_num_shift_up;
+  frac_num_disp_shift_up       = fn->frac_num_disp_shift_up;
+  frac_num_gap_min             = fn->frac_num_gap_min;
+  frac_num_disp_gap_min        = fn->frac_num_disp_gap_min;
+  frac_denom_shift_down        = fn->frac_denom_shift_down;
+  frac_denom_disp_shift_down   = fn->frac_denom_disp_shift_down;
+  frac_denom_gap_min           = fn->frac_denom_gap_min;
+  frac_denom_disp_gap_min      = fn->frac_denom_disp_gap_min;
 }
 
 void

--- a/src/Graphics/Fonts/font.hpp
+++ b/src/Graphics/Fonts/font.hpp
@@ -79,6 +79,15 @@ struct font_rep : rep<font> {
   SI upper_limit_baseline_rise_min;
   SI lower_limit_gap_min;
   SI lower_limit_baseline_drop_min;
+  SI frac_rule_thickness;
+  SI frac_num_shift_up;
+  SI frac_num_disp_shift_up;
+  SI frac_num_gap_min;
+  SI frac_num_disp_gap_min;
+  SI frac_denom_shift_down;
+  SI frac_denom_disp_shift_down;
+  SI frac_denom_gap_min;
+  SI frac_denom_disp_gap_min;
 
   SI wpt;   // width of one point in font
   SI hpt;   // height of one point in font (usually wpt)

--- a/src/Plugins/Freetype/unicode_font.cpp
+++ b/src/Plugins/Freetype/unicode_font.cpp
@@ -447,7 +447,7 @@ unicode_font_rep::unicode_font_rep (string name, string family2, int size2,
       this->math_face = math_face2;
       this->math_table= math_face2->math_table;
       math_type       = MATH_TYPE_OPENTYPE;
-      init_design_unit_factor();
+      init_design_unit_factor ();
       // limit boxes
       upper_limit_gap_min=
           design_unit_to_metric (math_table->constants_table[upperLimitGapMin]);
@@ -1042,18 +1042,18 @@ unicode_font_rep::init_design_unit_factor () {
   get_extents ("m", ex);
   em= ex->x2 - ex->x1;
 
-  metric_to_design_unit_factor = (double) units_of_m / (double) em;
-  design_unit_to_metric_factor = (double) em / (double) units_of_m;
+  metric_to_design_unit_factor= (double) units_of_m / (double) em;
+  design_unit_to_metric_factor= (double) em / (double) units_of_m;
 }
 
 inline SI
 unicode_font_rep::design_unit_to_metric (int du) {
-  return (SI) design_unit_to_metric_factor*du;
+  return (SI) design_unit_to_metric_factor * du;
 }
 
 inline int
 unicode_font_rep::metric_to_design_unit (SI m) {
-  return (int) metric_to_design_unit_factor*m;
+  return (int) metric_to_design_unit_factor * m;
 }
 
 font

--- a/src/Typeset/Boxes/Composite/math_boxes.cpp
+++ b/src/Typeset/Boxes/Composite/math_boxes.cpp
@@ -110,7 +110,6 @@ frac_box_rep::frac_box_rep (path ip, box b1, box b2, font fn2, font sfn2,
     insert (line_box (decorate_middle (ip), d, 0, w - d, 0, bar_pen), 0, bar_y);
   }
   else {
-  h:
     insert (b1, (w >> 1) - (b1->x2 >> 1), bar_y + sep + (bar_w >> 1) - b1_y);
     insert (b2, (w >> 1) - (b2->x2 >> 1), bar_y - sep - (bar_w >> 1) - b2_y);
     insert (line_box (decorate_middle (ip), d, 0, w - d, 0, bar_pen), 0, bar_y);

--- a/src/Typeset/Boxes/construct.hpp
+++ b/src/Typeset/Boxes/construct.hpp
@@ -145,7 +145,7 @@ box highlight_box (path ip, box b, box xb, ornament_parameters ps);
 box highlight_box (path ip, box b, SI w, brush col, brush sunc, brush shad);
 box art_box (path ip, box b, art_box_parameters ps);
 
-box frac_box (path ip, box b1, box b2, font fn, font sfn, pencil pen);
+box frac_box (path ip, box b1, box b2, font fn, font sfn, pencil pen, bool opentype_disp = false);
 box sqrt_box (path ip, box b1, box b2, box sqrtb, font fn, pencil pen);
 box neg_box (path ip, box b, font fn, pencil pen);
 box tree_box (path ip, array<box> bs, font fn, pencil pen);

--- a/src/Typeset/Boxes/construct.hpp
+++ b/src/Typeset/Boxes/construct.hpp
@@ -145,7 +145,8 @@ box highlight_box (path ip, box b, box xb, ornament_parameters ps);
 box highlight_box (path ip, box b, SI w, brush col, brush sunc, brush shad);
 box art_box (path ip, box b, art_box_parameters ps);
 
-box frac_box (path ip, box b1, box b2, font fn, font sfn, pencil pen, bool opentype_disp = false);
+box frac_box (path ip, box b1, box b2, font fn, font sfn, pencil pen,
+              bool opentype_disp= false);
 box sqrt_box (path ip, box b1, box b2, box sqrtb, font fn, pencil pen);
 box neg_box (path ip, box b, font fn, pencil pen);
 box tree_box (path ip, array<box> bs, font fn, pencil pen);

--- a/src/Typeset/Concat/concat_math.cpp
+++ b/src/Typeset/Concat/concat_math.cpp
@@ -393,7 +393,7 @@ concater_rep::typeset_frac (tree t, path ip) {
   if (disp) env->local_end (MATH_DISPLAY, old);
   else env->local_end_script (old);
   if (num->w () <= env->frac_max && den->w () <= env->frac_max)
-    print (frac_box (ip, num, den, env->fn, sfn, env->pen));
+    print (frac_box (ip, num, den, env->fn, sfn, env->pen, disp));
   else typeset_wide_frac (t, ip);
 }
 


### PR DESCRIPTION
## What
Improving Fraction Box Typesetting.

## Why
For some OpenType fonts, the heights of the numerator and denominator in the fraction box environment are not suitable.

## How to test your changes?
Open `devel/80_5.tmu`.

Before (Anasa Math font):
![image](https://github.com/user-attachments/assets/a6f3d3a4-9ecc-491c-958f-ee3c0be8e4b2)

After:
![image](https://github.com/user-attachments/assets/a8bc5314-6d96-44a9-97f9-899b78f53e5b)

