### PR TITLE
[202_2787] Fix inconsistent focus toolbar numbering button in tables

### DIFF
--- a/TeXmacs/progs/table/table-menu.scm
+++ b/TeXmacs/progs/table/table-menu.scm
@@ -16,6 +16,18 @@
         (generic generic-menu)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Table predicates
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (numbered-context? t)
+  (:require (tree-in? t '(table row cell tformat tabular)))
+  (and-with p (tree-outer t) (numbered-context? p)))
+
+(tm-define (numbered-numbered? t)
+  (:require (tree-in? t '(table row cell tformat tabular)))
+  (and-with p (tree-outer t) (numbered-numbered? p)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inserting tables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/devel/202_2787.md
+++ b/devel/202_2787.md
@@ -1,0 +1,11 @@
+# 202_2787 Fix inconsistent focus toolbar numbering button in tables
+
+## 2026/02/20 fix-table-numbering-focus
+### What
+Modified `TeXmacs/progs/table/table-menu.scm` to extend the definition of `numbered-context?` and `numbered-numbered?`.
+
+### Why
+Inside tables (`tabular`, `tformat`, etc.), the `numbered-context?` predicate returned `#f` for `cell` and `row` tags, causing the numbering/unnumbering buttons in the focus toolbar to be disabled or hidden. This fixes issue #2787.
+
+### How
+By recursively checking parent nodes, table cells can now inherit the numbering properties of the enclosing `small-table` or `big-table`. Verification: Insert a small table, click inside a cell, and the numbering button in the focus toolbar should become active and toggle numbering correctly.


### PR DESCRIPTION
### What
Modified [TeXmacs/progs/table/table-menu.scm]  to extend the definition of `numbered-context?` and `numbered-numbered?`.

### Why
Inside tables (`tabular`, `tformat`, etc.), the `numbered-context?` predicate returned `#f` for `cell` and `row` tags, causing the numbering/unnumbering buttons in the focus toolbar to be disabled or hidden. This fixes issue #2787.

### How
By recursively checking parent nodes, table cells can now inherit the numbering properties of the enclosing `small-table` or `big-table`. Verification: Insert a small table, click inside a cell, and the numbering button in the focus toolbar should become active and toggle numbering correctly.