### PR TITLE
[206_19]: Fix Latin Modern Math cannot input "h" in math mode

### DIFF
--- a/devel/206_19.md
+++ b/devel/206_19.md
@@ -1,0 +1,22 @@
+# 206_19 修复 Latin Modern Math 字体在数学模式下无法输入 "h" 的问题
+
+## 如何测试
+1. 将数学模式字体设置为 Latin Modern Math
+2. 进入数学模式，输入字母 "h"
+3. 确认 "h" 能正常显示为数学斜体 h（U+210E）
+
+## 2026/02/26 修复数学斜体 h 的 Unicode 映射
+### What
+当数学模式字体为 Latin Modern Math 等 OpenType Math 字体时，输入字母 "h" 无法显示。
+
+### Why
+在 `smart_font_rep::advance()` 中，小写字母通过偏移量映射到 Unicode Mathematical Italic 区段：
+```
+0x1D44E + (s[0] - 'a')
+```
+对于 'h'，计算结果为 U+1D455。但 Unicode 标准中 **U+1D455 是未分配的码位**——数学斜体小写 h 的正确码位是 **U+210E**（PLANCK CONSTANT），位于 Letterlike Symbols 区块。因此 Latin Modern Math 字体在 U+1D455 处无字形，导致 "h" 无法显示。
+
+### How
+- 在 `smart_font_rep::advance()` 中为 'h' 添加特殊映射，将其映射到 U+210E 而非 U+1D455
+- 在 `init_unicode_substitution()` 中添加 U+210E → 'h' 的反向映射，确保双向映射一致
+- 修改文件：`src/Graphics/Fonts/smart_font.cpp`

--- a/src/Graphics/Fonts/smart_font.cpp
+++ b/src/Graphics/Fonts/smart_font.cpp
@@ -257,6 +257,7 @@ init_unicode_substitution () {
   unicode_subst (0x2111, 0x4a, 1, "frak");
   unicode_subst (0x211c, 0x52, 1, "frak");
   unicode_subst (0x2128, 0x5a, 1, "frak");
+  unicode_subst (0x210e, 0x68, 1, "italic-math"); // U+210E PLANCK CONSTANT
   unicode_subst (0x2102, 0x43, 1, "bbb");
   unicode_subst (0x210d, 0x48, 1, "bbb");
   unicode_subst (0x2115, 0x4e, 1, "bbb");
@@ -784,7 +785,9 @@ smart_font_rep::advance (string s, int& pos, string& r, int& nr) {
     nr = 0;
     pos= pos + 1;
     if (is_locase (s[0])) {
-      r= "<#" * to_Hex (0x1d44e + (int) (s[0] - 'a')) * ">";
+      if (s[0] == 'h')
+        r= "<#210E>"; // U+210E PLANCK CONSTANT (math italic small h)
+      else r= "<#" * to_Hex (0x1d44e + (int) (s[0] - 'a')) * ">";
     }
     else if (is_upcase (s[0])) {
       r= "<#" * to_Hex (0x1d434 + (int) (s[0] - 'A')) * ">";


### PR DESCRIPTION
Fixes #2742

## Problem
When the math mode font is set to Latin Modern Math, typing "h" in math mode produces no output.

## Root Cause
In `smart_font_rep::advance()`, lowercase letters are mapped to Unicode Mathematical Italic codepoints via a simple offset: `0x1D44E + (s[0] - 'a')`. For 'h', this computes U+1D455 — but U+1D455 is intentionally **unassigned** in the Unicode standard. The correct math italic small h is at **U+210E** (PLANCK CONSTANT) in the Letterlike Symbols block. Since Latin Modern Math (and all conforming OpenType Math fonts) has no glyph at U+1D455, the character fails to render.

## Fix
- Add a special case in `smart_font_rep::advance()` to map 'h' → U+210E instead of the unassigned U+1D455
- Add the corresponding reverse mapping `U+210E → 'h'` in `init_unicode_substitution()` for consistency

## How to Test
1. Set the math mode font to Latin Modern Math
2. Enter math mode and type "h"
3. Confirm "h" displays correctly as math italic h

Developer document: `devel/206_19.md`