### PR TITLE
[222_70] compact toolbar and fix native menu bar empty strip (#2877)

### DIFF
--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -26,13 +26,13 @@ QMenuBar QWidget {
 }
 
 QMenuBar {
-  padding-top: 6px;
-  spacing: 8px;
+  padding-top: 2px;
+  spacing: 4px;
 }
 
 QMenuBar::item {
   background: transparent;
-  padding: 6px 12px;
+  padding: 3px 10px;
   border-radius: 4px;
 }
 
@@ -119,16 +119,31 @@ QToolBar {
   background: #2c2c2c;
   color: #ffffff;
   border-bottom: none;
-  spacing: 3px;
-  padding: 4px;
-  min-height: 36px !important;
-  max-height: 36px !important;
+  spacing: 1px;
+  padding: 1px;
+  min-height: 28px !important;
+  max-height: 28px !important;
+}
+
+QToolBar#focusToolBar,
+QToolBar#modeToolBar,
+QToolBar#mainToolBar,
+QToolBar#tabToolBar {
+  min-height: 28px !important;
+  max-height: 28px !important;
+  padding: 2px;
+}
+
+QToolBar#menuToolBar {
+  min-height: 28px !important;
+  max-height: 28px !important;
+  padding: 0px;
 }
 
 QToolButton {
-  border-radius: 8px;
-  padding: 4px;
-  margin: 2px;
+  border-radius: 6px;
+  padding: 2px;
+  margin: 1px;
   background-color: transparent;
   border: 1px solid transparent;
   color: #ffffff;

--- a/TeXmacs/misc/themes/liii.css
+++ b/TeXmacs/misc/themes/liii.css
@@ -26,13 +26,13 @@ QMenuBar QWidget {
 }
 
 QMenuBar {
-  padding-top: 6px;
-  spacing: 8px;
+  padding-top: 2px;
+  spacing: 4px;
 }
 
 QMenuBar::item {
   background: transparent;
-  padding: 6px 12px;
+  padding: 3px 10px;
   border-radius: 4px;
 }
 
@@ -115,25 +115,31 @@ QToolBar {
   background: #f3f3f3;
   color: #2c2c2c;
   border-bottom: none;
-  spacing: 3px;
-  padding: 2px;
-  min-height: 36px !important;
-  max-height: 36px !important;
+  spacing: 1px;
+  padding: 1px;
+  min-height: 28px !important;
+  max-height: 28px !important;
 }
 
 QToolBar#focusToolBar,
 QToolBar#modeToolBar,
 QToolBar#mainToolBar,
 QToolBar#tabToolBar {
-  min-height: 36px !important;
-  max-height: 36px !important;
-  padding: 4px;
+  min-height: 28px !important;
+  max-height: 28px !important;
+  padding: 2px;
+}
+
+QToolBar#menuToolBar {
+  min-height: 28px !important;
+  max-height: 28px !important;
+  padding: 0px;
 }
 
 QToolButton {
-  border-radius: 8px;
-  padding: 4px;
-  margin: 2px;
+  border-radius: 6px;
+  padding: 2px;
+  margin: 1px;
   background-color: transparent;
   border: 1px solid transparent;
 }

--- a/devel/222_70.md
+++ b/devel/222_70.md
@@ -1,0 +1,43 @@
+# 222_45 Compact toolbar and native menu bar fix
+
+Issue #2877
+
+## Summary
+
+Reduce vertical height of the `liii` and `liii-night` toolbars for a more compact UI,
+fix the empty white strip left behind when `use_native_menubar` is enabled on macOS.
+
+## How to Test
+
+### Compact toolbar (liii / liii-night theme)
+
+- Build and launch Mogan with the default (`liii`) or `liii Dark` theme.
+- Verify the toolbar rows (main, mode, focus, tab) are visually more compact than before.
+- Verify the menu bar (File, Edit, etc.) is visible and items are readable.
+- Verify icon hover/press states still render correctly.
+
+### Native menu bar (macOS)
+
+- In Preferences -> User Interface, enable `use_native_menubar`.
+- Restart Mogan.
+- Verify the macOS system menu bar shows File, Edit, etc. correctly.
+- Verify no empty white strip appears where the in-window menu bar used to be.
+- Disable `use_native_menubar`, restart - verify the in-window menu bar returns.
+
+### Menu bar regression check (Linux / Windows)
+
+- Build and launch Mogan with the `liii` or `liii Dark` theme.
+- Verify the in-window menu bar remains visible when `use_native_menubar` is enabled.
+- Verify the menu bar height still renders correctly on scaled displays.
+
+## Files Changed
+
+- `TeXmacs/misc/themes/liii.css` - reduced toolbar `min/max-height` from 36 px to 28 px;
+  reduced `QToolButton` and `QMenuBar` padding to fit the new height.
+- `TeXmacs/misc/themes/liii-night.css` - same changes as `liii.css` for the dark theme.
+- `src/Plugins/Qt/qt_tm_widget.cpp`:
+  - Hide `menuToolBar` only for the macOS native menu bar path in
+    `update_visibility()` and `install_main_menu()`, removing the empty strip
+    without hiding the in-window menu bar on Linux or Windows.
+  - Use a smaller minimum-height fallback for styled non-native menus on macOS
+    instead of the non-macOS fixed-height workaround.

--- a/src/Plugins/Qt/qt_tm_widget.cpp
+++ b/src/Plugins/Qt/qt_tm_widget.cpp
@@ -910,6 +910,12 @@ void
 qt_tm_widget_rep::update_visibility () {
 #define XOR(exp1, exp2) (((!exp1) && (exp2)) || ((exp1) && (!exp2)))
 
+#ifdef Q_OS_MAC
+  bool use_native_menu_bar_in_window= use_native_menubar;
+#else
+  bool use_native_menu_bar_in_window= false;
+#endif
+
   bool old_mainVisibility  = mainToolBar->isVisible ();
   bool old_menuVisibility  = menuToolBar->isVisible ();
   bool old_modeVisibility  = modeToolBar->isVisible ();
@@ -926,7 +932,7 @@ qt_tm_widget_rep::update_visibility () {
   bool old_titleVisibility = windowAgent->titleBar ()->isVisible ();
 
   bool new_mainVisibility  = visibility[1] && visibility[0];
-  bool new_menuVisibility  = visibility[0];
+  bool new_menuVisibility  = visibility[0] && !use_native_menu_bar_in_window;
   bool new_modeVisibility  = visibility[2] && visibility[0];
   bool new_focusVisibility = visibility[3] && visibility[0];
   bool new_userVisibility  = visibility[4] && visibility[0];
@@ -1333,12 +1339,19 @@ qt_tm_widget_rep::query (slot s, int type_id) {
 
 void
 qt_tm_widget_rep::install_main_menu () {
+#ifdef Q_OS_MAC
+  bool use_native_menu_bar_in_window= use_native_menubar;
+#else
+  bool use_native_menu_bar_in_window= false;
+#endif
+
   if (main_menu_widget == waiting_main_menu_widget) return;
   main_menu_widget    = waiting_main_menu_widget;
   QList<QAction*>* src= main_menu_widget->get_qactionlist ();
   if (!src) return;
-  QMenuBar* dest  = new QMenuBar ();
-  QScreen*  screen= QGuiApplication::primaryScreen ();
+  QMenuBar* dest= new QMenuBar ();
+#ifndef Q_OS_MAC
+  QScreen* screen= QGuiApplication::primaryScreen ();
 #ifdef Q_OS_WIN
   // 设置与 menuToolBar 匹配的固定高度
   // 使用 devicePixelRatio() 获取正确的屏幕缩放比
@@ -1352,10 +1365,17 @@ qt_tm_widget_rep::install_main_menu () {
   int    h    = (int) floor (108 * scale + 0.5);
 #endif
   dest->setFixedHeight (h);
+#endif
 
   if (tm_style_sheet == "") dest->setStyle (qtmstyle ());
   if (!use_native_menubar) {
     dest->setNativeMenuBar (false);
+#ifdef Q_OS_MAC
+    if (tm_style_sheet != "") {
+      int min_h= (int) floor (28 * retina_scale);
+      dest->setMinimumHeight (min_h);
+    }
+#endif
   }
 
   dest->clear ();
@@ -1382,7 +1402,7 @@ qt_tm_widget_rep::install_main_menu () {
     w->setParent (nullptr);
   }
   // 确保 menuToolBar 可见
-  if (!menuToolBar->isVisible ()) {
+  if (!use_native_menu_bar_in_window && !menuToolBar->isVisible ()) {
     menuToolBar->setVisible (true);
   }
 


### PR DESCRIPTION
Closes Issue #2877

## Summary

Two related UI improvements for the liii/liii-night themes on macOS:

1. **Compact toolbars** - reduce toolbar row height from 36 px to 28 px and tighten button padding, giving a denser, more native-feeling toolbar layout.
2. **Fix empty white strip with native menu bar** - when `use_native_menubar` is enabled, the `menuToolBar` container remained visible at full height even though its content moved to the system menu bar. The toolbar is now hidden in this case.

Also removes an incorrect `setFixedHeight(108 * devicePixelRatio)` on the `QMenuBar` widget, which was setting a physical-pixel value on a logical-pixel widget (resulting in a 216 px tall menu bar on Retina displays).

## Files Changed

- `TeXmacs/misc/themes/liii.css`
- `TeXmacs/misc/themes/liii-night.css`
- `src/Plugins/Qt/qt_tm_widget.cpp`

## How to Test

- Build and launch with the default (`liii`) theme; verify toolbar rows are more compact
- Enable `use_native_menubar` in Preferences -> User Interface; verify no empty strip remains below the title bar
- Disable `use_native_menubar`; verify the in-window menu bar returns correctly

**OLD - `use_nativebar=True`**
<img width="1700" height="830" alt="CleanShot 2026-02-27 at 10 22 58@2x" src="https://github.com/user-attachments/assets/4a6d7185-e112-4368-ab43-36f46dc66342" />

**OLD - `use_nativebar=False`**
<img width="1756" height="750" alt="CleanShot 2026-02-27 at 10 23 57@2x" src="https://github.com/user-attachments/assets/29256160-e6ac-4629-8c91-088f343b8f47" />

**NEW**
<img width="1386" height="766" alt="Image" src="https://github.com/user-attachments/assets/c7e956f0-7edf-49ba-aa34-a4ad8632456c" />