### PR TITLE
[59_23] Keyboard: Add std = as a keybinding for zoom-in

### DIFF
--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -621,7 +621,6 @@
   ("macos F" (toggle-full-screen-mode))
   ("macos C-f" (toggle-full-screen-edit-mode))
 
-  ("macos =" (zoom-in (sqrt (sqrt 2.0))))
   ("macos S-=" (zoom-in (sqrt (sqrt 2.0))))
   ("macos S-+" (zoom-in (sqrt (sqrt 2.0))))
   ("macos S--" (zoom-out (sqrt (sqrt 2.0))))
@@ -807,6 +806,7 @@
   ("std z" (undo 0))
   ("std Z" (redo 0))
   ("std +" (zoom-in (sqrt (sqrt 2.0))))
+  ("std =" (zoom-in (sqrt (sqrt 2.0))))
   ("std -" (zoom-out (sqrt (sqrt 2.0))))
   ("std 0" (change-zoom-factor 1.0))
 


### PR DESCRIPTION
## What
Add `std =` as a keybinding for zoom-in

## Why
`C-=` for zoom in is nice than pressing `C-S-=`.

## How to test your changes?
+ [x] Linux (KDE)
+ [ ] macOS
+ [ ] Windows