### PR TITLE
[203_18] 三重积分符号解析修复

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-symbol-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-symbol-drd.scm
@@ -81,11 +81,14 @@
   bignone bigtimes bigoplus bigotimes bigodot
   bigvee bigwedge bigsqcup bigcup bigcap bigpluscup
   bigtriangledown bigtriangleup
-  int bigiint bigiiint bigiiiint bigidotsint oint bigoiint bigoiiint
-  bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
-  bigointwl bigoiintwl bigoiiintwl
-  bigupint bigupiint bigupiiint bigupoint bigupoiint bigupoiiint
-  bigupintwl bigupiintwl bigupiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
+  int iint iiint iiiint idotsint bigint bigiint bigiiint bigiiiint bigidotsint
+  upint upiint upiiint upiiiint upidotsint bigupint bigupiint bigupiiint bigupiiiint bigupidotsint
+  oint oiint oiiint bigoint bigoiint bigoiiint
+  upoint upoiint upoiiint bigupoint bigupoiint bigupoiiint
+  intwl iintwl iiintwl iiiintwl idotsintwl bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
+  upintwl upiintwl upiiintwl upiiiintwl upidotsintwl bigupintwl bigupiintwl bigupiiintwl bigupiiiintwl bigupidotsintwl
+  ointwl oiintwl oiiintwl bigointwl bigoiintwl bigoiiintwl
+  upointwl upoiintwl upoiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from latexsym package

--- a/TeXmacs/progs/convert/latex/latex-symbol-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-symbol-drd.scm
@@ -81,11 +81,14 @@
   bignone bigtimes bigoplus bigotimes bigodot
   bigvee bigwedge bigsqcup bigcup bigcap bigpluscup
   bigtriangledown bigtriangleup
-  int bigiint bigiiint bigiiiint bigidotsint oint bigoiint bigoiiint
-  bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
-  bigointwl bigoiintwl bigoiiintwl
-  bigupint bigupiint bigupiiint bigupoint bigupoiint bigupoiiint
-  bigupintwl bigupiintwl bigupiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
+  int iint iiint iiiint idotsint bigint bigiint bigiiint bigiiiint bigidotsint
+  upint upiint upiiint upiiiint upidotsint bigupint bigupiint bigupiiint bigupiiiint bigupidotsint
+  oint oiint oiiint bigoint bigoiint bigoiiint
+  upoint upoiint upoiiint bigupoint bigupoiint bigupoiiint
+  intwl iintwl iiintwl iiiintwl idotsintwl bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
+  upintwl upiintwl upiiintwl upiiiintwl upidotsintwl bigupintwl bigupiintwl bigupiiintwl bigupiiiintwl bigupidotsintwl
+  ointwl oiintwl oiiintwl bigointwl bigoiintwl bigoiiintwl
+  upointwl upoiintwl upoiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Symbols from latexsym package

--- a/devel/203_18.md
+++ b/devel/203_18.md
@@ -1,0 +1,34 @@
+# [203_18] 三重积分符号解析修复
+
+### 如何测试
+以LaTeX形式导入 `\( {\iiint }_{\Omega }f\left( {{x}^{2} + {y}^{2} + {z}^{2}}\right) \mathrm{d}x\mathrm{\;d}y\mathrm{\;d}z = {\int }_{0}^{2\pi }{d\theta }{\int }_{0}^{\pi /4}{d\varphi }{\int }_{0}^{2}f\left( {r}^{2}\right) {r}^{2}\sin \varphi \mathrm{d}r \)` 开头的三重积分符号应该能正常显示
+
+## 2026/1/12
+
+### What
+导入 latex 时三重积分符号无法解析，需要改进 `latex-big-symbol%` 表
+
+### How
+原先的 `latex-big-symbol%` 表中对积分符号的注册不完整：
+```scheme
+(logic-group latex-big-symbol%
+  ;; ...
+  int bigiint bigiiint bigiiiint bigidotsint oint bigoiint bigoiiint
+  bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
+  bigointwl bigoiintwl bigoiiintwl
+  bigupint bigupiint bigupiiint bigupoint bigupoiint bigupoiiint
+  bigupintwl bigupiintwl bigupiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
+```
+现补全了所有 latex 积分号的种类，包含原生支持部分和宏包部分：
+```scheme
+(logic-group latex-big-symbol%
+  ;; ...
+  int iint iiint iiiint idotsint bigint bigiint bigiiint bigiiiint bigidotsint
+  upint upiint upiiint upiiiint upidotsint bigupint bigupiint bigupiiint bigupiiiint bigupidotsint
+  oint oiint oiiint bigoint bigoiint bigoiiint
+  upoint upoiint upoiiint bigupoint bigupoiint bigupoiiint
+  intwl iintwl iiintwl iiiintwl idotsintwl bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
+  upintwl upiintwl upiiintwl upiiiintwl upidotsintwl bigupintwl bigupiintwl bigupiiintwl bigupiiiintwl bigupidotsintwl
+  ointwl oiintwl oiiintwl bigointwl bigoiintwl bigoiiintwl
+  upointwl upoiintwl upoiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
+```


### PR DESCRIPTION
# [203_18] 三重积分符号解析修复

### 如何测试
以LaTeX形式导入 `\( {\iiint }_{\Omega }f\left( {{x}^{2} + {y}^{2} + {z}^{2}}\right) \mathrm{d}x\mathrm{\;d}y\mathrm{\;d}z = {\int }_{0}^{2\pi }{d\theta }{\int }_{0}^{\pi /4}{d\varphi }{\int }_{0}^{2}f\left( {r}^{2}\right) {r}^{2}\sin \varphi \mathrm{d}r \)` 开头的三重积分符号应该能正常显示

## 2026/1/12

### What
导入 latex 时三重积分符号无法解析，需要改进 `latex-big-symbol%` 表

### How
原先的 `latex-big-symbol%` 表中对积分符号的注册不完整：
```scheme
(logic-group latex-big-symbol%
  ;; ...
  int bigiint bigiiint bigiiiint bigidotsint oint bigoiint bigoiiint
  bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
  bigointwl bigoiintwl bigoiiintwl
  bigupint bigupiint bigupiiint bigupoint bigupoiint bigupoiiint
  bigupintwl bigupiintwl bigupiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
```
现补全了所有 latex 积分号的种类，包含原生支持部分和宏包部分：
```scheme
(logic-group latex-big-symbol%
  ;; ...
  int iint iiint iiiint idotsint bigint bigiint bigiiint bigiiiint bigidotsint
  upint upiint upiiint upiiiint upidotsint bigupint bigupiint bigupiiint bigupiiiint bigupidotsint
  oint oiint oiiint bigoint bigoiint bigoiiint
  upoint upoiint upoiiint bigupoint bigupoiint bigupoiiint
  intwl iintwl iiintwl iiiintwl idotsintwl bigintwl bigiintwl bigiiintwl bigiiiintwl bigidotsintwl
  upintwl upiintwl upiiintwl upiiiintwl upidotsintwl bigupintwl bigupiintwl bigupiiintwl bigupiiiintwl bigupidotsintwl
  ointwl oiintwl oiiintwl bigointwl bigoiintwl bigoiiintwl
  upointwl upoiintwl upoiiintwl bigupointwl bigupoiintwl bigupoiiintwl)
```