### PR TITLE
[80_9] Font: render as italic for math font family ending with Math

### DIFF
--- a/TeXmacs/tests/tmu/80_9.tmu
+++ b/TeXmacs/tests/tmu/80_9.tmu
@@ -1,0 +1,50 @@
+<TMU|<tuple|1.0.5|1.2.9.5>>
+
+<style|<tuple|generic|chinese>>
+
+<\body>
+  <\hide-preamble>
+    \;
+  </hide-preamble>
+
+  Roman:
+
+  <\equation*>
+    a+b+ab
+  </equation*>
+
+  Stix Math:
+
+  <\equation*>
+    <with|font|Stix Math|a+b+ab>
+  </equation*>
+
+  Latin Modern Math:
+
+  <\equation*>
+    <with|font|Latin Modern Math|a+b+ab>
+  </equation*>
+
+  TeX Gyre Bonum Math:
+
+  <\equation*>
+    <with|font|TeX Gyre Bonum Math|a+b+ab>
+  </equation*>
+
+  Fira Math:
+
+  <\equation*>
+    <with|font|Fira Math|a+b+ab>
+  </equation*>
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|font|roman>
+    <associate|font-family|rm>
+    <associate|math-font|roman>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -808,11 +808,12 @@ smart_font_rep::advance (string s, int& pos, string& r, int& nr) {
   if (nr < 0) return;
   if (N (fn) <= nr || is_nil (fn[nr])) initialize_font (nr);
   if (sm->fn_rewr[nr] != REWRITE_NONE) r= rewrite (r, sm->fn_rewr[nr]);
-  if (s_N == 1 && is_locase (s[0]) && math_kind == 0 && is_math_family(mfam))  {
+  if (s_N == 1 && is_locase (s[0]) && math_kind == 0 && is_math_family (mfam)) {
     r= "<#" * to_Hex (0x1d44e + (int) (s[0] - 'a')) * ">";
   }
   if (DEBUG_VERBOSE) {
-    debug_fonts << "Advance for font of [" << s << "] " << this->res_name << " math_kind: " << math_kind << LF;
+    debug_fonts << "Advance for font of [" << s << "] " << this->res_name
+                << " math_kind: " << math_kind << LF;
     debug_fonts << "Physical font of [" << r << "]"
                 << "[" << herk_to_utf8 (r) << "][" << cork_to_utf8 (r) << "]"
                 << " is " << fn[nr]->res_name << LF;
@@ -860,8 +861,9 @@ is_wanted (string c, string family, array<string> rules, array<string> given) {
 int
 smart_font_rep::resolve (string c, string fam, int attempt) {
   if (DEBUG_VERBOSE) {
-    debug_fonts << "Resolve " << c << " in math_kind " << math_kind << " in fam " << fam << " mfam " << mfam
-                << ", attempt " << attempt << LF;
+    debug_fonts << "Resolve " << c << " in math_kind " << math_kind
+                << " in fam " << fam << " mfam " << mfam << ", attempt "
+                << attempt << LF;
   }
   array<string> a= trimmed_tokenize (fam, "=");
   if (N (a) >= 2) {

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -808,7 +808,11 @@ smart_font_rep::advance (string s, int& pos, string& r, int& nr) {
   if (nr < 0) return;
   if (N (fn) <= nr || is_nil (fn[nr])) initialize_font (nr);
   if (sm->fn_rewr[nr] != REWRITE_NONE) r= rewrite (r, sm->fn_rewr[nr]);
+  if (s_N == 1 && is_locase (s[0]) && math_kind == 0 && is_math_family(mfam))  {
+    r= "<#" * to_Hex (0x1d44e + (int) (s[0] - 'a')) * ">";
+  }
   if (DEBUG_VERBOSE) {
+    debug_fonts << "Advance for font of [" << s << "] " << this->res_name << " math_kind: " << math_kind << LF;
     debug_fonts << "Physical font of [" << r << "]"
                 << "[" << herk_to_utf8 (r) << "][" << cork_to_utf8 (r) << "]"
                 << " is " << fn[nr]->res_name << LF;
@@ -856,7 +860,7 @@ is_wanted (string c, string family, array<string> rules, array<string> given) {
 int
 smart_font_rep::resolve (string c, string fam, int attempt) {
   if (DEBUG_VERBOSE) {
-    debug_fonts << "Resolve " << c << " in fam " << fam << " mfam " << mfam
+    debug_fonts << "Resolve " << c << " in math_kind " << math_kind << " in fam " << fam << " mfam " << mfam
                 << ", attempt " << attempt << LF;
   }
   array<string> a= trimmed_tokenize (fam, "=");

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -755,61 +755,74 @@ smart_font_rep::advance (string s, int& pos, string& r, int& nr) {
   int                   start= pos;
   nr                         = -1;
   int s_N                    = N (s);
-  while (pos < s_N) {
-    if (s[pos] != '<') {
-      int c= (int) (unsigned char) s[pos];
-
-      int fn_index= chv[c];
-      if (math_kind != 0 && math_kind != 2 && is_alpha (c) &&
-          (pos == 0 || !is_alpha (s[pos - 1])) &&
-          (pos + 1 == s_N || !is_alpha (s[pos + 1]))) {
-        fn_index= italic_nr;
-      }
-      else if (fn_index == -1) {
-        fn_index= resolve (s (pos, pos + 1));
-      }
-
-      if (count == 1 && nr != -1 && fn_index == nr) {
-        // NOTE: rewrite strings like --- character by character if necessary
-        if (sm->fn_rewr[nr] == REWRITE_SPECIAL) break;
-      }
-      if (fn_index == nr) pos++;
-      else if (nr == -1) {
-        pos++;
-        nr= fn_index;
-      }
-      else break;
+  if (s_N == 1 && pos == 0 && math_kind == 1 && ends (mfam, "Math") &&
+      is_alpha (s[0])) {
+    nr = 0;
+    pos= pos + 1;
+    if (is_locase (s[0])) {
+      r= "<#" * to_Hex (0x1d44e + (int) (s[0] - 'a')) * ">";
+    }
+    else if (is_upcase (s[0])) {
+      r= "<#" * to_Hex (0x1d434 + (int) (s[0] - 'A')) * ">";
     }
     else {
-      int end= pos;
-      tm_char_forwards (s, end);
-      string current_c= s (pos, end);
-
-      int fn_index= cht[current_c];
-      if (fn_index == -1) {
-        fn_index= resolve (current_c);
-      }
-
-      if (count == 1 && nr != -1 && fn_index == nr) {
-        if (N (fn) <= nr || is_nil (fn[nr])) initialize_font (nr);
-        if (!fn[nr]->supports (s (start, end))) break;
-        pos= end;
-      }
-      else if (fn_index == nr) pos= end;
-      else if (nr == -1) {
-        pos= end;
-        nr = fn_index;
-      }
-      else break;
+      TM_FAILED ("invalid branch for smart_fon_rep::advance");
     }
-    count++;
   }
-  r= s (start, pos);
-  if (nr < 0) return;
-  if (N (fn) <= nr || is_nil (fn[nr])) initialize_font (nr);
-  if (sm->fn_rewr[nr] != REWRITE_NONE) r= rewrite (r, sm->fn_rewr[nr]);
-  if (s_N == 1 && is_locase (s[0]) && math_kind == 0 && is_math_family (mfam)) {
-    r= "<#" * to_Hex (0x1d44e + (int) (s[0] - 'a')) * ">";
+  else {
+    while (pos < s_N) {
+      if (s[pos] != '<') {
+        int c= (int) (unsigned char) s[pos];
+
+        int fn_index= chv[c];
+        if (math_kind != 0 && math_kind != 2 && is_alpha (c) &&
+            (pos == 0 || !is_alpha (s[pos - 1])) &&
+            (pos + 1 == s_N || !is_alpha (s[pos + 1]))) {
+          fn_index= italic_nr;
+        }
+        else if (fn_index == -1) {
+          fn_index= resolve (s (pos, pos + 1));
+        }
+
+        if (count == 1 && nr != -1 && fn_index == nr) {
+          // NOTE: rewrite strings like --- character by character if necessary
+          if (sm->fn_rewr[nr] == REWRITE_SPECIAL) break;
+        }
+        if (fn_index == nr) pos++;
+        else if (nr == -1) {
+          pos++;
+          nr= fn_index;
+        }
+        else break;
+      }
+      else {
+        int end= pos;
+        tm_char_forwards (s, end);
+        string current_c= s (pos, end);
+
+        int fn_index= cht[current_c];
+        if (fn_index == -1) {
+          fn_index= resolve (current_c);
+        }
+
+        if (count == 1 && nr != -1 && fn_index == nr) {
+          if (N (fn) <= nr || is_nil (fn[nr])) initialize_font (nr);
+          if (!fn[nr]->supports (s (start, end))) break;
+          pos= end;
+        }
+        else if (fn_index == nr) pos= end;
+        else if (nr == -1) {
+          pos= end;
+          nr = fn_index;
+        }
+        else break;
+      }
+      count++;
+    }
+    r= s (start, pos);
+    if (nr < 0) return;
+    if (N (fn) <= nr || is_nil (fn[nr])) initialize_font (nr);
+    if (sm->fn_rewr[nr] != REWRITE_NONE) r= rewrite (r, sm->fn_rewr[nr]);
   }
   if (DEBUG_VERBOSE) {
     debug_fonts << "Advance for font of [" << s << "] " << this->res_name


### PR DESCRIPTION
## What
Render the single character in math mode as italic math unicode.

## Why
For Latin Modern Math, it is using the pool italic fallback font and it is very ugly.

## How to test your changes?
Open 80_9.tmu

Before:
![image](https://github.com/user-attachments/assets/d77b6894-6c34-4a02-9806-aebdcc95b378)

Now:
![image](https://github.com/user-attachments/assets/1a4d870a-8e92-4e44-aaf5-370d55ed9d5e)


