### PR TITLE
[213_22] Replace focus cyan border with translucent background fill

### DIFF
--- a/devel/213_22.md
+++ b/devel/213_22.md
@@ -1,0 +1,10 @@
+# [213_22] Replace focus border with translucent background
+
+Issue: https://github.com/MoganLab/mogan/issues/2759
+
+Replace the cyan border (`#0ff`) used to indicate focused structures (tables, math formulas, etc.) with a translucent background fill, improving visual clarity and reducing distraction.
+
+## Changes
+- `src/Typeset/Env/env_default.cpp`: Changed `FOCUS_COLOR` from `#0ff` (opaque cyan, 4-digit) to `#00ffff1a` (translucent cyan, 9-digit with alpha)
+- `src/Edit/Interface/edit_interface.cpp`: In `compute_env_rects`, when generating `foc_rects` (non-recursive mode), use `thicken(sel->rs, 0, 2 * pixel)` instead of `outlines(sel->rs, pixel)` to produce filled rectangles rather than border outlines
+- `src/Edit/Interface/edit_repaint.cpp`: Use `draw_selection` instead of `draw_rectangles` for `foc_rects` rendering under Qt

--- a/src/Edit/Interface/edit_interface.cpp
+++ b/src/Edit/Interface/edit_interface.cpp
@@ -630,8 +630,10 @@ edit_interface_rep::compute_env_rects (path p, rectangles& rs, bool recurse) {
       else selection_correct (p1, p2, q1, q2);
       selection sel= eb->find_check_selection (q1, q2);
       if (N (focus_get ()) >= N (p))
-        if (!recurse || get_preference ("show full context") == "on")
-          rs << outlines (sel->rs, pixel);
+        if (!recurse || get_preference ("show full context") == "on") {
+          if (recurse) rs << outlines (sel->rs, pixel);
+          else rs << thicken (sel->rs, 0, 2 * pixel);
+        }
     }
     set_access_mode (old_mode);
     if (recurse || N (rs) == 0) compute_env_rects (path_up (p), rs, recurse);

--- a/src/Edit/Interface/edit_repaint.cpp
+++ b/src/Edit/Interface/edit_repaint.cpp
@@ -67,7 +67,11 @@ edit_interface_rep::draw_env (renderer ren) {
     if (!is_nil (foc_rects)) {
       color col= get_env_color (FOCUS_COLOR);
       ren->set_pencil (pencil (col, ren->pixel));
+#ifdef QTTEXMACS
+      ren->draw_selection (foc_rects);
+#else
       ren->draw_rectangles (foc_rects);
+#endif
     }
     if (!is_nil (sem_rects)) {
       if (sem_correct) {

--- a/src/Typeset/Env/env_default.cpp
+++ b/src/Typeset/Env/env_default.cpp
@@ -59,7 +59,7 @@ initialize_default_env () {
 
   env (CURSOR_COLOR)         = "#000000";   // cursor color in user interface
   env (MATH_CURSOR_COLOR)    = "#b0f";      // cursor color in math mode
-  env (FOCUS_COLOR)          = "#0ff";      // color of focus rectangles
+  env (FOCUS_COLOR)          = "#00ffff1a"; // color of focus background
   env (CONTEXT_COLOR)        = "#00555518"; // color of context rectangles
   env (SELECTION_COLOR)      = "#2d69f033"; // color of selections
   env (TABLE_SELECTION_COLOR)= "#50f3";   // color of selections of table cells


### PR DESCRIPTION
Fixes #2759

- Change FOCUS_COLOR from #0ff (opaque cyan) to #0ff1a (translucent cyan)
- Use draw_selection instead of draw_rectangles for foc_rects under Qt to render a semi-transparent background fill instead of a border