### PR TITLE
[209_8] 新增 SQL 语言语法高亮支持

### DIFF
--- a/TeXmacs/tests/tmu/209_8.tmu
+++ b/TeXmacs/tests/tmu/209_8.tmu
@@ -1,0 +1,148 @@
+<TMU|<tuple|1.1.0|2026.1.1>>
+
+<style|<tuple|generic|number-europe|preview-ref|sql|chinese|table-captions-above>>
+
+<\body>
+  SQL 语言行内代码示例：
+
+  <\itemize>
+    <item>这是一段 SQL 代码示例 <sql|<code|<code*|SELECT * FROM Students;>>>，用于查询所有学生。
+  </itemize>
+
+  \;
+
+  SQL 语言代码块示例：
+
+  <\sql-code>
+    -- Create a table with constraints
+
+    CREATE TABLE users (
+
+    \ \ \ \ id \ \ \ \ \ \ \ \ \ SERIAL PRIMARY KEY,
+
+    \ \ \ \ username \ \ \ VARCHAR(50) NOT NULL UNIQUE,
+
+    \ \ \ \ email \ \ \ \ \ \ VARCHAR(255) NOT NULL,
+
+    \ \ \ \ created_at \ TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    \ \ \ \ is_active \ \ BOOLEAN DEFAULT TRUE
+
+    );
+
+    \;
+
+    CREATE TABLE orders (
+
+    \ \ \ \ id \ \ \ \ \ \ \ \ \ SERIAL PRIMARY KEY,
+
+    \ \ \ \ user_id \ \ \ \ INTEGER NOT NULL,
+
+    \ \ \ \ amount \ \ \ \ \ DECIMAL(10, 2) CHECK (amount \<gtr\>= 0),
+
+    \ \ \ \ status \ \ \ \ \ VARCHAR(20) DEFAULT 'pending',
+
+    \ \ \ \ created_at \ TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    \ \ \ \ CONSTRAINT fk_user
+
+    \ \ \ \ \ \ \ \ FOREIGN KEY (user_id)
+
+    \ \ \ \ \ \ \ \ REFERENCES users(id)
+
+    \ \ \ \ \ \ \ \ ON DELETE CASCADE
+
+    );
+
+    \;
+
+    -- Insert data
+
+    INSERT INTO users (username, email)
+
+    VALUES
+
+    \ \ \ \ ('alice', 'alice@example.com'),
+
+    \ \ \ \ ('bob', \ \ 'bob@example.com');
+
+    \;
+
+    INSERT INTO orders (user_id, amount, status)
+
+    VALUES
+
+    \ \ \ \ (1, 99.99, 'paid'),
+
+    \ \ \ \ (1, 15.50, 'pending'),
+
+    \ \ \ \ (2, 42.00, 'paid');
+
+    \;
+
+    -- Query with JOIN, aggregation, and filtering
+
+    SELECT
+
+    \ \ \ \ u.username,
+
+    \ \ \ \ COUNT(o.id) AS order_count,
+
+    \ \ \ \ SUM(o.amount) AS total_spent
+
+    FROM users u
+
+    LEFT JOIN orders o
+
+    \ \ \ \ ON u.id = o.user_id
+
+    WHERE u.is_active = TRUE
+
+    GROUP BY u.username
+
+    HAVING SUM(o.amount) \<gtr\> 20
+
+    ORDER BY total_spent DESC;
+
+    \;
+
+    -- Subquery example
+
+    SELECT *
+
+    FROM orders
+
+    WHERE amount \<gtr\> (
+
+    \ \ \ \ SELECT AVG(amount)
+
+    \ \ \ \ FROM orders
+
+    );
+
+    \;
+
+    -- Update and delete
+
+    UPDATE orders
+
+    SET status = 'shipped'
+
+    WHERE status = 'paid';
+
+    \;
+
+    DELETE FROM users
+
+    WHERE username = 'bob';
+
+    \;
+  </sql-code>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/209_8.md
+++ b/devel/209_8.md
@@ -1,0 +1,32 @@
+# [209_8] 新增 SQL 语言语法高亮支持
+
+## 如何测试
+
+在文本模式下，点击菜单栏，依次选择：
+- 插入 -> 程序 -> 行内代码 -> SQL
+- 插入 -> 程序 -> 代码块 -> SQL
+
+输入 SQL 程序，检查是否正确地显示高亮。
+
+
+## 插件位置
+
+插件位于 TeXmacs/plugins/sql 目录下。插件新增的文件列表如下所示：
+
+- 插件文档：`TeXmacs/plugins/sql/doc/sql.en.tmu`
+- 语言样式包：`TeXmacs/plugins/sql/packages/code/sql.ts`
+- 编辑功能支持：`TeXmacs/plugins/sql/progs/code/sql-edit.scm`
+- 语法支持：`TeXmacs/plugins/sql/progs/code/sql-lang.scm`
+- 语言模式：`TeXmacs/plugins/sql/progs/code/sql-mode.scm`
+- 格式定义：`TeXmacs/plugins/sql/progs/data/sql.scm`
+
+
+**插入 -> 程序** 目录，进行了内容修改，对应修改的文件如下所示：
+
+```
+TeXmacs/progs/prog/prog-menu.scm
+```
+
+
+## 2026/01/20 新增了 SQL 语言插件，提供 SQL 语法高亮功能支持
+


### PR DESCRIPTION
# [209_8] 新增 SQL 语言语法高亮支持

## 如何测试

在文本模式下，点击菜单栏，依次选择：
- 插入 -> 程序 -> 行内代码 -> SQL
- 插入 -> 程序 -> 代码块 -> SQL

输入 SQL 程序，检查是否正确地显示高亮。


## 插件位置

插件位于 TeXmacs/plugins/sql 目录下。插件新增的文件列表如下所示：

- 插件文档：`TeXmacs/plugins/sql/doc/sql.en.tmu`
- 语言样式包：`TeXmacs/plugins/sql/packages/code/sql.ts`
- 编辑功能支持：`TeXmacs/plugins/sql/progs/code/sql-edit.scm`
- 语法支持：`TeXmacs/plugins/sql/progs/code/sql-lang.scm`
- 语言模式：`TeXmacs/plugins/sql/progs/code/sql-mode.scm`
- 格式定义：`TeXmacs/plugins/sql/progs/data/sql.scm`


**插入 -> 程序** 目录，进行了内容修改，对应修改的文件如下所示：

```
TeXmacs/progs/prog/prog-menu.scm
```


## 2026/01/20 新增了 SQL 语言插件，提供 SQL 语法高亮功能支持

