### PR TITLE
[203_2827] support \bold command

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm
@@ -254,7 +254,7 @@
 (logic-group latex-modifier-1%
   textnormalfont
   textrm texttt textsf textmd textbf textup textit textsl textsc emph
-  mathrm mathtt mathsf mathmd mathbf mathup mathit mathsl mathnormal
+  mathrm mathtt mathsf mathmd mathbf mathup mathit mathsl mathnormal bold
   mathcal mathfrak mathbb mathbbm mathscr operatorname boldsymbol
   lowercase MakeLowercase uppercase MakeUppercase selectlanguage)
 

--- a/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm
@@ -1612,7 +1612,8 @@
 
 (define (post-process-math-text t)
   (cond ((or (nlist? t) (!= (length t) 2)) t)
-        ((nin? (car t) '(mathrm mathbf mathsf mathit mathsl mathtt tmop)) t)
+        ((nin? (car t) '(mathrm mathbf mathsf mathit mathsl mathtt tmop bold)) t)
+        ((func? t 'bold 1) (post-process-math-text (list 'mathbf (cadr t))))
         ((and (string? (cadr t)) (string-alpha? (cadr t))) t)
         ((func? t 'mathrm 1) `(textrm ,(cadr t)))
         ((func? t 'mathbf 1) `(textbf ,(cadr t)))
@@ -1641,7 +1642,7 @@
       (let ((w (tmtex-get-with-cmd var val))
             (a (tmtex-get-assign-cmd var val)))
         (cond ((and w (tm-func? arg w 1)) arg)
-              ((in? w '(mathrm mathbf mathsf mathit mathtt mathsl))
+              ((in? w '(mathrm mathbf mathsf mathit mathtt mathsl bold))
                (post-process-math-text (list w arg)))
               (w (list w arg))
               (a (list '!group (tex-concat (list (list a) " " arg))))

--- a/devel/203_2827.md
+++ b/devel/203_2827.md
@@ -1,0 +1,17 @@
+# 203_2827 Support \bold command
+
+## How to test
+1. Create a LaTeX file containing `\bold{test}`.
+2. Import the file into `.tm` format.
+3. Verify that the imported document correctly renders "test" in bold text, identical to how `\mathbf{test}` is normally handled, instead of showing a raw red `\bold` tag.
+
+## 2026/02/21 Support \bold command
+### What
+Added support for the `\bold` command within the LaTeX plugin's import logic.
+
+### Why
+To resolve issue #2827. The original LaTeX parser treated `\bold` as an undefined macro during import. This resulted in an unsupported red tag appearing in the Mogan editor.
+
+### How
+1. In `TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm`, registered `bold` in the `latex-modifier-1%` logic group so the parser recognizes it as a standard single-argument formatting macro.
+2. In `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`, added a proxy translation rule inside `post-process-math-text`: `((func? t 'bold 1) (post-process-math-text (list 'mathbf (cadr t))))`. This intercepts `\bold` and delegates it to `\mathbf`, ensuring that it inherits all necessary logic for properly rendering both text and math content into bold.


### PR DESCRIPTION
## 2026/02/21 Support \bold command

### What
Added support for the `\bold` command within the LaTeX plugin's import logic.

### Why
To Fix issue #2827 @da-liii 
The original LaTeX parser treated `\bold` as an undefined macro during import. This resulted in an unsupported red tag appearing in the Mogan editor.

### How
1. In `TeXmacs/plugins/latex/progs/convert/latex/latex-command-drd.scm`, registered `bold` in the `latex-modifier-1%` logic group so the parser recognizes it as a standard single-argument formatting macro.
2. In `TeXmacs/plugins/latex/progs/convert/latex/tmtex.scm`, added a proxy translation rule inside `post-process-math-text`: `((func? t 'bold 1) (post-process-math-text (list 'mathbf (cadr t))))`. This intercepts `\bold` and delegates it to `\mathbf`, ensuring that it inherits all necessary logic for properly rendering both text and math content into bold.

## How to test
1. Create a LaTeX file containing `\bold{test}`.
2. Import the file into `.tm` format.
3. Verify that the imported document correctly renders "test" in bold text, identical to how `\mathbf{test}` is normally handled, instead of showing a raw red `\bold` tag.
