### PR TITLE
[201_2769] Add accessible property to bibliography drd-props 

### DIFF
--- a/TeXmacs/packages/section/section-base.ts
+++ b/TeXmacs/packages/section/section-base.ts
@@ -318,9 +318,9 @@
     <render-bibliography|<localize|<arg|name>>|<arg|body>>
   </macro>>
 
-  <drd-props|bibliography|arity|4|identifier|0|string|1|url|2>
+  <drd-props|bibliography|arity|4|accessible|3|identifier|0|string|1|url|2>
 
-  <drd-props|bibliography*|arity|5|identifier|0|string|1|url|2>
+  <drd-props|bibliography*|arity|5|accessible|4|identifier|0|string|1|url|2>
 
   <assign|thebibliography|<\macro|largest|body>
     <render-bibliography|<bibliography-text>|<bib-list|<arg|largest>|<arg|body>>>

--- a/devel/201_2769.md
+++ b/devel/201_2769.md
@@ -1,0 +1,13 @@
+# 201_2769 Fix: Cannot enter bibliography with right arrow key
+
+## 2026/02/24 Add accessible property to bibliography drd-props
+### What
+Added `accessible|3` to `bibliography` and `accessible|4` to `bibliography*` in `drd-props` definitions in `TeXmacs/packages/section/section-base.ts`.
+
+### Why
+The `bibliography` tag has 4 arguments (aux, style, file-name, body) with the last one being the body containing the actual bibliography entries. Without the `accessible` property, the body argument was not navigable via arrow keys, preventing users from entering the bibliography content using the right arrow key.
+
+Similarly, `bibliography*` has 5 arguments (aux, style, file-name, name, body) where arg 4 is the body.
+
+### How
+Following the same pattern used by other tags in the codebase (e.g., `mini-paragraph`, `extend`, `arrow-with-text`), we mark the body argument index as accessible in the `drd-props` declaration.


### PR DESCRIPTION
Fixes #2769

## What
Added `accessible|3` to `bibliography` and `accessible|4` to `bibliography*` 
in their `drd-props` definitions in `TeXmacs/packages/section/section-base.ts`

## Why
Users cannot navigate into the bibliography body using the right arrow key

In TeXmacs, the `accessible` property in `drd-props` controls whether cursor 
navigation via arrow keys can enter a tag's child argument. The `bibliography` 
tag's body is at argument index 3, and `bibliography*`'s body is at index 4 — 
neither had the `accessible` property set, so the cursor would skip over them entirely.

## How
Following the same pattern used by other tags in the codebase (e.g., `mini-paragraph` 
with `accessible|1`, `arrow-with-text` with `accessible|2`), so I added the `accessible`
property pointing to the body argument index in each tag's `drd-props` declaration.
