### PR TITLE
[201_86] Remove popups to improve UI when inserting Automatic Content

### DIFF
--- a/TeXmacs/progs/generic/document-edit.scm
+++ b/TeXmacs/progs/generic/document-edit.scm
@@ -582,10 +582,11 @@
   ("document update times" "3" notify-doc-update-times))
 
 (define (wait-update-current-buffer)
-  (system-wait "Updating current buffer, " "please wait")
+  (set-message "Updating current buffer ..." "please wait")
   (update-current-buffer))
 
 (tm-define (update-document what)
+  (set-cursor-style "wait")
   (for (.. 0 doc-update-times)       
     (delayed    ; allow typesetting/magic to happen before next update
       (:idle 1)
@@ -596,4 +597,5 @@
               (generate-all-aux) (wait-update-current-buffer))
              ((== what "buffer") 
               (wait-update-current-buffer))
-             (else (generate-aux what)))))))
+             (else (generate-aux what))))))
+  (delayed (:idle 1) (set-cursor-style "normal")))

--- a/TeXmacs/progs/text/text-menu.scm
+++ b/TeXmacs/progs/text/text-menu.scm
@@ -470,7 +470,7 @@
   ("Table of contents"
    (begin
      (make-aux "table-of-contents" "toc-prefix" "toc")
-     (update-document "table-of-contents")))
+     (update-document "all")))
   (assuming (get-boolean-preference "gui:new bibliography dialogue")
     ("Bibliography" (open-bibliography-inserter)))
   (assuming (not (get-boolean-preference "gui:new bibliography dialogue"))
@@ -481,21 +481,21 @@
   ("Index" 
     (begin 
       (make-aux "the-index" "index-prefix" "idx")
-      (update-document "the-index")))
+      (update-document "all")))
   ("Glossary" 
     (begin
       (make-aux "the-glossary" "glossary-prefix" "gly")
-      (update-document "the-glossary")))
+      (update-document "all")))
   ;;("List of figures" (make-aux* "the-glossary*" "figure-list-prefix" "figure" "List of figures"))
   ;;("List of tables" (make-aux* "the-glossary*" "table-list-prefix" "table" "List of tables"))
   ("List of figures" 
     (begin
       (make-aux "list-of-figures" "figure-list-prefix" "figure")
-      (update-document "list-of-figures")))
+      (update-document "all")))
   ("List of tables" 
     (begin
       (make-aux "list-of-tables" "table-list-prefix" "table")
-      (update-document "list-of-tables"))))
+      (update-document "all"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Text menus for inserting block content

--- a/devel/201_86.md
+++ b/devel/201_86.md
@@ -1,4 +1,4 @@
-# 201_86: Reduce popup/screen flashing when inserting Automatic content
+# 201_86: Remove popups causing screen flash when inserting Automatic content
 
 ### Issue #2814 :
 When using `Insert -> Automatic -> Table of contents / Index / Glossary / List of figures / List of tables`,
@@ -6,37 +6,27 @@ the editor shows repeated popup/wait dialogs and visible screen disturbance.
 
 ### How to Test
  Open any text document with section/index/glossary markers.
- Trigger each item via `Insert -> Automatic`:
+ Trigger any of this via `Insert -> Automatic`:
    - Table of contents
    - Index
    - Glossary
    - List of figures
    - List of tables
- Content is inserted and generated as before.
- No more popupo or screen flashing.
+  Content will be inserted just like before but without popup, Wait cursor appears during the update and resets after. (wait cursor may not be visible due to fast update)
+  Instead of popup now "Updating current buffer ..." message is shown in status bar.
 
 
 ### What Changed
-Changed update keys in `text-menu.scm`:
 
-```scheme
-;; BEFORE
-(update-document "all")
+#### `document-edit.scm`: `system-wait` → `set-message` + wait cursor
+- Replaced popup dialog with footer status bar message
+- Added `set-cursor-style "wait"/"normal"` around `update-document`
 
-;; AFTER (per item)
-(update-document "table-of-contents")
-(update-document "the-index")
-(update-document "the-glossary")
-(update-document "list-of-figures")
-(update-document "list-of-tables")
-```
-This keeps insertion behavior unchanged (`make-aux` still runs) while avoiding unnecessary full-update UI churn.
+#### `edit_process.cpp`: `system_wait` → `set_message`
+Replaced popup in `generate_bibliography`, `generate_index`, `generate_glossary`.
 
 
 ### Why
-In `text-menu.scm`, each automatic insertion path called:
-1. `make-aux ...` (insert placeholder)
-2. `update-document "all"` (full document update)
-
-`"all"` triggers heavier update flow and repeated delayed passes, so users saw extra popups/refresh noise.
-
+`system-wait` created popup overlays via `show_wait_indicator` in `qt_gui.cpp`. With 3 update passes
+(`doc-update-times=3`), this produced 3-12 popup flashes per operation. Replaced with `set-message`
+(footer bar) and `set-cursor-style "wait"` (spinning cursor) for non-intrusive feedback.

--- a/src/Edit/Process/edit_process.cpp
+++ b/src/Edit/Process/edit_process.cpp
@@ -113,7 +113,7 @@ edit_process_rep::generate_bibliography (string bib, string style,
                                          string fname) {
 #ifdef USE_PLUGIN_BIBTEX
   if (N (style) == 0) style= "tm-plain";
-  system_wait ("Generating bibliography, ", "please wait");
+  set_message ("Generating bibliography ... ", "please wait");
   if (DEBUG_AUTO)
     debug_automatic << "Generating bibliography"
                     << " [" << bib << ", " << style << ", " << fname << "]\n";
@@ -420,7 +420,7 @@ make_entry (tree& D, tree t, hashmap<string, tree> refs, bool rec) {
 
 void
 edit_process_rep::generate_index (string idx) {
-  system_wait ("Generating index, ", "please wait");
+  set_message ("Generating index ...", "please wait");
   if (DEBUG_AUTO) debug_automatic << "Generating index [" << idx << "]\n";
   tree                  I= copy (buf->data->aux[idx]);
   hashmap<string, tree> R= buf->data->ref;
@@ -467,7 +467,7 @@ edit_process_rep::generate_index (string idx) {
 
 void
 edit_process_rep::generate_glossary (string gly) {
-  system_wait ("Generating glossary, ", "please wait");
+  set_message ("Generating glossary ...", "please wait");
   if (DEBUG_AUTO) debug_automatic << "Generating glossary [" << gly << "]\n";
   tree G= copy (buf->data->aux[gly]);
   if (buf->prj != NULL) G= copy (buf->prj->data->aux[gly]);


### PR DESCRIPTION
## Issue :
On inserting Automatic Content Screen popups causing flash and bad ui, the editor shows repeated popup/wait dialogs and visible screen disturbance.
also issue #2814 
on debian:

https://github.com/user-attachments/assets/3b50d07d-7052-4776-81e8-d53fdc462abe



## How to Test
 Open any text document with section/index/glossary markers.
 Trigger any of this via `Insert -> Automatic`:
   - Table of contents
   - Index
   - Glossary
   - List of figures
   - List of tables
  Content will be inserted just like before but without popup, Wait cursor appears during the update and resets after. (wait cursor may not be visible due to fast update)
  Instead of popup now "Updating current buffer ..." message is shown in status bar.
 
##  What Changed

#### `document-edit.scm`: `system-wait` → `set-message` + wait cursor
- Replaced popup dialog with footer status bar message
- Added `set-cursor-style "wait"/"normal"` around `update-document`

#### `edit_process.cpp`: `system_wait` → `set_message`
Replaced popup in `generate_bibliography`, `generate_index`, `generate_glossary`.

  ## Screen-Rec 
(Cursor not visible due to my system settings) 

https://github.com/user-attachments/assets/cec29822-5ad8-4b50-a4aa-6257322bc2da

