### PR TITLE
[201_85] Fix : LaTeX formula imports using aligned to show correct numbering format

### DIFF
--- a/TeXmacs/packages/environment/env-math.ts
+++ b/TeXmacs/packages/environment/env-math.ts
@@ -149,7 +149,7 @@
   </macro>>
 
   <assign|aligned*|<\macro|body>
-    <align*|<tformat|<arg|body>>>
+    <tformat|<twith|table-min-cols|2>|<twith|table-max-cols|2>|<cwith|1|-1|1|1|cell-lsep|0spc>|<cwith|1|-1|1|1|cell-rsep|0.5spc>|<cwith|1|-1|-1|-1|cell-rsep|0spc>|<cwith|1|-1|-1|-1|cell-lsep|0spc>|<cwith|1|-1|1|-1|cell-bsep|0.1fn>|<cwith|1|-1|1|-1|cell-tsep|0.1fn>|<cwith|1|-1|1|1|cell-halign|r>|<cwith|1|-1|-1|-1|cell-halign|l>|<cwith|1|-1|1|-1|cell-block|no>|<arg|body>>
   </macro>>
 
   <assign|aligned|<\macro|body>
@@ -157,11 +157,11 @@
   </macro>>
 
   <assign|alignedat*|<\macro|ncol|body>
-    <align*|<tformat|<arg|body>>>
+    <aligned*|<tformat|<arg|body>>>
   </macro>>
 
   <assign|alignedat|<\macro|ncol|body>
-    <align|<tformat|<arg|body>>>
+    <aligned*|<tformat|<arg|body>>>
   </macro>>
 
   <assign|flalign*|<\macro|body>

--- a/devel/201_87.md
+++ b/devel/201_87.md
@@ -1,0 +1,9 @@
+#[201_87] Fix LaTeX formula imports using "aligned" to show correct numbering format
+## 2026/02/25 Fix equation numbering alignment in `aligned` environment
+### What
+Redefined `aligned*`, `alignedat*`, and `alignedat` in `env-math.ts` to produce inline `tformat` tables instead of delegating to `align*`/`align`.
+### Why
+Issue #2804 : when using `aligned` inside `equation`, the equation number (1) appeared below the multi-line expression instead of vertically centered to the right. The root cause was that `aligned*` was aliased to `align*`.
+This caused the equation number to be appended sequentially after the block rather than inline beside it.
+### How
+Changed the body of `aligned*` from `<align*|<tformat|<arg|body>>>` to a inline `tformat` with explicit settings. This makes `aligned` behave as an inline math construct with natural width and no block wrapping, so the equation number is placed correctly to the right.


### PR DESCRIPTION
fixes #2804 
---
[201_87] : Fix LaTeX formula imports using "aligned" to show correct numbering format

## 2026/02/25 Fix equation numbering alignment in `aligned` environment

### What
Redefined `aligned*`, `alignedat*`, and `alignedat` in `env-math.ts` to produce inline `tformat` tables instead of delegating to `align*`/`align`.

### Why
Issue #2804 : when using `aligned` inside `equation`, the "equation number" appeared below the multi-line expression instead of vertically centered to the right. The root cause was that `aligned*` was aliased to `align*`.
This caused the equation number to be appended sequentially after the block rather than inline beside it.

### How
Changed the body of `aligned*` from `<align*|<tformat|<arg|body>>>` to a inline `tformat` with explicit settings. This makes `aligned` behave as an inline math construct with natural width and no block wrapping, so the equation number is placed correctly to the right.

### Screenshots
before
<img width="900" height="297" alt="image" src="https://github.com/user-attachments/assets/ccaab053-1a4a-4096-b956-c12e805f184e" />
after
<img width="1484" height="703" alt="image" src="https://github.com/user-attachments/assets/6fa6d43a-4779-48b8-a4aa-4c97c2347c1f" />
 