### PR TITLE
[5_32] docs: 修复源码链接地址

### DIFF
--- a/docs/zh/guide/SourceCode.md
+++ b/docs/zh/guide/SourceCode.md
@@ -11,7 +11,7 @@
 </tr>
 <tr>
 <td>GitCode</td>
-<td><a href="https:/gitcode.com/XmacsLabs/mogan">https://gitcode.org/XmacsLabs/mogan</a></td>
+<td><a href="https://gitcode.com/XmacsLabs/mogan">https://gitcode.com/XmacsLabs/mogan</a></td>
 <td><img src="../../images/gitcode.png" width="20px;" height="20px;" alt="" /></td>
 </tr>
 <tr>


### PR DESCRIPTION
docs: 修复源码链接地址

- 修正 GitCode 链接地址中的拼写错误
- 将 "https://gitcode.org/XmacsLabs/mogan" 修改为 "https://gitcode.com/XmacsLabs/mogan"
