### PR TITLE
[202_2723] Add tooltips for overbrace underbrace underline 

### DIFF
--- a/TeXmacs/progs/math/math-menu.scm
+++ b/TeXmacs/progs/math/math-menu.scm
@@ -1257,7 +1257,10 @@
             ((balloon (icon "tm_dot.xpm") "keyboard equivalent:") (make-wide "<dot>"))
             ((balloon (icon "tm_ddot.xpm") "keyboard equivalent:") (make-wide "<ddot>"))
             ((balloon (icon "tm_acute.xpm") "keyboard equivalent:") (make-wide "<acute>"))
-            ((balloon (icon "tm_grave.xpm") "keyboard equivalent:") (make-wide "<grave>"))))
+            ((balloon (icon "tm_grave.xpm") "keyboard equivalent:") (make-wide "<grave>"))
+            ((balloon "\\overbrace" "keyboard equivalent:") (make-wide "<wide-overbrace>"))
+            ((balloon "\\underbrace" "keyboard equivalent:") (make-wide-under "<wide-underbrace>"))
+            ((balloon "\\underline" "keyboard equivalent:") (make-wide-under "<wide-bar>"))))
   /
   (=> (balloon (icon "tm_binop.xpm") "Insert a binary operation")
       (tile 8 (link binary-operation-menu)))

--- a/devel/202_2723.md
+++ b/devel/202_2723.md
@@ -1,0 +1,18 @@
+# 202_2723 Add \overbrace, \underbrace, \underline tooltips
+
+## How to test
+1. Open Mogan and enter a math environment (`$`).
+2. Long press or click the "Wide accents" toolbar icon (the `~` on the mode toolbar).
+3. Verify that `\overbrace`, `\underbrace`, and `\underline` are present in the popup menu.
+4. Hover over them to see the translated tooltips and shortcuts.
+5. Click them to verify they insert the correct macros.
+
+## 2026/02/24 Add tooltips for overbrace, underbrace, and underline
+### What
+Added missing text-based balloon widgets for `\overbrace`, `\underbrace`, and `\underline` to the `math-insert-icons` menu in `math-menu.scm`.
+
+### Why
+The mode toolbar's accent popup was missing these corresponding options, meaning users had no tooltips or UI buttons for inserting wide braces or underlines from the toolbar. This resolves issue #2723.
+
+### How
+Modified `TeXmacs/progs/math/math-menu.scm` to append three new entries to the `tm_wide` tile grid within `math-insert-icons`. They use text labels `\overbrace`, `\underbrace`, and `\underline` and are mapped to `(make-wide "<wide-overbrace>")`, `(make-wide-under "<wide-underbrace>")`, and `(make-wide-under "<wide-bar>")` respectively.


### PR DESCRIPTION
### 2026/02/24 Add tooltips for overbrace, underbrace, and underline

## What
Added missing text-based balloon widgets for `\overbrace`, `\underbrace`, and `\underline` to the `math-insert-icons` menu in [math-menu.scm].

## Why
The mode toolbar's accent popup was missing these corresponding options, meaning users had no tooltips or UI buttons for inserting wide braces or underlines from the toolbar. This resolves issue #2723.

## How
Modified [TeXmacs/progs/math/math-menu.scm] to append three new entries to the `tm_wide` tile grid within `math-insert-icons`. They use text labels `\overbrace`, `\underbrace`, and `\underline` and are mapped to `(make-wide "<wide-overbrace>")`, `(make-wide-under "<wide-underbrace>")`, and `(make-wide-under "<wide-bar>")` respectively.

## How to test
1. Open Mogan and enter a math environment (`$`).
2. Long press or click the "Wide accents" toolbar icon (the `~` on the mode toolbar).
3. Verify that `\overbrace`, `\underbrace`, and `\underline` are present in the popup menu.
4. Hover over them to see the translated tooltips and shortcuts.
5. Click them to verify they insert the correct macros.