### PR TITLE
[202_2723]: Add toolbar entries for overbrace, underbrace and underline

### DIFF
--- a/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_bar.xpm
+++ b/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_bar.xpm
@@ -1,0 +1,31 @@
+/* XPM */
+static char *magick[] = {
+/* columns rows colors chars-per-pixel */
+"15 17 8 1",
+"  c None",
+"Y c #686c68",
+". c #0000f8",
+"X c #383cf8",
+"o c #787cb8",
+"O c #787cf8",
+"+ c #a8aca8",
+"@ c #b8bcb8",
+/* pixels */
+"               ",
+"               ",
+"      @X       ",
+"     XoXOO     ",
+"     oX.X@     ",
+"     X...O     ",
+"     O@X@o     ",
+"      @O       ",
+"               ",
+"               ",
+"   YYYYYYYY+   ",
+"   YYYYYYYY+   ",
+"               ",
+"               ",
+"               ",
+"               ",
+"               "
+};

--- a/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_overbrace.xpm
+++ b/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_overbrace.xpm
@@ -1,0 +1,31 @@
+/* XPM */
+static char *magick[] = {
+/* columns rows colors chars-per-pixel */
+"15 17 8 1",
+"  c None",
+"Y c #686c68",
+". c #0000f8",
+"X c #383cf8",
+"o c #787cb8",
+"O c #787cf8",
+"+ c #a8aca8",
+"@ c #b8bcb8",
+/* pixels */
+"               ",
+"               ",
+"      +++      ",
+"     +YYY+     ",
+"     Y+ +Y     ",
+"    YY   YY    ",
+"    Y     Y    ",
+"               ",
+"               ",
+"      @X       ",
+"     XoXOO     ",
+"     oX.X@     ",
+"     X...O     ",
+"     O@X@o     ",
+"      @O       ",
+"               ",
+"               "
+};

--- a/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_underbrace.xpm
+++ b/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_underbrace.xpm
@@ -1,0 +1,31 @@
+/* XPM */
+static char *magick[] = {
+/* columns rows colors chars-per-pixel */
+"15 17 8 1",
+"  c None",
+"Y c #686c68",
+". c #0000f8",
+"X c #383cf8",
+"o c #787cb8",
+"O c #787cf8",
+"+ c #a8aca8",
+"@ c #b8bcb8",
+/* pixels */
+"               ",
+"               ",
+"      @X       ",
+"     XoXOO     ",
+"     oX.X@     ",
+"     X...O     ",
+"     O@X@o     ",
+"      @O       ",
+"               ",
+"    Y     Y    ",
+"    YY   YY    ",
+"     Y+ +Y     ",
+"     +YYY+     ",
+"      +++      ",
+"               ",
+"               ",
+"               "
+};

--- a/TeXmacs/progs/math/math-menu.scm
+++ b/TeXmacs/progs/math/math-menu.scm
@@ -1257,7 +1257,10 @@
             ((balloon (icon "tm_dot.xpm") "keyboard equivalent:") (make-wide "<dot>"))
             ((balloon (icon "tm_ddot.xpm") "keyboard equivalent:") (make-wide "<ddot>"))
             ((balloon (icon "tm_acute.xpm") "keyboard equivalent:") (make-wide "<acute>"))
-            ((balloon (icon "tm_grave.xpm") "keyboard equivalent:") (make-wide "<grave>"))))
+            ((balloon (icon "tm_grave.xpm") "keyboard equivalent:") (make-wide "<grave>"))
+            ((balloon (icon "tm_wide_overbrace.xpm") "keyboard equivalent:") (make-wide "<wide-overbrace>"))
+            ((balloon (icon "tm_wide_underbrace.xpm") "keyboard equivalent:") (make-wide-under "<wide-underbrace>"))
+            ((balloon (icon "tm_wide_bar.xpm") "keyboard equivalent:") (make-wide-under "<wide-bar>"))))
   /
   (=> (balloon (icon "tm_binop.xpm") "Insert a binary operation")
       (tile 8 (link binary-operation-menu)))

--- a/devel/202_2723.md
+++ b/devel/202_2723.md
@@ -1,0 +1,32 @@
+# [202_2723] Add toolbar entries for \overbrace, \underbrace, \underline
+
+## Issue
+
+#2723 — The math mode toolbar's wide accent popup is missing entries for
+`\overbrace`, `\underbrace`, and `\underline`, even though they are available
+in the Insert menu.
+
+## Fix
+
+Added 3 entries to the wide accent popup in `math-insert-icons`
+(`TeXmacs/progs/math/math-menu.scm`), following the same pattern as the
+existing accent buttons.
+
+Also added 3 new XPM icons in `TeXmacs/misc/pixmaps/modern/16x16/focus/`:
+- `tm_wide_overbrace.xpm`
+- `tm_wide_underbrace.xpm`
+- `tm_wide_bar.xpm`
+
+## Changed Files
+
+- `TeXmacs/progs/math/math-menu.scm`
+- `TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_overbrace.xpm`
+- `TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_underbrace.xpm`
+- `TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_bar.xpm`
+
+## How to Test
+
+1. Build with `xmake build stem` and run with `xmake run stem`
+2. Enter math mode with `$`
+3. Open the wide accent popup in the toolbar
+4. Verify `\overbrace`, `\underbrace`, and `\underline` now appear and insert correctly


### PR DESCRIPTION
Fixes #2723

## What
Added 3 missing entries to the wide accent toolbar popup in math mode:
- `\overbrace` (`make-wide`)
- `\underbrace` (`make-wide-under`)
- `\underline` / wide-bar (`make-wide-under`)

Also added the corresponding 16x16 XPM icons using the same 8-color palette
as the existing accent icons (e.g. [tm_bar.xpm](cci:7://file:///Users/rajesh/Desktop/mogan1st/mogan/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_bar.xpm:0:0-0:0)).

## Changed Files
- [TeXmacs/progs/math/math-menu.scm](cci:7://file:///Users/rajesh/Desktop/mogan1st/mogan/TeXmacs/progs/math/math-menu.scm:0:0-0:0) — 3 new entries in the wide accent popup
- [TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_overbrace.xpm](cci:7://file:///Users/rajesh/Desktop/mogan1st/mogan/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_overbrace.xpm:0:0-0:0) — new icon
- [TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_underbrace.xpm](cci:7://file:///Users/rajesh/Desktop/mogan1st/mogan/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_underbrace.xpm:0:0-0:0) — new icon
- [TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_bar.xpm](cci:7://file:///Users/rajesh/Desktop/mogan1st/mogan/TeXmacs/misc/pixmaps/modern/16x16/focus/tm_wide_bar.xpm:0:0-0:0) — new icon
- [devel/202_2723.md](cci:7://file:///Users/rajesh/Desktop/mogan1st/mogan/devel/202_2723.md:0:0-0:0) — dev doc

## Known Issue
I used the EXACT SAME COLOR PALETTE  and `a` pixel art   as the existing icons for the 3 new XPM icons ,

 but they render slightly differently at small sizes
(the `a` appears as a blue dot instead of a clear letter). 

I wasn't able to figure out why ...  the pixel data is byte-for-byte identical to the
working icons. Happy to take suggestions on improving the icons.

## Testing
- Built with `xmake build stem`, ran with `xmake run stem`
- Entered math mode, opened the wide accent popup
- Verified all 3 new entries appear and insert the correct constructs

<img width="882" height="533" alt="fine" src="https://github.com/user-attachments/assets/2bbdfa91-72c6-4195-862b-f9bfcd65d12b" />
