### PR TITLE
[222_34] 打开已有文件时删除标题栏额外出现“无标题文件”

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-files.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-files.scm
@@ -547,11 +547,19 @@
         ((in? :new-window opts)
          (open-buffer-in-window name (buffer-get name) ""))
         (else
-          (with wins (buffer->windows-of-tabpage name)
-            (if (and (!= wins '())
-                     (in? (current-window) wins))
-              (switch-to-buffer* name)
-              (switch-to-buffer name)))))
+         ;; Remember current buffer to check if it's an unmodified scratch buffer
+         (let ((prev-buffer (current-buffer)))
+           (with wins (buffer->windows-of-tabpage name)
+             (if (and (!= wins '())
+                      (in? (current-window) wins))
+                 (switch-to-buffer* name)
+                 (switch-to-buffer name)))
+           ;; Close the previous unmodified scratch buffer after loading new file
+           (when (and prev-buffer
+                      (!= prev-buffer name)
+                      (url-scratch? prev-buffer)
+                      (not (buffer-modified? prev-buffer)))
+             (cpp-buffer-close prev-buffer)))))
   (buffer-notify-recent name)
   ;; Remember directory for file dialog
   (remember-file-dialog-directory name)

--- a/devel/222_34.md
+++ b/devel/222_34.md
@@ -1,0 +1,53 @@
+# [222_34] 打开已有文件时删除标题栏额外出现“无标题文件”
+## 如何测试
+打开任意TMU文件
+观察标题栏，不会出现“无标题文件”，只会出现打开文件的文件名
+
+## 2026/01/23
+### What
+
+Fix ：修复打开已有文件但标题栏额外出现“无标题文件[1]”
+
+### How
+之前的修复在 load-buffer-open 函数中添加了逻辑：在打开新文件后，自动关闭之前未修改的 scratch buffer。但这个修复有一个关键缺陷：
+
+```scheme
+(let ((prev-buffer (current-buffer)))
+  (cond ((in? :background opts) (noop))  ; ← 后台模式只是noop
+        ...)
+  ;; 问题：这个when块在cond之后无条件执行！
+  (when (and prev-buffer
+             (!= prev-buffer name)
+             (url-scratch? prev-buffer)
+             (not (buffer-modified? prev-buffer)))
+    (cpp-buffer-close prev-buffer)))
+```
+
+1. 当以 :background 模式加载文件时，cond 分支只执行 (noop)，不切换buffer
+2. 但 when 块在 cond 之后仍然会执行
+3. 这导致在后台加载时，当前正在使用的 scratch buffer 被意外关闭
+4. 用户仍在这个已关闭的buffer中操作，导致崩溃
+
+正确的修复方案:关闭旧 scratch buffer 的逻辑应该只在实际发生buffer切换时执行，即放在 else 分支内部。这样在:background 和 :new-window 模式下不会触发关闭逻辑
+只有在正常切换buffer的场景下才会关闭旧的空白scratch buffer
+
+```scheme
+(define (load-buffer-open name opts)
+  ;(display* "load-buffer-open " name ", " opts "\n")
+  (cond ((in? :background opts) (noop))
+        ((in? :new-window opts)
+         (open-buffer-in-window name (buffer-get name) ""))
+        (else
+         (let ((prev-buffer (current-buffer)))  ; ← 只在else分支记录
+           (with wins (buffer->windows-of-tabpage name)
+             (if (and (!= wins '())
+                      (in? (current-window) wins))
+                 (switch-to-buffer* name)
+                 (switch-to-buffer name)))
+           ;; 只在成功切换后才关闭旧的scratch buffer
+           (when (and prev-buffer
+                      (!= prev-buffer name)
+                      (url-scratch? prev-buffer)
+                      (not (buffer-modified? prev-buffer)))
+             (cpp-buffer-close prev-buffer))))))
+```


### PR DESCRIPTION
# [222_34] 打开已有文件时删除标题栏额外出现“无标题文件”
## 如何测试
打开任意TMU文件
观察标题栏，不会出现“无标题文件”，只会出现打开文件的文件名

## 2026/01/23
### What

Fix ：修复打开已有文件但标题栏额外出现“无标题文件[1]”

### How
之前的修复在 load-buffer-open 函数中添加了逻辑：在打开新文件后，自动关闭之前未修改的 scratch buffer。但这个修复有一个关键缺陷：

```scheme
(let ((prev-buffer (current-buffer)))
  (cond ((in? :background opts) (noop))  ; ← 后台模式只是noop
        ...)
  ;; 问题：这个when块在cond之后无条件执行！
  (when (and prev-buffer
             (!= prev-buffer name)
             (url-scratch? prev-buffer)
             (not (buffer-modified? prev-buffer)))
    (cpp-buffer-close prev-buffer)))
```

1. 当以 :background 模式加载文件时，cond 分支只执行 (noop)，不切换buffer
2. 但 when 块在 cond 之后仍然会执行
3. 这导致在后台加载时，当前正在使用的 scratch buffer 被意外关闭
4. 用户仍在这个已关闭的buffer中操作，导致崩溃

正确的修复方案:关闭旧 scratch buffer 的逻辑应该只在实际发生buffer切换时执行，即放在 else 分支内部。这样在:background 和 :new-window 模式下不会触发关闭逻辑
只有在正常切换buffer的场景下才会关闭旧的空白scratch buffer

```scheme
(define (load-buffer-open name opts)
  ;(display* "load-buffer-open " name ", " opts "\n")
  (cond ((in? :background opts) (noop))
        ((in? :new-window opts)
         (open-buffer-in-window name (buffer-get name) ""))
        (else
         (let ((prev-buffer (current-buffer)))  ; ← 只在else分支记录
           (with wins (buffer->windows-of-tabpage name)
             (if (and (!= wins '())
                      (in? (current-window) wins))
                 (switch-to-buffer* name)
                 (switch-to-buffer name)))
           ;; 只在成功切换后才关闭旧的scratch buffer
           (when (and prev-buffer
                      (!= prev-buffer name)
                      (url-scratch? prev-buffer)
                      (not (buffer-modified? prev-buffer)))
             (cpp-buffer-close prev-buffer))))))
```