### PR TITLE
[209_15] 代码块括号函数参数修复

### DIFF
--- a/TeXmacs/plugins/matlab/progs/code/matlab-edit.scm
+++ b/TeXmacs/plugins/matlab/progs/code/matlab-edit.scm
@@ -92,11 +92,11 @@
 
 (tm-define (matlab-bracket-open lbr rbr)
   ;; 插入一对括号或引号，并将光标定位在中间
-  (bracket-open lbr rbr))
+  (bracket-open lbr rbr "\\"))
 
 (tm-define (matlab-bracket-close lbr rbr)
   ;; 处理闭合括号或引号，并正确放置光标位置
-  (bracket-close lbr rbr))
+  (bracket-close lbr rbr "\\"))
 
 (tm-define (notify-cursor-moved status)
   (:require prog-highlight-brackets?)

--- a/TeXmacs/plugins/sql/progs/code/sql-edit.scm
+++ b/TeXmacs/plugins/sql/progs/code/sql-edit.scm
@@ -130,11 +130,11 @@
 
 (tm-define (sql-bracket-open lbr rbr)
   ;; Insert a pair of brackets/quotes and position cursor between them
-  (bracket-open lbr rbr))
+  (bracket-open lbr rbr "\\"))
 
 (tm-define (sql-bracket-close lbr rbr)
   ;; Handle closing bracket/quote and position cursor appropriately
-  (bracket-close lbr rbr))
+  (bracket-close lbr rbr "\\"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Comment toggling

--- a/devel/209_15.md
+++ b/devel/209_15.md
@@ -1,0 +1,30 @@
+# 209_15 代码块括号函数参数修复
+
+## 如何测试
+
+1. 启动 Mogan。
+2. 插入 `matlab-code` 代码块。
+3. 分别输入 `'`、`"`、`(`、`)`、`[`、`]`、`{`、`}`。
+4. 观察是否出现 Scheme 报错。
+
+预期结果：
+- 输入过程无报错；
+- 相关括号/引号行为正常。
+
+## 2026/02/04
+
+### What
+- 修复 `matlab-edit.scm` 中 `bracket-open/bracket-close` 参数个数不匹配问题。
+- 修复 `sql-edit.scm` 中同类潜在问题。
+
+### How
+- `prog-edit.scm` 中 `bracket-open` 和 `bracket-close` 的签名是三参数：
+  - `(bracket-open lb rb esc)`
+  - `(bracket-close lb rb esc)`
+- 之前 `matlab/sql` 插件包装函数只传了两个参数，现统一补为：
+  - `(bracket-open lbr rbr "\\")`
+  - `(bracket-close lbr rbr "\\")`
+
+### Why
+- 第三个参数 `esc` 表示转义字符。
+- 当前一个字符等于 `esc` 时，仅插入左侧字符，不进行自动配对，可避免误补全。


### PR DESCRIPTION
## 如何测试

1. 启动 Mogan。
2. 插入 `matlab-code` 代码块。
3. 分别输入 `'`、`"`、`(`、`)`、`[`、`]`、`{`、`}`。
4. 观察是否出现 Scheme 报错。

预期结果：
- 输入过程无报错；
- 相关括号/引号行为正常。

## 2026/02/04

### What
- 修复 `matlab-edit.scm` 中 `bracket-open/bracket-close` 参数个数不匹配问题。
- 修复 `sql-edit.scm` 中同类潜在问题。

### How
- `prog-edit.scm` 中 `bracket-open` 和 `bracket-close` 的签名是三参数：
  - `(bracket-open lb rb esc)`
  - `(bracket-close lb rb esc)`
- 之前 `matlab/sql` 插件包装函数只传了两个参数，现统一补为：
  - `(bracket-open lbr rbr "\\")`
  - `(bracket-close lbr rbr "\\")`

### Why
- 第三个参数 `esc` 表示转义字符。
- 当前一个字符等于 `esc` 时，仅插入左侧字符，不进行自动配对，可避免误补全。
