### PR TITLE
[209_6] 修复R语言排版的问题

### DIFF
--- a/devel/209_6.md
+++ b/devel/209_6.md
@@ -13,6 +13,10 @@
 - 高亮功能：TeXmacs/plugins/r/progs/code/r-lang.scm
 - 文档：TeXmacs/plugins/r/doc/r.en.tmu
 
+## 2025/01/21
+### What
+修复了r-edit.scm中已知的bug
+
 ## 2025/01/19 
 ### What
 改进了R语言的高亮显示


### PR DESCRIPTION
## 如何测试

1. 选择菜单插入-程序-代码块/行内代码或使用 `\r` 或者 `\r-code`插入代码块环境
2. 输入一些R语言代码检查高亮
- 测试文档：TeXmacs/tests/tmu/209_6.tmu

## 文件位置
- 语言定义：TeXmacs/plugins/r/progs/data/r.scm
- 样式包：TeXmacs/plugins/r/packages/code/r.ts
- 编辑功能：TeXmacs/plugins/r/progs/code/r-edit.scm
- 高亮功能：TeXmacs/plugins/r/progs/code/r-lang.scm
- 文档：TeXmacs/plugins/r/doc/r.en.tmu

## 2025/01/21
### What
修复了r-edit.scm中已知的bug

## 2025/01/19 
### What
改进了R语言的高亮显示

## 2025/01/16 
### What
为Mogan STEM添加R编程语言的语法高亮支持，包括语言定义文件和样式包。

### Why
满足用户的插入R语言代码需求