### PR TITLE
[201_85]: Prevent matrix/det from being resized by mouse drag

### DIFF
--- a/devel/201_85.md
+++ b/devel/201_85.md
@@ -1,0 +1,21 @@
+# [201_85] Matrices and determinants should not be resizable by mouse drag
+
+## How to Test
+1. Insert a matrix (`Insert` -> `Table` -> `Matrix`) and click inside it
+2. Verify that no resize handles appear around the matrix
+3. Hover over the internal grid lines of the matrix — the cursor should remain normal (no resize cursor)
+4. Try dragging a grid line inside the matrix — it should not resize
+5. Repeat the above for `det`, `bmatrix`, `Bmatrix`, `choice`, and `stack`
+6. Insert a normal table (`Insert` -> `Table` -> `Plain tabular`) — resize handles and line dragging should still work as before
+
+## Issue
+#2783 — Matrices and determinants can be resized by dragging the mouse, which should not be allowed.
+
+## 2026/2/25
+### What
+The table resizing feature (drag grid lines, scale handles) was incorrectly applying to mathematical table environments like `matrix`, `det`, `bmatrix`, `Bmatrix`, `choice`, and `stack`. These are mathematical constructs where resizing by mouse drag is not meaningful.
+
+### How
+1. In `edit_interface.cpp`, added `matrix`, `matrix*`, `bmatrix`, `Bmatrix`, `det`, `choice`, and `stack` to the `is_true_table` exclusion list. This prevents scale resize handles from appearing on these math table types (the handle drawing code already checks `is_true_table`).
+2. In `edit_mouse.cpp` `table_line_start`, added an `is_true_table` guard so that internal grid line dragging is blocked for math tables.
+3. In `edit_mouse.cpp` `mouse_any`, added an `is_true_table` check before setting the `hovering_table` cursor style, so the resize cursor (↔/↕) no longer appears when hovering over matrix/det grid lines.

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -1193,7 +1193,11 @@ edit_interface_rep::is_true_table (path p) {
         is_compound (qt, "gather") || is_compound (qt, "gather*") ||
         is_compound (qt, "multline") || is_compound (qt, "multline*") ||
         is_compound (qt, "alignat") || is_compound (qt, "alignat*") ||
-        is_compound (qt, "flalign") || is_compound (qt, "flalign*"))
+        is_compound (qt, "flalign") || is_compound (qt, "flalign*") ||
+        is_compound (qt, "matrix") || is_compound (qt, "matrix*") ||
+        is_compound (qt, "bmatrix") || is_compound (qt, "Bmatrix") ||
+        is_compound (qt, "det") || is_compound (qt, "choice") ||
+        is_compound (qt, "stack"))
       return false;
   }
   return true;

--- a/src/Edit/Interface/edit_mouse.cpp
+++ b/src/Edit/Interface/edit_mouse.cpp
@@ -585,6 +585,7 @@ edit_interface_rep::table_line_start (const table_hit& hit, SI x, SI y) {
 
   path fp= ::table_search_format (et, tp);
   if (is_nil (fp)) return;
+  if (!is_true_table (fp)) return;
 
   table_resizing_type   = 1;
   table_line_vertical   = hit.orient == "col";
@@ -825,10 +826,18 @@ edit_interface_rep::mouse_any (string type, SI x, SI y, int mods, time_t t,
     rectangles rs;
     tree       r= eb->message (tree ("table-loc?"), x, y, rs);
     if (is_func (r, TUPLE) && r[0] == "table-loc") {
-      string orient= as_string (r[1]);
-      if (orient == "cell") hovering_table= -1;
-      else if (orient == "row") hovering_table= 1;
-      else if (orient == "col") hovering_table= 2;
+      // Check if the table is a "true table" (not matrix/det/etc.)
+      path hover_tp= tree_path (find_innermost_scroll (eb, tp), x, y, 0);
+      while (!is_nil (hover_tp) && !has_subtree (et, hover_tp))
+        hover_tp= path_up (hover_tp);
+      path hover_fp=
+          is_nil (hover_tp) ? path () : ::table_search_format (et, hover_tp);
+      if (!is_nil (hover_fp) && is_true_table (hover_fp)) {
+        string orient= as_string (r[1]);
+        if (orient == "cell") hovering_table= -1;
+        else if (orient == "row") hovering_table= 1;
+        else if (orient == "col") hovering_table= 2;
+      }
     }
   }
   bool hovering_hlink= false;


### PR DESCRIPTION
Fixes #2783

## Problem
Matrices and determinants (and other math table environments) could be resized by dragging the mouse — both via internal grid line dragging and scale handles. This behavior is incorrect since these are mathematical constructs, not regular tables.

## Changes
- **`src/Edit/Interface/edit_interface.cpp`**: Added `matrix`, `matrix*`, `bmatrix`, `Bmatrix`, `det`, `choice`, and `stack` to the `is_true_table` exclusion list, preventing scale resize handles from appearing.
- **`src/Edit/Interface/edit_mouse.cpp`**: 
  - Added `is_true_table` guard in `table_line_start` to block grid line dragging for math tables.
  - Added `is_true_table` check in `mouse_any` hover logic so the resize cursor no longer appears on math table grid lines.
- **`devel/201_85.md`**: Developer document for this task.

## How to Test
1. Insert a matrix (`Insert` -> `Table` -> `Matrix`) and click inside it
2. Verify that no resize handles appear around the matrix
3. Hover over the internal grid lines — cursor should remain normal
4. Try dragging a grid line — it should not resize
5. Repeat for `det`, `bmatrix`, `Bmatrix`, `choice`, and `stack`
6. Insert a normal table (`Insert` -> `Table` -> `Plain tabular`) — resize handles and line dragging should still work as before