### PR TITLE
[222_42] 修复转到第一个文件失败并收敛无标题页清理逻辑

### DIFF
--- a/devel/222_42.md
+++ b/devel/222_42.md
@@ -1,0 +1,40 @@
+﻿# 222_42 修复“转到第一个文件失败”并收敛无标题页清理逻辑
+
+## 如何测试
+1. 启动 Mogan，保持默认“无标题文件”。
+2. 连续打开多个 `.tmu` 文件（至少 2 个）。
+3. 在顶部“转到 / Open documents”里点击第一个打开的文件。
+4. 观察是否能正常切换到第一个文件。
+5. 查看日志，确认不再出现：`url-none? first argument, #f`。
+
+---
+
+## 2026/02/05
+
+### What
+- 修复“转到第一个文件失败”的问题。
+- 保留“启动后首次打开真实文件时自动清理默认无标题页”的能力。
+
+### Why
+- `buffer->windows-of-tabpage` 直接对 `view->window-of-tabpage` 的返回值调用 `url-none?`。
+- 在某些时序下，该返回值可能是 `#f`，导致：
+  - `url-none? first argument, #f`
+  - Go 菜单/工具栏构建流程报错，进而影响“转到”行为。
+
+### How
+本次修改集中在 `TeXmacs/progs/texmacs/texmacs/tm-files.scm`：
+
+1. 对窗口列表做防御过滤（关键修复）
+
+```scheme
+(tm-define (buffer->windows-of-tabpage buf)
+  ;; 某些时序下 view->window-of-tabpage 可能返回 #f，需先过滤再判定 url-none?
+  (remove (lambda (vw) (or (not vw) (url-none? vw)))
+          (map view->window-of-tabpage (buffer->views buf))))
+```
+
+2. 将“关闭默认无标题页”限制在“首次成功加载真实文件”场景
+- 移出 `load-buffer-open` 通用切换流程，避免影响“转到已打开文件”。
+- 仅在 `load-buffer-load` 的 `buffer-load` 成功分支触发。
+- 增加 `startup-scratch-buffer?` 统一判定条件，便于维护。
+


### PR DESCRIPTION
## 如何测试
1. 启动 Mogan，保持默认“无标题文件”。
2. 连续打开多个 `.tmu` 文件（至少 2 个）。
3. 在顶部“转到 / Open documents”里点击第一个打开的文件。
4. 观察是否能正常切换到第一个文件。
5. 查看日志，确认不再出现：`url-none? first argument, #f`。

---

## 2026/02/05

### What
- 修复“转到第一个文件失败”的问题。
- 保留“启动后首次打开真实文件时自动清理默认无标题页”的能力。

### Why
- `buffer->windows-of-tabpage` 直接对 `view->window-of-tabpage` 的返回值调用 `url-none?`。
- 在某些时序下，该返回值可能是 `#f`，导致：
  - `url-none? first argument, #f`
  - Go 菜单/工具栏构建流程报错，进而影响“转到”行为。

### How
本次修改集中在 `TeXmacs/progs/texmacs/texmacs/tm-files.scm`：

1. 对窗口列表做防御过滤（关键修复）

```scheme
(tm-define (buffer->windows-of-tabpage buf)
  ;; 某些时序下 view->window-of-tabpage 可能返回 #f，需先过滤再判定 url-none?
  (remove (lambda (vw) (or (not vw) (url-none? vw)))
          (map view->window-of-tabpage (buffer->views buf))))
```

2. 将“关闭默认无标题页”限制在“首次成功加载真实文件”场景
- 移出 `load-buffer-open` 通用切换流程，避免影响“转到已打开文件”。
- 仅在 `load-buffer-load` 的 `buffer-load` 成功分支触发。
- 增加 `startup-scratch-buffer?` 统一判定条件，便于维护。

