### PR TITLE
[213_23] Fix piecewise function LaTeX import with aligned environment

### DIFF
--- a/devel/213_23.md
+++ b/devel/213_23.md
@@ -1,0 +1,24 @@
+# [213_23] Fix piecewise function LaTeX import with aligned environment
+
+Issue: https://github.com/MoganLab/mogan/issues/2733
+
+When importing LaTeX code like `\left\{\begin{aligned}...\end{aligned}\right.`, the `aligned` environment inside `\left\{...\right.` was not recognized as a matrix-like environment, causing broken layout for piecewise functions.
+
+## How to Test
+1. Create a new document in Mogan
+2. Use `Insert → Session → LaTeX input` or paste the following LaTeX code via clipboard import:
+   ```tex
+   $f(x)=\left\{\begin{aligned}-x^{2}+1&\quad x\neq0\\ 0&\quad x=0\end{aligned}\right.$
+   ```
+3. Verify that the piecewise function is displayed as a properly formatted table with left brace delimiter, with each case on its own row
+4. Before this fix, the `aligned` environment was not recognized, resulting in broken layout with raw tokens
+
+## Root Cause
+The `aligned` environment was not handled in `finalize_pmatrix` or `parse_pmatrix`, so it was passed through as raw BEGIN/END tokens instead of being converted to a proper table structure.
+
+## Changes
+- `src/Plugins/Tex/fromtex_post.cpp`:
+  - Added `aligned` as a recognized environment in `finalize_pmatrix`, converting it to `tabular*` format (same as `array`)
+  - Added `END "aligned"` as a break condition in `parse_pmatrix`
+
+The `\left\{` and `\right.` delimiters are already handled by the existing LEFT/RIGHT processing, so the aligned content inside will now be properly laid out as a table within the braces.

--- a/src/Plugins/Tex/fromtex_post.cpp
+++ b/src/Plugins/Tex/fromtex_post.cpp
@@ -338,6 +338,7 @@ parse_pmatrix (tree& r, tree t, int& i, string lb, string rb, string fm) {
     else if (v == tree (END, "bmatrix")) break;
     else if (v == tree (END, "vmatrix")) break;
     else if (v == tree (END, "smallmatrix")) break;
+    else if (v == tree (END, "aligned")) break;
     else if (v == tree (APPLY, "hline")) {
       int howmany= 1;
       while (i + 1 < N (t) &&
@@ -446,6 +447,8 @@ finalize_pmatrix (tree t) {
                  u[i][0] == "tabularx" || u[i][0] == "tabularx*")
           parse_pmatrix (r, u, i, "", "", "tabular*");
         else if (u[i][0] == "cases") parse_pmatrix (r, u, i, "", "", "choice");
+        else if (u[i][0] == "aligned")
+          parse_pmatrix (r, u, i, "", "", "tabular*");
         else if (u[i][0] == "stack") parse_pmatrix (r, u, i, "", "", "stack");
         else if (u[i][0] == "matrix")
           parse_pmatrix (r, u, i, "", "", "tabular*");


### PR DESCRIPTION
Fixes #2733

- Add 'aligned' as a recognized environment in finalize_pmatrix
- Add END 'aligned' as a break condition in parse_pmatrix
- This allows \left\{\begin{aligned}...\end{aligned}\right. to be properly imported as a table structure with left brace delimiter