### PR TITLE
[201_78] 修改最近打开文件的json格式

### DIFF
--- a/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
+++ b/TeXmacs/progs/kernel/texmacs/tm-dialogue.scm
@@ -166,6 +166,26 @@
                 ("total" . 0)))
       ("files" . #())))
 
+(define (recent-file-item-valid? item)
+  (and (json-object? item)
+       (string? (json-ref item "path"))
+       (string? (json-ref item "name"))
+       (number? (json-ref item "last_open"))
+       (number? (json-ref item "open_count"))
+       (boolean? (json-ref item "show"))))
+
+(define (recent-files-json-valid? recent-files)
+  (and (json-object? recent-files)
+       (let* ((meta (json-ref recent-files "meta"))
+              (files (json-ref recent-files "files"))
+              (version (and (json-object? meta) (json-ref meta "version")))
+              (total (and (json-object? meta) (json-ref meta "total"))))
+         (and (json-object? meta)
+              (number? version)
+              (integer? total) (>= total 0)
+              (vector? files)
+              (every recent-file-item-valid? (vector->list files))))))
+
 
 #|
 recent-files-remove-by-path
@@ -558,9 +578,21 @@ unspecified
         (set! interactive-arg-table (decode l))))
   (when (url-exists? "$TEXMACS_HOME_PATH/system/recent-files.json")
       (set! interactive-arg-recent-file-json
-            (string->json
-             (string-load
-               (string->url "$TEXMACS_HOME_PATH/system/recent-files.json"))))))
+            (catch #t
+              (lambda ()
+                (let ((recent-files
+                       (string->json
+                        (string-load
+                         (string->url "$TEXMACS_HOME_PATH/system/recent-files.json")))))
+                  (if (recent-files-json-valid? recent-files)
+                      recent-files
+                      `(("meta" . (("version" . 1)
+                                    ("total" . 0)))
+                        ("files" . #())))))
+              (lambda args
+                `(("meta" . (("version" . 1)
+                              ("total" . 0)))
+                  ("files" . #())))))))
 
 
 (on-entry (retrieve-learned))

--- a/devel/201_78.md
+++ b/devel/201_78.md
@@ -8,6 +8,16 @@
 5. 点击`文件->最近使用`，选择一个已经打开的文件，会跳转过去，随后点击`文件->最近使用`，选择的文件位于第一处。
 5. 删除一个文件，再尝试通过`文件->最近使用`打开它，会弹出窗口提示文件不存在，随后点击`文件->最近使用`，观察该文件是否存在。
 6. 关闭程序，执行`cat ~/.local/share/moganlab/system/recent-files.json | python3 -m json.tool`，观察字段是否准确。
+7. 关闭程序，编辑`~/.local/share/moganlab/system/recent-files.json`，输入如下内容
+```
+{meta:{total:4},files:[{path:"\/home\/da\/git\/mogan\/TeXmacs\/doc\/manual\/manu.gettingstarted.zh.tmu",name:"manu.gettingstarted.zh.tmu",last_open:1770625505.296669,open_count:1,show:true},{path:"\/home\/da\/git\/mogan\/TeXmacs\/doc\/about\/mogan\/stem.zh.tmu",name:"stem.zh.tmu",last_open:1770625495.617651,open_count:2,show:true},{path:"\/home\/da\/DevTeam\/程设小作业资料.tmu",name:"程设小作业资料.tmu",last_open:1770618896.320695,open_count:2,show:true},{path:"\/home\/da\/DevTeam\/home\/da\/快捷键顺序调整.tmu",name:"快捷键顺序调整.tmu",last_open:1770618870.53241,open_count:1,show:true}]}
+```
+打开程序，点击`文件->最近使用`，由于json结构不匹配，此时是空列表。
+8. 关闭程序，编辑`~/.local/share/moganlab/system/recent-files.json`，测试在非法json时能否正常运行
+···
+{meta:{total:4},files:[{path:"\/home\/da\/git\/mogan\/TeXmacs\/doc\/manual\/manu.gettingstarted.zh.tmu",name:"manu.gettingstarted.zh.tmu",last_open:1770625505.296669,open_count:1,show:true},{path:"\/home\/da\/git\/mogan\/TeXmacs\/doc\/about\/mogan\/stem.zh.tmu",name:"stem.zh.tmu",last_open:1770625495.617651,open_count:2,show:true},{path:"\/home\/da\/DevTeam\/程设小作业资料.tmu",name:"程设小作业资料.tmu",last_open:1770618896.320695,open_count:2,show:true},{path:"\/home\/da\/DevTeam\/home\/da\/快捷键顺序调整.tmu",name:"快捷键顺序调整.tmu",last_open:1770618870.53241,open_cou
+···
+打开程序，点击`文件->最近使用`，由于非法json，此时是空列表。
 
 ## 2026/02/10 修改最近存储文件的json格式
 


### PR DESCRIPTION
# [201_71] 使用json来存储最近使用的文件

## 如何测试
1. 点击`文件->打开`，打开几个文件。
2. 点击`文件->最近使用`，能看到刚刚打开的几个文件。
3. 关闭一个文件a,再点击`文件->最近使用`打开文件a,观察能否打开成功，随后点击`文件->最近使用`，文件a的选项在第一处。
4. 点击`文件->最近使用`，选择一个已经打开的文件，会跳转过去，随后点击`文件->最近使用`，选择的文件位于第一处。
2. 点击`文件->最近使用`，能看到刚刚打开的几个文件。关闭程序，执行`cat ~/.local/share/moganlab/system/recent-files.json | python3 -m json.tool`，能观察到最近打开的文件。
3. 再次打开程序，点击`文件->最近使用`，能看到刚刚打开的几个文件。
4. 关闭一个文件a,再点击`文件->最近使用`打开文件a,观察能否打开成功，随后点击`文件->最近使用`，文件a的选项在第一处。
5. 点击`文件->最近使用`，选择一个已经打开的文件，会跳转过去，随后点击`文件->最近使用`，选择的文件位于第一处。
5. 删除一个文件，再尝试通过`文件->最近使用`打开它，会弹出窗口提示文件不存在，随后点击`文件->最近使用`，观察该文件是否存在。
6. 关闭程序，执行`cat ~/.local/share/moganlab/system/recent-files.json | python3 -m json.tool`，观察字段是否准确。

## 2026/02/10 修改最近存储文件的json格式

## 2026/02/04 使用json来存储最近使用的文件