### PR TITLE
[212_2]: Fix hyperlinks unclickable in beamer PDF export

### DIFF
--- a/TeXmacs/tests/tmu/212_2_beamer_hlink.tmu
+++ b/TeXmacs/tests/tmu/212_2_beamer_hlink.tmu
@@ -1,0 +1,25 @@
+<TMU|<tuple|1.0.2|1.2.8-rc1>>
+
+<style|<tuple|beamer|no-page-numbers>>
+
+<\body>
+  <screens|<\shown>
+    Test slide with hyperlinks
+
+    <hlink|Mogan Research|https://mogan.app>
+
+    <hlink|GNU GPL v3|https://www.gnu.org/licenses/gpl-3.0.html>
+  </shown>|<\shown>
+    Second slide
+
+    <hlink|GitHub|https://github.com>
+  </shown>>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|font-base-size|24>
+    <associate|page-medium|beamer>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>

--- a/devel/212_2.md
+++ b/devel/212_2.md
@@ -1,0 +1,27 @@
+# 212_2: Fix hyperlinks unclickable in beamer PDF export
+
+## Issue
+Hyperlinks become invalid and unclickable after exporting a slideshow/beamer presentation to PDF. (Issue #2843)
+
+## How to test
+1. Open `TeXmacs/tests/tmu/212_2_beamer_hlink.tmu`
+2. Export as PDF via File → Export → Pdf...
+3. Open the exported PDF and verify all hyperlinks are clickable
+
+## 2026/02/24
+
+### What
+Fixed hyperlinks (`hlink`) becoming unclickable after exporting a beamer presentation to PDF.
+
+### Why
+When exporting a beamer presentation to PDF, `wrapped-print-to-file` creates a temporary buffer copy, calls `dynamic-make-slides` to expand slides, then calls `print-to-file` (→ C++ `print_doc`).
+
+In `print_doc`, `typeset_as_document` creates a typesetter, typesets the document (registering link/ID observers in global tables), then immediately destroys the typesetter — which unregisters all link observers.
+
+During the rendering loop that follows, `display_links` (called by `box_rep::redraw` for non-screen renderers) queries these global link tables via `get_ids()`/`get_links()`. But the tables are now empty because the typesetter was already destroyed. So `ren->href()` is never called, and no link annotations appear in the PDF.
+
+For regular documents, the screen-display typesetter from the original buffer is still alive with its link registrations. But for beamer export, the temporary buffer copy has no prior typesetting history — hence unclickable hyperlinks.
+
+### How
+- Inlined `typeset_as_document` in `print_doc` and deferred `delete_typesetter` until after the rendering loop, so link registrations persist through `display_links` calls
+- Added a free-function `typeset(typesetter)` wrapper in `typesetter.hpp`/`typesetter.cpp` to avoid needing the `typesetter_rep` class definition in `edit_main.cpp`

--- a/src/Typeset/Bridge/typesetter.cpp
+++ b/src/Typeset/Bridge/typesetter.cpp
@@ -301,6 +301,11 @@ exec_until (typesetter ttt, path p) {
 }
 
 box
+typeset (typesetter ttt) {
+  return ttt->typeset ();
+}
+
+box
 typeset (typesetter ttt, SI& x1, SI& y1, SI& x2, SI& y2) {
   return ttt->typeset (x1, y1, x2, y2);
 }

--- a/src/Typeset/typesetter.hpp
+++ b/src/Typeset/typesetter.hpp
@@ -31,6 +31,7 @@ void notify_assign_node (typesetter ttt, path p, tree_label op);
 void notify_insert_node (typesetter ttt, path p, tree t);
 void notify_remove_node (typesetter ttt, path p);
 void exec_until (typesetter ttt, path p);
+box  typeset (typesetter ttt);
 box  typeset (typesetter ttt, SI& x1, SI& y1, SI& x2, SI& y2);
 
 box        typeset_as_concat (edit_env env, tree t, path ip);


### PR DESCRIPTION
## Summary
Fixes #2843 — Hyperlinks become invalid and unclickable after exporting a slideshow/beamer presentation to PDF.

<img width="1180" height="815" alt="image" src="https://github.com/user-attachments/assets/08e7a6fc-6b57-4427-aca2-1f8197d3f7b6" />


## Root Cause
When exporting a beamer presentation to PDF, `typeset_as_document()` creates a typesetter, typesets the document (registering link/ID observers in global tables like `id_resolve` and `vertex_occurrences`), then **immediately destroys** the typesetter — which unregisters all link observers.

During the rendering loop that follows, `display_links()` queries these global link tables. But the tables are now empty because the typesetter was already destroyed, so `ren->href()` is never called and **no PDF link annotations are generated**.

For regular documents this isn't a problem because the screen-display typesetter keeps its link registrations alive. But for beamer export, a temporary buffer copy is used with no prior typesetting history — hence the broken hyperlinks.

## Fix
- Inlined `typeset_as_document()` in `print_doc()` and **deferred `delete_typesetter()`** until after the rendering loop completes, keeping link registrations alive during PDF generation.
- Added a free-function `typeset(typesetter)` wrapper in `typesetter.hpp`/`typesetter.cpp` for use outside the editor class hierarchy.

## Files Changed
| File | Change |
|------|--------|
| `src/Edit/Editor/edit_main.cpp` | Inline typesetter lifecycle in `print_doc`, defer destruction |
| `src/Typeset/typesetter.hpp` | Add `typeset()` free function declaration |
| `src/Typeset/Bridge/typesetter.cpp` | Add `typeset()` free function implementation |
| `devel/212_2.md` | Development documentation |
| `TeXmacs/tests/tmu/212_2_beamer_hlink.tmu` | Test beamer file with hyperlinks |

## How to Test
1. Open `TeXmacs/tests/tmu/212_2_beamer_hlink.tmu`
2. Export as PDF via **File → Export → Pdf...**
3. Open the exported PDF and verify all 3 hyperlinks are clickable