### PR TITLE
[2815]: Fix ugly scrollbar in shortcut key editor input box

### DIFF
--- a/TeXmacs/progs/source/shortcut-widgets.scm
+++ b/TeXmacs/progs/source/shortcut-widgets.scm
@@ -52,7 +52,7 @@
       (vertical
         (aligned
           (item (text "Shortcut")
-            (resize "350px" "30px"
+            (resize "350px" "60px"
               (texmacs-input `(document (preview-shortcut ,(global-ref u :sh)))
                              `(style (tuple "generic" "shortcut-editor")) u)))
           (item (text "Command")
@@ -89,7 +89,7 @@
     (vertical
       (aligned
         (item (text "Shortcut")
-          (resize "250px" "30px"
+          (resize "250px" "60px"
             (texmacs-input `(document (preview-shortcut ,(global-ref u :sh)))
                            `(style (tuple "generic" "shortcut-editor")) u)))
         (item (text "Command")


### PR DESCRIPTION
Fixes #2815

The shortcut input field was limited to 30px height, which made its internal scrollbar take up too much visible space and look awkward.

i  increased the height to 60px so the field feels cleaner and more usable, while keeping the existing behavior intact.

Updated in shortcut-widgets.scm for both dialog and side panel modes.