### PR TITLE
[22_47] Translate seminar style tooltip

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -74,7 +74,7 @@
 ("Sprout User" "发芽用户")
 ("Start an AI interactive session" "AI功能")
 ("Store tracking information in LaTeX files" "在 LaTeX 文件中保存追踪信息")
-("Style for presentations using an overhead projector" "使用投影仪进行演示的风格")
+("Style for seminar" "研讨会样式")
 ("Tab::keyboard" "Tab")
 ("Tag Image File Format" "标记图像文件格式")
 ("Taiwan" "中国台湾")

--- a/TeXmacs/progs/generic/document-style.scm
+++ b/TeXmacs/progs/generic/document-style.scm
@@ -236,7 +236,7 @@
   ("generic"        "Default document style")
   ("letter"         "Default style for writing letters")
   ("poster"         "Style for posters")
-  ("seminar"        "Style for presentations using an overhead projector")
+  ("seminar"        "Style for seminar")
   ("source"         "Style for editing style files and packages")
 
   ("acmconf"        "ACM conference style")

--- a/devel/22_47.md
+++ b/devel/22_47.md
@@ -1,5 +1,24 @@
 # 22_47：翻译 seminar样式的悬浮提示
 
+
+
+## 2026/1/12 翻译 seminar 样式的悬浮提示
+### What
+- 将 seminar 样式的悬浮提示由冗长的描述性文本调整为简洁的样式名称提示。
+- 英文统一为 “Style for seminar”，中文对应为「研讨会样式」。
+
+### Why
+- 原有提示 “Style for presentations using an overhead projector” 语义偏说明性，
+  不符合样式类 tooltip 的命名规范。
+- 与 article、book、generic 等样式的提示风格不一致，影响 UI 一致性与可读性。
+
+### 如何测试
++ 创建新文档
++ 选择文档->样式->seminar
++ 将鼠标悬停在 seminar 样式上
++ 检查悬浮提示显示为"研讨会样式"
+
+
 ## 2025/11/24
 ### What
 为 seminar 样式的悬浮提示添加中文翻译


### PR DESCRIPTION
Task: 22_47

- Update the seminar style tooltip to a concise name-style description.
- Add/update zh_CN translation.

Test:
- Document → Style → seminar
- Hover on seminar, tooltip shows “研讨会样式”.
