### PR TITLE
Update library requirements for Linux platform

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -197,8 +197,8 @@ end
 
 add_requires("libjpeg")
 if is_plat("linux") then
-    add_requires("apt::libpng-dev", {alias="libpng"})
-    add_requires("apt::libcurl4-openssl-dev", {alias="libcurl"})
+    add_requires("libpng", {alias="libpng"})
+    add_requires("libcurl", {alias="libcurl"})
 end
 
 add_requires("liii-pdfhummus", {system=false,configs={libpng=true,libjpeg=true}})
@@ -207,7 +207,7 @@ if using_legacy_apt() then
     add_requireconfs("liii-pdfhummus.freetype", {version = FREETYPE_VERSION, system = false, override=true})
 else
     if is_plat("linux") then
-        add_requires("apt::libfreetype-dev", {alias="freetype"})
+        add_requires("freetype", {alias="libfreetype"})
     else
         add_requires("freetype "..FREETYPE_VERSION, {system=false, configs={png=true}})
     end


### PR DESCRIPTION
The use of `apt::` presupposes the presence of apt, which is not available on many Linux distributions that don't fall within Debian-based systems. Consequently, it is advisable to employ `xmake`'s cross-platform configuration mechanism, which automatically selects the appropriate tools for different OS.