### PR TITLE
[209_7] 修复bash代码模式下的错误高亮

### DIFF
--- a/TeXmacs/plugins/bash/progs/code/bash-lang.scm
+++ b/TeXmacs/plugins/bash/progs/code/bash-lang.scm
@@ -139,6 +139,12 @@
       "##" "#" "%%" "%"                   ;; ${var##pat} ${var%pat} ...
       )))
 
+;; Paths / urls
+(tm-define (parser-feature lan key)
+  (:require (and (== lan "bash") (== key "path")))
+  `(,(string->symbol key)
+    (enable)))
+
 ;; Numbers
 (tm-define (parser-feature lan key)
   (:require (and (== lan "bash") (== key "number")))
@@ -163,7 +169,8 @@
 (tm-define (parser-feature lan key)
   (:require (and (== lan "bash") (== key "comment")))
   `(,(string->symbol key)
-    (inline "#")))
+    (inline "#")
+    (inline_require_space)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Preferences for syntax highlighting

--- a/TeXmacs/tests/tmu/209_7.tmu
+++ b/TeXmacs/tests/tmu/209_7.tmu
@@ -1,4 +1,4 @@
-<TMU|<tuple|1.1.0|2026.1.1>>
+<TMU|<tuple|1.1.0|2026.1.2>>
 
 <style|<tuple|generic|chinese|table-captions-above|number-europe|preview-ref|bash>>
 
@@ -23,6 +23,38 @@
     set -euo pipefail
 
     IFS=$'\\n\\t'
+
+    # ---------- path -------------
+
+    \;
+
+    tar xzvf nvim-linux-x86_64.tar.gz
+
+    sudo mv nvim-linux-x86_64 /opt/nvim
+
+    git clone git@gitee.com:XmacsLabs/mogan.git
+
+    cat chapter-3.1.tmu
+
+    3.2 4.5
+
+    \;
+
+    # ----------- commment ---------
+
+    echo $# # 行尾注释
+
+    \;
+
+    echo ${#PATH}#not_comment
+
+    echo "${#PATH}#still_not_comment"
+
+    \;
+
+    echo ${#PATH} # 这里才是注释
+
+    \;
 
     \;
 

--- a/devel/209_7.md
+++ b/devel/209_7.md
@@ -33,3 +33,13 @@
 
 关联 issue #2607
 
+## 2026/01/29
+### What
+- 修复 Bash 代码模式下 `#` 在 `$#`、`${#...}` 中被误识别为注释的问题
+- 增加路径/URL 识别规则，避免路径/文件名中的关键字与数字误高亮（如 `abc.git`）
+
+### How
+- 在 `prog_language.cpp` 增加可配置的 `path` 解析步骤，位于 `string_parser` 之后、`keyword/number` 之前；匹配到路径/URL token 则整体消费
+- `bash-lang.scm` 中启用 `path` 解析
+- 注释规则增加 `inline_require_space`：仅当 `#` 位于行首或空白后才作为注释起始
+

--- a/src/System/Language/impl_language.hpp
+++ b/src/System/Language/impl_language.hpp
@@ -90,7 +90,11 @@ struct prog_language_rep : abstract_language_rep {
   void customize_string (tree config);
   void customize_preprocessor (tree config);
   void customize_comment (tree config);
+  void customize_path (tree config);
   tree get_parser_config (string lan, string key);
+
+  bool inline_comment_requires_space;
+  bool path_parser_enabled;
 };
 
 struct scheme_language_rep : language_rep {


### PR DESCRIPTION
## 如何测试

1. 选择菜单插入-程序-代码块/行内代码或使用 `\bash` 或者 `\bash-code`插入代码块环境
2. 输入一些Bash代码检查高亮
- 测试文档: TeXmacs/tests/tmu/209_7.tmu

## 文件位置
- 语言定义：TeXmacs/plugins/bash/progs/data/bash.scm
- 样式包：TeXmacs/plugins/bash/packages/code/bash.ts
- 编辑功能：TeXmacs/plugins/bash/progs/code/bash-edit.scm
- 高亮功能：TeXmacs/plugins/bash/progs/code/bash-lang.scm
- 文档：TeXmacs/plugins/bash/doc/bash.en.tmu

## 2026/01/29
### What
- 修复 Bash 代码模式下 `#` 在 `$#`、`${#...}` 中被误识别为注释的问题
- 增加路径/URL 识别规则，避免路径/文件名中的关键字与数字误高亮（如 `abc.git`）

### How
- 在 `prog_language.cpp` 增加可配置的 `path` 解析步骤，位于 `string_parser` 之后、`keyword/number` 之前；匹配到路径/URL token 则整体消费
- `bash-lang.scm` 中启用 `path` 解析
- 注释规则增加 `inline_require_space`：仅当 `#` 位于行首或空白后才作为注释起始

## 2025/01/22
### What
补充了bash-lang.scm中语法高亮的定义，增加了
- **外部命令高亮（external_command）**  
  - GNU coreutils 
  - 常用开发工具，如 `git`、`gh`、`code`、`claude`  
  - 常用 alias（如 `ll`、`gco`）


## 2025/01/20 
### What
为Mogan STEM添加Bash代码的语法高亮支持，包括语言定义文件和样式包。

### Why
满足用户的插入Bash代码需求

关联 issue #2607

