### PR TITLE
[201_60] 修复图片悬浮弹窗位置异常

### DIFF
--- a/devel/201_60.md
+++ b/devel/201_60.md
@@ -1,0 +1,34 @@
+# [201_60] 修复图片悬浮弹窗位置异常
+
+## 如何测试
+1. 插入一张图片或复制粘贴图片到编辑器，测试鼠标悬浮后按钮位置是否正确（有轻微下沉正常）
+2. 反复滚动页面、缩放视图、移动窗口、在图片前后插入文字调整图片位置，测试悬浮按钮位置是否正确
+3. 更改系统分辨率、系统缩放比后，测试悬浮按钮位置是否正确
+4. 切换 Windows Linux MacOS 三个平台，测试悬浮按钮位置是否正确
+
+## 2026/1/20
+### What
+之前的代码相对冗杂，且控件位置仍然有问题
+
+这里简化了计算并修复图片悬浮弹窗位置异常
+
+### How
+1. 简化计算公式：
+```cpp
+double cx_px = ((cx_logic - cached_scroll_x) * cached_magf + cached_canvas_x) * inv_unit;
+double top_px= -(top_logic - cached_scroll_y) * cached_magf * inv_unit;
+```
+
+2. 修复 `viewport > surface` 时图片悬浮弹窗位置异常：
+```cpp
+double blank_top= 0.0;
+if (owner && owner->scrollarea () && owner->scrollarea ()->viewport () &&
+   owner->scrollarea ()->surface ()) {
+ int vp_h  = owner->scrollarea ()->viewport ()->height ();
+ int surf_h= owner->scrollarea ()->surface ()->height ();
+ if (vp_h > surf_h) blank_top= (vp_h - surf_h) * 0.5;
+}
+top_px+= blank_top;
+```
+
+3. 删除 `cached_magf` 补丁


### PR DESCRIPTION
# [201_60] 修复图片悬浮弹窗位置异常

## 如何测试
1. 插入一张图片或复制粘贴图片到编辑器，测试鼠标悬浮后按钮位置是否正确（有轻微下沉正常）
2. 反复滚动页面、缩放视图、移动窗口、在图片前后插入文字调整图片位置，测试悬浮按钮位置是否正确
3. 更改系统分辨率、系统缩放比后，测试悬浮按钮位置是否正确
4. 切换 Windows Linux MacOS 三个平台，测试悬浮按钮位置是否正确

## 2026/1/20
### What
之前的代码相对冗杂，且控件位置仍然有问题

这里简化了计算并修复图片悬浮弹窗位置异常

### How
1. 简化计算公式：
```cpp
double cx_px = ((cx_logic - cached_scroll_x) * cached_magf + cached_canvas_x) * inv_unit;
double top_px= -(top_logic - cached_scroll_y) * cached_magf * inv_unit;
```

2. 修复 `viewport > surface` 时图片悬浮弹窗位置异常：
```cpp
double blank_top= 0.0;
if (owner && owner->scrollarea () && owner->scrollarea ()->viewport () &&
   owner->scrollarea ()->surface ()) {
 int vp_h  = owner->scrollarea ()->viewport ()->height ();
 int surf_h= owner->scrollarea ()->surface ()->height ();
 if (vp_h > surf_h) blank_top= (vp_h - surf_h) * 0.5;
}
top_px+= blank_top;
```

3. 删除 `cached_magf` 补丁