### PR TITLE
improve sector drawing order

### DIFF
--- a/TeXmacs/progs/graphics/graphics-markup.scm
+++ b/TeXmacs/progs/graphics/graphics-markup.scm
@@ -141,20 +141,20 @@
                          (points-add (point-times (point-get-unit (points-sub mid-p-x c)) r) c))))))
        (if (clockwise (points-cross-product-k vec-c-p vec-c-q) 0)
          (if (eq? clockwise >)
-            `(superpose
-              (std-arc ,c ,p ,m)
-              (std-arc ,c ,m ,x)
-              (with "color" "none"
-               (line ,p ,c ,x ,m ,p)))
-             `(superpose
-              (std-arc-counterclockwise ,c ,p ,m)
-              (std-arc-counterclockwise ,c ,m ,x)
-              (with "color" "none"
-               (line ,p ,c ,x ,m ,p))))
-        `(superpose    
-          (with "color" "none"
-           (line ,p ,c ,x))
-          (arc ,p ,m ,x)))))
+           `(superpose
+             (with "color" "none"
+               (line ,p ,c ,x ,m ,p))
+             (std-arc ,c ,p ,m)
+             (std-arc ,c ,m ,x))
+           `(superpose
+             (with "color" "none"
+               (line ,p ,c ,x ,m ,p))
+             (std-arc-counterclockwise ,c ,p ,m)
+             (std-arc-counterclockwise ,c ,m ,x)))
+         `(superpose
+           (with "color" "none"
+             (line ,p ,c ,x))
+           (arc ,p ,m ,x)))))
 
 (define-graphics (sector C P Q)
   (sector-helper C P Q >))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Change the order when drawing sector, especially when it has filled color.
Before:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/bb6e333b-1614-4c12-8a1d-5ef4347bff0b" />

After:
<img width="262" alt="image" src="https://github.com/user-attachments/assets/e6ddf024-357a-46c9-8634-49c1f40ab6cb" />

## Why
The polygon without border color should be drawn first, then the std-arc.
## How to test your changes?
