### PR TITLE
[improve] Add M-a/C-a event for QTMLineEdit

### DIFF
--- a/src/Plugins/Qt/QTMMenuHelper.cpp
+++ b/src/Plugins/Qt/QTMMenuHelper.cpp
@@ -531,8 +531,8 @@ QTMLineEdit::keyPressEvent (QKeyEvent* ev) {
         (ev->modifiers () & Qt::MetaModifier) == 0) {
       QLineEdit::keyPressEvent (ev);
     }
-    else if ((last_key == 'C' || last_key == 'V' ||
-              last_key == 'X' || last_key == 'A') &&
+    else if ((last_key == 'C' || last_key == 'V' || last_key == 'X' ||
+              last_key == 'A') &&
              (ev->modifiers () == Qt::ControlModifier)) {
       // M-x/M-c/M-v/M-a on macOS or C-x/C-c/C-v/C-a on Linux and Windows
       QLineEdit::keyPressEvent (ev);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What  
Added support for `Cmd+A` / `Ctrl+A` key events in `QTMLineEdit` to select all text in the search toolbar.

Related: #2232

## Why  
`Cmd+A` / `Ctrl+A` is a native `QLineEdit` behavior in Qt. Supporting it improves usability by allowing users to quickly modify their search query. This standard interaction should not be ignored, I guess.

## How to test your changes  
1. Build the project.  
2. Open the search toolbar using `Cmd+f` / `Ctrl+f`.  
3. Enter any text.  
4. Press `Cmd+a` / `Ctrl+a` to ensure all text is selected.