### PR TITLE
[209_10] 修复C++代码模式下回车后光标位置错误

### DIFF
--- a/TeXmacs/plugins/code/progs/code/cpp-edit.scm
+++ b/TeXmacs/plugins/code/progs/code/cpp-edit.scm
@@ -39,6 +39,12 @@
   (:mode in-prog-cpp?)
   (select-brackets-after-movement "([{" ")]}" "\\"))
 
+(tm-define (program-compute-indentation doc row col)
+  (:mode in-prog-cpp?)
+  (if (<= row 0) 0
+      (let ((prev-row (program-row (- row 1))))
+        (if prev-row (string-get-indent prev-row) 0))))
+
 (kbd-map
   (:mode in-prog-cpp?)
   ("{" (cpp-bracket-open "{" "}" ))

--- a/TeXmacs/tests/tmu/209_10.tmu
+++ b/TeXmacs/tests/tmu/209_10.tmu
@@ -1,0 +1,30 @@
+<TMU|<tuple|1.1.0|2026.1.1>>
+
+<style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref>>
+
+<\body>
+  C++代码换行示例('\|'表示在第一行末按下回车期待光标出现的位置):
+
+  <\cpp-code>
+    abc def
+
+    \|
+  </cpp-code>
+
+  \;
+
+  <\cpp-code>
+    \ \ abc def
+
+    \ \ \|
+
+    \ \ 
+  </cpp-code>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/209_10.md
+++ b/devel/209_10.md
@@ -1,0 +1,43 @@
+# 209_10: 修复C++代码模式下回车后光标位置错误
+
+## 如何测试
+1. 启动 Mogan / TeXmacs
+2. 新建C++代码环境：
+   - 插入 `\cpp-code` 环境
+3. 在段首（第一行）输入测试内容：
+   ```
+   abc def
+   ```
+4. 按回车键
+
+- 测试文档：TeXmacs/tests/tmu/209_10.tmu
+
+期望结果：
+- 光标定位在新行行首（列位置0）
+- 光标不会错误地落在字符'd'前（列位置4）
+
+## 2026/1/21
+### What
+修复在C++代码模式下，当在段首输入内容后按回车键，光标位置错误的问题。
+
+具体问题现象：
+- 在C++代码环境段首输入"abc def"
+- 按回车键创建新行
+- 光标错误地落在字符'd'前（第4列），而不是正确的新行行首位置（第0列）
+
+### Why
+
+关联 Issue： #2602
+
+问题根源在于C++代码编辑模块缺少正确的缩进计算逻辑：
+
+1. C++使用 `TeXmacs/plugins/code/progs/code/cpp-edit.scm` 作为语言特定编辑模块
+2. 该模块没有定义自己的 `program-compute-indentation` 函数
+3. 因此使用了 `prog-edit.scm` 中的默认实现，该实现缺少对第一行的边界检查
+4. 当在段首按回车时，新行（第二行，row=1）的缩进被错误计算，导致光标位置错误
+
+### How
+参照 `python-edit.scm` 的正确实现，在 `cpp-edit.scm` 中添加 `program-compute-indentation` 函数：
+
+**修改文件**: `TeXmacs/plugins/code/progs/code/cpp-edit.scm:41-47`
+


### PR DESCRIPTION
## 如何测试
1. 启动 Mogan / TeXmacs
2. 新建C++代码环境：
   - 插入 `\cpp-code` 环境
3. 在段首（第一行）输入测试内容：
   ```
   abc def
   ```
4. 按回车键

- 测试文档：TeXmacs/tests/tmu/209_10.tmu

期望结果：
- 光标定位在新行行首（列位置0）
- 光标不会错误地落在字符'd'前（列位置4）

## 2026/1/21
### What
修复在C++代码模式下，当在段首输入内容后按回车键，光标位置错误的问题。

具体问题现象：
- 在C++代码环境段首输入"abc def"
- 按回车键创建新行
- 光标错误地落在字符'd'前（第4列），而不是正确的新行行首位置（第0列）

### Why

关联 Issue： #2602

问题根源在于C++代码编辑模块缺少正确的缩进计算逻辑：

1. C++使用 `TeXmacs/plugins/code/progs/code/cpp-edit.scm` 作为语言特定编辑模块
2. 该模块没有定义自己的 `program-compute-indentation` 函数
3. 因此使用了 `prog-edit.scm` 中的默认实现，该实现缺少对第一行的边界检查
4. 当在段首按回车时，新行（第二行，row=1）的缩进被错误计算，导致光标位置错误

### How
参照 `python-edit.scm` 的正确实现，在 `cpp-edit.scm` 中添加 `program-compute-indentation` 函数：

**修改文件**: `TeXmacs/plugins/code/progs/code/cpp-edit.scm:41-47`

