### PR TITLE
[fix] Shift-F5 being falsely inserted as 'S-F5'

### DIFF
--- a/src/Edit/Interface/edit_keyboard.cpp
+++ b/src/Edit/Interface/edit_keyboard.cpp
@@ -152,7 +152,7 @@ edit_interface_rep::try_shortcut (string comb) {
             verbatim (rhs), shorth == "" ? 1 : 3000);
     }
     if ((status & 1) == 1) cmd ();
-    else if (N (shorth) > 0) call ("kbd-insert", shorth);
+    else if (N (shorth) > 0 && comb != "S-F5") call ("kbd-insert", shorth);
     // cout << "Mark= " << sh_mark << "\n";
     return true;
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What  
Resolved the issue where `Shift-F5` was incorrectly interpreted as `S-F5` by adding a simple check: `comb != "S-F5"` during fallback.

Related: #2217

## Why  
Though this may not be the most elegant solution, it effectively addresses the issue for now, I think.

## How to test your changes  
1. Build and run the project  
2. Enter math mode by typing `$`  
3. Press `Shift+F5` or `Shift+F5+I` or `Shift+F5+O` or `Shift+F5+U` or `Shift+F5+N` (possibly with the Fn key) 
4. Verify that the integral sign is inserted, rather than the string `S-F5`