### PR TITLE
[204_28] 修复大根号撕裂问题

### DIFF
--- a/devel/204_28.md
+++ b/devel/204_28.md
@@ -17,6 +17,4 @@
 原本的校正值 `dy = -fn->wfn/36` 导致横线位置偏低，与拆分的勾号部分无法连接，需要调整该校正值使横线适当上移。
 
 ### How
-将 `math_boxes.cpp` 中 `sqrt_box_rep` 构造函数中的横线y坐标计算由 `dy = -fn->wfn/36` 改为 `dy = +fn->wfn/54` 
-
-这样横线会上移约`0.046×wfn`（即 `5*wfn/108`），与拆分的勾号部分正确连接，消除撕裂现象。
+将 `math_boxes.cpp` 中 `sqrt_box_rep` 构造函数中的横线y坐标计算由 `dy = -fn->wfn/36` 改为 `dy = +fn->wfn/52` 

--- a/src/Typeset/Boxes/Composite/math_boxes.cpp
+++ b/src/Typeset/Boxes/Composite/math_boxes.cpp
@@ -173,7 +173,7 @@ sqrt_box_rep::sqrt_box_rep (path ip, box b1, box b2, box sqrtb, font fn2,
 
   SI sep  = fn->sep;
   SI wline= fn->wline;
-  SI dx= -fn->wfn / 36, dy= +fn->wfn / 54; // correction
+  SI dx= -fn->wfn / 36, dy= +fn->wfn / 52; // correction
   SI by= sqrtb->y2 + dy;
   if (sqrtb->x2 - sqrtb->x4 > wline) dx-= (sqrtb->x2 - sqrtb->x4);
 


### PR DESCRIPTION
# [204_28] 修复大根号撕裂问题
## 如何测试
1. 以 LaTeX 形式插入 `$\sqrt{\frac{11111}{\frac{\frac{\frac{\frac{}{}}{}}{}}{}}}$`
2. 观察显示，根式左右两部分没有明显的撕裂现象（之前很明显的左边"勾号"右边"横线"）

## 2026/1/21
### What
**修复了高根号表达式渲染时的撕裂问题**

当根式内容很高时，根号符号会拆分为左侧的"勾号"和右侧的"横线"两部分，但两部分错位导致视觉上的撕裂现象

通过调整横线的垂直位置，确保两部分正确对齐

### Why
在高根式情况下，横线位置的y坐标计算不正确

原本的校正值 `dy = -fn->wfn/36` 导致横线位置偏低，与拆分的勾号部分无法连接,需要调整该校正值使横线适当上移。

### How
将 `math_boxes.cpp` 中 `sqrt_box_rep` 构造函数中的横线y坐标计算由 `dy = -fn->wfn/36` 改为 `dy = +fn->wfn/54` 

这样横线会上移约`0.037×wfn`，与拆分的勾号部分正确连接，消除撕裂现象。
