### PR TITLE
[209_7] 补充bash代码的语法高亮支持

### DIFF
--- a/TeXmacs/plugins/bash/progs/code/bash-lang.scm
+++ b/TeXmacs/plugins/bash/progs/code/bash-lang.scm
@@ -49,7 +49,9 @@
       "history" "fc"
       "compgen" "complete"
       "times"
-      "git" "ssh" "scp" "rsync"    ;;常用外部命令
+    )
+    (external_command
+      "ssh" "scp" "rsync"    ;; 常用外部命令
       "curl" "wget"
       "xmake" "cmake" "make" "ninja"
       "gcc" "g++" "clang" "clang++"
@@ -59,9 +61,34 @@
       "tar" "zip" "unzip"
       "grep" "sed" "awk"
       "jq"
-      "vim" "nvim"
-      "sudo")
-
+      "sudo"
+      "claude" "ll" "gh" "code" "gco"
+      ;; Git / GitHub
+      "git" "gh"
+      "gco" "gcb" "gcm" "gca" "gcp" "gst" "gpl" "gps"
+      ;; Editor / AI
+      "code" "code-insiders" "vim" "nvim"
+      "claude" "cursor" "zed"
+      ;; Common shell aliases
+      "ll" "la" "l"
+      ;; GNU coreutils
+      "arch" "basename" "b2sum" "base32" "base64" "basenc"
+      "cat" "chcon" "chgrp" "chmod" "chown" "chroot"
+      "cksum" "comm" "cp" "csplit" "cut" "date" "dd"
+      "df" "dir" "dircolors" "dirname" "du"
+      "env" "expand" "expr" "factor" "false" "fmt" "fold"
+      "groups" "head" "hostid" "id" "install"
+      "join" "link" "ln" "logname" "ls" "md5sum"
+      "mkdir" "mkfifo" "mknod" "mktemp" "mv"
+      "nice" "nl" "nohup" "nproc" "numfmt" "od"
+      "paste" "pathchk" "pinky" "pr" "printenv" "ptx"
+      "readlink" "realpath" "rm" "rmdir" "runcon"
+      "seq" "sha1sum" "sha224sum" "sha256sum" "sha384sum" "sha512sum"
+      "shred" "shuf" "sleep" "sort" "split" "stat"
+      "stdbuf" "stty" "sum" "sync" "tac" "tail"
+      "tee" "timeout" "touch" "tr" "true" "truncate"
+      "tsort" "tty" "uname" "unexpand" "uniq" "unlink"
+      "uptime" "users" "vdir" "wc" "who" "whoami" "yes")
     ;; 关键字
     (keyword
       "if" "then" "elif" "else" "fi"
@@ -154,6 +181,7 @@
   ("syntax:bash:constant_string" "dark grey" notify-bash-syntax)
   ("syntax:bash:constant_char" "#333333" notify-bash-syntax)
   ("syntax:bash:declare_function" "#0000c0" notify-bash-syntax)
+  ("syntax:bash:external_command" "#0000c0" notify-bash-syntax)
   ("syntax:bash:declare_type" "#0000c0" notify-bash-syntax)
   ("syntax:bash:operator" "#8b008b" notify-bash-syntax)
   ("syntax:bash:operator_openclose" "#B02020" notify-bash-syntax)

--- a/TeXmacs/tests/tmu/209_7.tmu
+++ b/TeXmacs/tests/tmu/209_7.tmu
@@ -316,7 +316,7 @@
 
     \;
 
-    # 常见 VCS / build / language commands
+    # VCS / build / language commands
 
     git status
 
@@ -350,7 +350,7 @@
 
     \;
 
-    # 网络 / 远程
+    # net
 
     ssh user@example.com true
 
@@ -360,7 +360,7 @@
 
     \;
 
-    # 容器 / 工具
+    # docker
 
     docker ps
 
@@ -368,9 +368,41 @@
 
     \;
 
-    # 文本处理
+    # text
 
     grep -E "error\|warn" "$LOG" \| awk '{print NR ":" $0}' \| sed 's/^/LOG: /'
+
+    \;
+
+    # ---------- team tools / aliases highlight test ----------
+
+    \;
+
+    # shell aliases
+
+    ll
+
+    la
+
+    l
+
+    \;
+
+    # git / github aliases
+
+    git status
+
+    gh repo view
+
+    gco main
+
+    \;
+
+    # editor / ai tools
+
+    code .
+
+    claude help
 
     \;
 

--- a/devel/209_7.md
+++ b/devel/209_7.md
@@ -13,7 +13,18 @@
 - 高亮功能：TeXmacs/plugins/bash/progs/code/bash-lang.scm
 - 文档：TeXmacs/plugins/bash/doc/bash.en.tmu
 
-## 2025/01/16 
+
+
+## 2025/01/22
+### What
+补充了bash-lang.scm中语法高亮的定义，增加了
+- **外部命令高亮（external_command）**  
+  - GNU coreutils 
+  - 常用开发工具，如 `git`、`gh`、`code`、`claude`  
+  - 常用 alias（如 `ll`、`gco`）
+
+
+## 2025/01/20 
 ### What
 为Mogan STEM添加Bash代码的语法高亮支持，包括语言定义文件和样式包。
 

--- a/src/System/Language/language.cpp
+++ b/src/System/Language/language.cpp
@@ -244,6 +244,7 @@ initialize_color_encodings () {
   language_rep::color_encoding ("declare_type")          = 33;
   language_rep::color_encoding ("declare_category")      = 34;
   language_rep::color_encoding ("declare_module")        = 35;
+  language_rep::color_encoding ("external_command")      = 36;
   language_rep::color_encoding ("operator")              = 40;
   language_rep::color_encoding ("operator_openclose")    = 41;
   language_rep::color_encoding ("operator_field")        = 42;
@@ -297,6 +298,8 @@ initialize_color_decodings (string lan_name) {
   lan->color_decoding (34)=
       get_preference (pfx * "declare_category", "#d030d0");
   lan->color_decoding (35)= get_preference (pfx * "declare_module", "#0000c0");
+  lan->color_decoding (36)=
+      get_preference (pfx * "external_command", "#0000c0");
   lan->color_decoding (40)= get_preference (pfx * "operator", "#8b008b");
   lan->color_decoding (41)=
       get_preference (pfx * "operator_openclose", "#B02020");


### PR DESCRIPTION
## 如何测试

1. 选择菜单插入-程序-代码块/行内代码或使用 `\bash` 或者 `\bash-code`插入代码块环境
2. 输入一些Bash代码检查高亮
- 测试文档: TeXmacs/tests/tmu/209_7.tmu

## 文件位置
- 语言定义：TeXmacs/plugins/bash/progs/data/bash.scm
- 样式包：TeXmacs/plugins/bash/packages/code/bash.ts
- 编辑功能：TeXmacs/plugins/bash/progs/code/bash-edit.scm
- 高亮功能：TeXmacs/plugins/bash/progs/code/bash-lang.scm
- 文档：TeXmacs/plugins/bash/doc/bash.en.tmu



## 2025/01/22
### What
补充了bash-lang.scm中语法高亮的定义，增加了
- **外部命令高亮（external_command）**  
  - GNU coreutils 
  - 常用开发工具，如 `git`、`gh`、`code`、`claude`  
  - 常用 alias（如 `ll`、`gco`）


## 2025/01/20 
### What
为Mogan STEM添加Bash代码的语法高亮支持，包括语言定义文件和样式包。

### Why
满足用户的插入Bash代码需求

关联 issue #2607