### PR TITLE
[204_28] 修复根号的渲染

### DIFF
--- a/devel/204_28.md
+++ b/devel/204_28.md
@@ -1,7 +1,32 @@
 # [204_28] 修复大根号撕裂问题
 ## 如何测试
-1. 以 LaTeX 形式插入 `$\sqrt{\frac{11111}{\frac{\frac{\frac{\frac{}{}}{}}{}}{}}}$`
-2. 观察显示，根式左右两部分没有明显的撕裂现象（之前很明显的左边"勾号"右边"横线"）
+1. 以 LaTeX 形式插入 `$\sqrt{\frac{11111}{\frac{\frac{\frac{\frac{}{}}{}}{}}{}}}$`，观察根式左右两部分没有明显的撕裂现象（之前很明显的左边"勾号"右边"横线"）
+2. 以 LaTeX 形式插入 `$\sqrt{\pi}$`，观察根号的左边与上方横线有没有不重合的情况
+
+## 2026/1/27
+### What
+小根号和大根号在渲染时，`dy` 校正值应该不同
+
+### How
+`sqrtb` 是一个 `tree()` 节点，其中有两种：
+1. `(move_delimiter, <large-sqrt-0>)`，在sqrt变种为 0 时，仅由一层 `move_delimiter` 包裹
+2. `(macro_delimiter, 247 (move_delimiter, <large-sqrt-7>))`，在sqrt变种大于 1 时，由 `macro_delimiter` 包裹 `move_delimiter`，此时需要展开第二项
+
+```cpp
+string sqrt_str = "";
+tree   sqrt_tree= (tree) sqrtb;
+if (is_tuple (sqrt_tree) && N (sqrt_tree) >= 2) {
+ while (sqrt_tree[0] == "macro_delimiter")
+   sqrt_tree= sqrt_tree[1];
+ tree inner= sqrt_tree[0] == "move_delimiter" ? sqrt_tree[1] : tree ();
+ if (is_atomic (inner)) sqrt_str= inner->label;
+}
+int sqrt_variant= as_int (sqrt_str (12, N (sqrt_str) - 1));
+```
+用于获取根号的变种，然后根据变种选择不同的 `dy` 校正值：
+```cpp
+dy   = sqrt_variant < 7 ? -fn->wfn / 36 : +fn->wfn / 52; // correction
+```
 
 ## 2026/1/21
 ### What

--- a/src/Typeset/Boxes/Composite/math_boxes.cpp
+++ b/src/Typeset/Boxes/Composite/math_boxes.cpp
@@ -171,10 +171,21 @@ sqrt_box_rep::sqrt_box_rep (path ip, box b1, box b2, box sqrtb, font fn2,
     : composite_box_rep (ip), fn (fn2), pen (pen2) {
   right_italic_correct (b1);
 
+  string sqrt_str = "";
+  tree   sqrt_tree= (tree) sqrtb;
+  if (is_tuple (sqrt_tree) && N (sqrt_tree) >= 2) {
+    while (sqrt_tree[0] == "macro_delimiter")
+      sqrt_tree= sqrt_tree[1];
+    tree inner= sqrt_tree[0] == "move_delimiter" ? sqrt_tree[1] : tree ();
+    if (is_atomic (inner)) sqrt_str= inner->label;
+  }
+  int sqrt_variant= as_int (sqrt_str (12, N (sqrt_str) - 1));
+
   SI sep  = fn->sep;
   SI wline= fn->wline;
-  SI dx= -fn->wfn / 36, dy= +fn->wfn / 52; // correction
-  SI by= sqrtb->y2 + dy;
+  SI dx   = -fn->wfn / 36,
+     dy   = sqrt_variant < 7 ? -fn->wfn / 36 : +fn->wfn / 52; // correction
+  SI by   = sqrtb->y2 + dy;
   if (sqrtb->x2 - sqrtb->x4 > wline) dx-= (sqrtb->x2 - sqrtb->x4);
 
   bool use_open_type= (fn->math_type == MATH_TYPE_OPENTYPE) &&


### PR DESCRIPTION
# [204_28] 修复根号的渲染
## 如何测试
1. 以 LaTeX 形式插入 `$\sqrt{\frac{11111}{\frac{\frac{\frac{\frac{}{}}{}}{}}{}}}$`，观察根式左右两部分没有明显的撕裂现象（之前很明显的左边"勾号"右边"横线"）
2. 以 LaTeX 形式插入 `$\sqrt{\pi}$`，观察根号的左边与上方横线有没有不重合的情况

## 2026/1/27
### What
小根号和大根号在渲染时，`dy` 校正值应该不同

### How
`sqrtb` 是一个 `tree()` 节点，其中有两种：
1. `(move_delimiter, <large-sqrt-0>)`，在sqrt变种为 0 时，仅由一层 `move_delimiter` 包裹
2. `(macro_delimiter, 247 (move_delimiter, <large-sqrt-7>))`，在sqrt变种大于 1 时，由 `macro_delimiter` 包裹 `move_delimiter`，此时需要展开第二项

```cpp
string sqrt_str = "";
tree   sqrt_tree= (tree) sqrtb;
if (is_tuple (sqrt_tree) && N (sqrt_tree) >= 2) {
 while (sqrt_tree[0] == "macro_delimiter")
   sqrt_tree= sqrt_tree[1];
 tree inner= sqrt_tree[0] == "move_delimiter" ? sqrt_tree[1] : tree ();
 if (is_atomic (inner)) sqrt_str= inner->label;
}
int sqrt_variant= as_int (sqrt_str (12, N (sqrt_str) - 1));
```
用于获取根号的变种，然后根据变种选择不同的 `dy` 校正值：
```cpp
dy   = sqrt_variant < 7 ? -fn->wfn / 36 : +fn->wfn / 52; // correction
```

## 2026/1/21
### What
**修复了高根号表达式渲染时的撕裂问题**

当根式内容很高时，根号符号会拆分为左侧的"勾号"和右侧的"横线"两部分，但两部分错位导致视觉上的撕裂现象

通过调整横线的垂直位置，确保两部分正确对齐

### Why
在高根式情况下，横线位置的y坐标计算不正确

原本的校正值 `dy = -fn->wfn/36` 导致横线位置偏低，与拆分的勾号部分无法连接，需要调整该校正值使横线适当上移。

### How
将 `math_boxes.cpp` 中 `sqrt_box_rep` 构造函数中的横线y坐标计算由 `dy = -fn->wfn/36` 改为 `dy = +fn->wfn/52` 
