### PR TITLE
[202_106]: Fix duplicate names in table variant dropdown

### DIFF
--- a/TeXmacs/progs/generic/generic-test.scm
+++ b/TeXmacs/progs/generic/generic-test.scm
@@ -11,7 +11,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (texmacs-module (generic generic-test)
-  (:use (generic generic-menu) ))
+  (:use (generic generic-menu)
+        (table table-menu) ))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; generic menu functions
@@ -23,6 +24,11 @@
    focus-tag-name :none
    (test "bmatrix" 'bmatrix "bmatrix")
    (test "Bmatrix" 'Bmatrix "Bmatrix")
+   (test "tabular" 'tabular "tabular")
+   (test "tabular*" 'tabular* "centered tabular")
+   (test "block" 'block "block")
+   (test "block*" 'block* "centered block")
+   (test "big-table" 'big-table "big table")
   ))
 
 (tm-define (regtest-generic)

--- a/TeXmacs/progs/table/table-menu.scm
+++ b/TeXmacs/progs/table/table-menu.scm
@@ -553,13 +553,30 @@
 	---
 	("Table properties" (open-table-properties)))))
 
-(tm-define (focus-tag-name l)
-  (:require (== l 'tabular*))
-  "centered tabular")
+(define (table-inline-variant-context? t)
+  (tree-in? t '(tabular tabular* wide-tabular block block* wide-block)))
+
+(define (table-inline-variants)
+  (if (in-math?)
+      '(tabular tabular* block block*)
+      '(tabular tabular* wide-tabular block block* wide-block)))
+
+(tm-define (focus-variants-of t)
+  (:require (table-inline-variant-context? t))
+  (table-inline-variants))
+
+(tm-define (variant-circulate t forward?)
+  (:require (table-inline-variant-context? t))
+  (variant-circulate-in t (table-inline-variants) forward?))
+
+(tm-define (variant-set-keep-numbering t v)
+  (:require (table-inline-variant-context? t))
+  (variant-set t v))
 
 (tm-define (focus-tag-name l)
-  (:require (== l 'block*))
-  "centered block")
+  (cond ((== l 'tabular*) "centered tabular")
+        ((== l 'block*) "centered block")
+        (else (former l))))
 
 (define (cell-halign-icon)
   (with h (cell-get-format "cell-halign")

--- a/devel/202_106.md
+++ b/devel/202_106.md
@@ -5,12 +5,13 @@
 2. Insert a table using `Alt+t`
 3. Click the "tabular" dropdown on the focus toolbar
 4. Verify all 6 variants have distinct names:
-   - 小表格 (small table)
-   - 大表格 (big table)
    - 无框表格 (tabular)
    - 居中无框表格 (centered tabular)
+   - 标宽无框表格 (wide tabular)
    - 有框表格 (block)
    - 居中有框表格 (centered block)
+   - 标宽有框表格 (wide block)
+5. Press `Alt/Option + Shift + v` repeatedly inside a table and verify cycling no longer lands on `big table`.
 
 ## 2026/02/27
 ### What
@@ -20,5 +21,19 @@ Added `focus-tag-name` overrides for `tabular*` and `block*` in `TeXmacs/progs/t
 The `focus-tag-name` function strips the `*` suffix from `tabular*` and `block*` (treating them as unnumbered variants of `tabular` and `block`), causing both pairs to display the same name in the table variant dropdown. This results in two duplicate entries: "无框表格" appears twice and "有框表格" appears twice.
 
 The fix adds explicit `focus-tag-name` dispatches for these two tags, using translation keys ("centered tabular" / "centered block") that already exist in all language dictionaries.
+
+## 2026/03/04
+### What
+- Restricted table variant dropdown / cycling to inline table variants:
+  - `tabular`, `tabular*`, `wide-tabular`, `block`, `block*`, `wide-block`
+- Added table-specific `variant-set-keep-numbering` behavior to avoid numbered/unnumbered star propagation on table variants.
+- Extended `TeXmacs/progs/generic/generic-test.scm` with regression tests for:
+  - `tabular* -> centered tabular`
+  - `block* -> centered block`
+  - fallback names such as `big-table -> big table`
+
+### Why
+- Similar-environment cycling from a tabular could reach `big-table`, which has incompatible structure for direct node relabeling and could produce a stuck state with `?` placeholders.
+- Table stars (`tabular*`, `block*`) encode alignment, not numbering. Reusing generic numbering-preserving variant logic is incorrect for table-specific cycling.
 
 Fixes: https://github.com/XmacsLabs/mogan/issues/2782


### PR DESCRIPTION
Fixes https://github.com/XmacsLabs/mogan/issues/2782

## Problem
When clicking the table variant dropdown on the focus toolbar, "无框表格" and "有框表格" each appear twice because `focus-tag-name` strips the `*` suffix from `tabular*` and `block*`, making them display identically to `tabular` and `block`.

## Solution
Added `focus-tag-name` overrides for `tabular*` → "centered tabular" (居中无框表格) and `block*` → "centered block" (居中有框表格) in `TeXmacs/progs/table/table-menu.scm`. The translation keys already exist in all language dictionaries.

## How to test
1. Open Mogan, insert a table with `Alt+t`
2. Click the "tabular" dropdown on the focus toolbar
3. Verify all 6 variants now have distinct names