### PR TITLE
[201_61] 修复 tab cycling 缩放导致的位置异常

### DIFF
--- a/devel/201_61.md
+++ b/devel/201_61.md
@@ -1,0 +1,25 @@
+# [201_61] 修复 tab cycling 缩放导致的位置异常
+
+## 如何测试
+1. 进入数学模式
+2. 缩放文档到很小，文档区域上方出现灰色区域
+3. 测试 tab cycling，测试弹窗位置是否在光标附近（没有明显上移）
+
+## 2026/1/21
+### What
+在缩放到很小后，tab cycling 弹窗位置异常
+
+### Why
+`viewport > surface` 时，上方的 blank 留白未计算进去
+
+### How
+```cpp
+double blank_top= 0.0;
+if (owner && owner->scrollarea () && owner->scrollarea ()->viewport () &&
+   owner->scrollarea ()->surface ()) {
+ int vp_h  = owner->scrollarea ()->viewport ()->height ();
+ int surf_h= owner->scrollarea ()->surface ()->height ();
+ if (vp_h > surf_h) blank_top= (vp_h - surf_h) * 0.5;
+}
+top_px+= blank_top;
+```

--- a/src/Plugins/Qt/QTMMathCompletionPopup.cpp
+++ b/src/Plugins/Qt/QTMMathCompletionPopup.cpp
@@ -14,6 +14,7 @@
 
 #include <QPainter>
 #include <QPen>
+#include <cmath>
 
 QTMMathCompletionPopup::QTMMathCompletionPopup (QWidget*              parent,
                                                 qt_simple_widget_rep* owner)
@@ -127,6 +128,14 @@ QTMMathCompletionPopup::getCachedPosition (int& x, int& y) {
       cached_canvas_x) /
      256;
   y= -((cached_cursor_y - 5000 - cached_scroll_y) * cached_magf) / 256;
+  double blank_top= 0.0;
+  if (owner && owner->scrollarea () && owner->scrollarea ()->viewport () &&
+      owner->scrollarea ()->surface ()) {
+    int vp_h  = owner->scrollarea ()->viewport ()->height ();
+    int surf_h= owner->scrollarea ()->surface ()->height ();
+    if (vp_h > surf_h) blank_top= (vp_h - surf_h) * 0.5;
+  }
+  y+= int (std::round (blank_top));
   y+= 10;
 }
 


### PR DESCRIPTION
# [201_61] 修复 tab cycling 缩放导致的位置异常

## 如何测试
1. 进入数学模式
2. 缩放文档到很小，文档区域上方出现灰色区域
3. 测试 tab cycling，测试弹窗位置是否在光标附近（没有明显上移）

## 2026/1/21
### What
在缩放到很小后，tab cycling 弹窗位置异常

### Why
`viewport > surface` 时，上方的 blank 留白未计算进去

### How
```cpp
double blank_top= 0.0;
if (owner && owner->scrollarea () && owner->scrollarea ()->viewport () &&
   owner->scrollarea ()->surface ()) {
 int vp_h  = owner->scrollarea ()->viewport ()->height ();
 int surf_h= owner->scrollarea ()->surface ()->height ();
 if (vp_h > surf_h) blank_top= (vp_h - surf_h) * 0.5;
}
top_px+= blank_top;
```