### PR TITLE
[201_84]: Fix "Prefix by section number" not applying to Question/Answer

### DIFF
--- a/TeXmacs/packages/environment/env-base.ts
+++ b/TeXmacs/packages/environment/env-base.ts
@@ -44,6 +44,12 @@
 
   <group-individual-counters|algorithm-env>
 
+  <new-counter-group|question-env>
+
+  <add-to-counter-group|question-env|std-env>
+
+  <group-individual-counters|question-env>
+
   <new-counter-group|figure-env>
 
   <add-to-counter-group|figure-env|std-env>
@@ -76,6 +82,8 @@
   <assign|new-remark|<macro|env|name|<new-env|<arg|env>|<arg|name>|theorem-env|render-remark>>>
 
   <assign|new-exercise|<macro|env|name|<new-env|<arg|env>|<arg|name>|exercise-env|render-exercise>>>
+
+  <assign|new-question|<macro|env|name|<new-env|<arg|env>|<arg|name>|question-env|render-remark>>>
 
   <\active*>
     <\src-comment>

--- a/TeXmacs/packages/environment/env-theorem.ts
+++ b/TeXmacs/packages/environment/env-theorem.ts
@@ -68,13 +68,9 @@
 
   <new-exercise|solution|Solution>
 
-  <new-remark|question|Question>
+  <new-question|question|Question>
 
-  <new-remark|answer|Answer>
-
-  <individual-counter|question>
-
-  <individual-counter|answer>
+  <new-question|answer|Answer>
 </body>
 
 <\initial>

--- a/devel/201_84.md
+++ b/devel/201_84.md
@@ -1,0 +1,33 @@
+# [201_84] Fix "Prefix by section number" not applying to Question/Answer environments
+
+## Issue
+#2806 — The "Prefix by section number" style option works for Theorem and Proposition but does not apply to Question and Answer environments.
+
+## Root Cause
+In `env-theorem.ts`, Question and Answer were created with `new-remark` (adding them to `theorem-env` counter group) and then `individual-counter` was called to give them separate counters. However, `individual-counter` replaces `display-question` with the raw identity function, which breaks the display chain:
+
+```
+display-question → display-in-theorem-env → display-std-env → section-prefix + nr
+```
+
+After `individual-counter`, the chain becomes just `display-question → identity(nr)`, losing the section prefix.
+
+## Fix
+1. Created a new `question-env` counter group in `env-base.ts` as a sub-group of `std-env` with `group-individual-counters` (following the same pattern as `exercise-env`)
+2. Added a `new-question` macro that uses `question-env` for counters and `render-remark` for visual rendering
+3. Changed Question/Answer from `new-remark` + `individual-counter` to `new-question`
+
+This preserves individual counters while maintaining the proper display chain for section prefixing.
+
+## Changed Files
+- `TeXmacs/packages/environment/env-base.ts`
+- `TeXmacs/packages/environment/env-theorem.ts`
+
+## How to Test
+1. Create a new document with article style
+2. Add chapters/sections with Question environments inside them
+3. Open style options (the wrench icon on the focus toolbar)
+4. Enable "Prefix by section number"
+5. Verify that Question numbers now show section prefix (e.g., "Question 1.1." instead of "Question 1.")
+6. Verify that Answer numbers also show section prefix
+7. Verify that Theorem/Proposition still work correctly with section prefix


### PR DESCRIPTION
Fixes #2806

## Problem
The "Prefix by section number" style option works for Theorem and Proposition but not for Question and Answer.

## Root Cause
In `env-theorem.ts`, Question and Answer were created with `new-remark` (adding them to `theorem-env`) and then `individual-counter` was called. However, `individual-counter` replaces `display-question` with the raw identity function, breaking the display chain:

After `individual-counter`, the chain becomes `display-question → identity(nr)`, losing the section prefix entirely.

## Fix
- Created a new `question-env` counter group in `env-base.ts` as a sub-group of `std-env` with `group-individual-counters` (same pattern as `exercise-env`)
- Added a `new-question` macro using `question-env` for counters and `render-remark` for rendering
- Changed Question/Answer from `new-remark` + `individual-counter` to `new-question`

This preserves individual counters while maintaining the proper display chain for section prefixing.

## How to Test
1. Create a new document with article style
2. Add chapters/sections with Question environments inside them
3. Enable "Prefix by section number" in style options
4. Verify Question/Answer numbers now show section prefix (e.g., "Question 1.1." instead of "Question 1.")
5. Verify Theorem/Proposition still work correctly

Dev doc: `devel/201_84.md`