### PR TITLE
[201_35] 修复在 frame、solution 等环境内的公式编号错位的问题

### DIFF
--- a/TeXmacs/tests/tmu/201_35.tmu
+++ b/TeXmacs/tests/tmu/201_35.tmu
@@ -1,8 +1,20 @@
-<TMU|<tuple|1.1.0|2025.2.2>>
+<TMU|<tuple|1.1.0|2026.2.0>>
 
 <style|<tuple|generic|number-europe|smart-ref>>
 
 <\body>
+  <\frame>
+    <\equation>
+      A x=B<label|eq1>
+    </equation>
+
+    <\equation>
+      x=A<rsup|-1>B<label|eq2>
+    </equation>
+  </frame>
+
+  \;
+
   <\align>
     <tformat|<table|<row|<cell|f<around*|(|x|)>\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>><label|l1a><eq-number><label|l1b>>>|<row|<cell|\<leq\>>|<cell|<around*|\<\|\|\>|g<around*|(|x|)>-z<around*|(|x|)>|\<\|\|\>>+<around*|\<\|\|\>|z<around*|(|x|)>-h<around*|(|x|)>|\<\|\|\>><label|l2a><eq-number><label|l2b><with|math-display|false|<with|math-display|true|>>>>>>
   </align>
@@ -17,16 +29,22 @@
     sin<around*|(|x|)>=cos<around*|(|<frac|\<pi\>|2>-x|)><label|l4>
   </equation>
 
+  \;
+
   <with|font-series|bold|reference>:
 
   <\itemize>
-    <item>in align, line1 label before eq-number: <reference|l1a>, label after eq-number: <reference|l1b>
+    <item>in frame, line1 label: <reference|eq1>, line2 label: <reference|eq2>
+  </itemize>
 
-    <item>in align, line2 label before eq-number: <reference|l2a>, label after eq-number: <reference|l2b>
+  <\itemize>
+    <item>in align, line3 label before eq-number: <reference|l1a>, label after eq-number: <reference|l1b>
 
-    <item>in equation, line3 label: <reference|l3>
+    <item>in align, line4 label before eq-number: <reference|l2a>, label after eq-number: <reference|l2b>
 
-    <item>in equation, line4 label: <reference|l4>
+    <item>in equation, line5 label: <reference|l3>
+
+    <item>in equation, line6 label: <reference|l4>
   </itemize>
 
   \;
@@ -34,13 +52,15 @@
   <with|font-series|bold|smart-ref>:
 
   <\itemize>
-    <item>in align line1 label before eq-number:<smart-ref|l1a>, label after eq-number: <smart-ref|l1b>
+    <item>in frame, line1 label: <smart-ref|eq1>, line2 label: <smart-ref|eq2>
 
-    <item>in align line2 label before eq-number:<smart-ref|l2a>, label after eq-number: <smart-ref|l2b>
+    <item>in align line3 label before eq-number:<smart-ref|l1a>, label after eq-number: <smart-ref|l1b>
 
-    <item>in equation, line3 label: <smart-ref|l3>
+    <item>in align line4 label before eq-number:<smart-ref|l2a>, label after eq-number: <smart-ref|l2b>
 
-    <item>in equation, line4 label: <smart-ref|l4>
+    <item>in equation, line5 label: <smart-ref|l3>
+
+    <item>in equation, line6 label: <smart-ref|l4>
   </itemize>
 
   \;
@@ -55,11 +75,13 @@
 
 <\references>
   <\collection>
-    <associate|l1a|<tuple|1|1>>
-    <associate|l1b|<tuple|1|1>>
-    <associate|l2a|<tuple|2|1>>
-    <associate|l2b|<tuple|2|1>>
-    <associate|l3|<tuple|3|1>>
-    <associate|l4|<tuple|4|?>>
+    <associate|eq1|<tuple|1|1>>
+    <associate|eq2|<tuple|2|1>>
+    <associate|l1a|<tuple|3|1>>
+    <associate|l1b|<tuple|3|1>>
+    <associate|l2a|<tuple|4|1>>
+    <associate|l2b|<tuple|4|1>>
+    <associate|l3|<tuple|5|1>>
+    <associate|l4|<tuple|6|1>>
   </collection>
 </references>

--- a/devel/201_35.md
+++ b/devel/201_35.md
@@ -3,10 +3,31 @@
 ## 如何测试
 打开 `TeXmacs\tests\tmu\201_35.tmu` ，查看 smart-ref 和 reference 的公式编号是否正确
 
-- line1 的 label 编号应该都是1
-- line2 的 label 编号应该都是2
+- line1 的 label 编号应该都是1（这一次修改的修复样例）
+- line2 的 label 编号应该都是2（这一次修改的修复样例）
 - line3 的 label 编号应该都是3
 - line4 的 label 编号应该都是4
+- line5 的 label 编号应该都是5
+- line6 的 label 编号应该都是6
+
+## 2026/2/28
+### What
+修复在 frame、solution 等环境内的公式编号错位的问题
+
+### Why
+之前的实现把 `defer-tags=row` 放在 `table_rep::typeset_row` 行入口处，导致**所有**走 table row 的场景都可能触发延迟绑定
+
+但 `defer-tags` 的设计初衷仅是服务多行公式（align/eqnarray/gather 等）中“`label` 先于 `eq-number`”的时序修正。像 frame、solution 这类外层环境内部也会进入 `typeset_row`，从而把本不该延迟重绑的 label 键加入 `the-tags`，最终在后续 `set-binding`（1参）时被错误覆盖，表现为编号错位
+
+### How
+将 `typeset_row` 中 `defer-tags/the-tags` 的行级作用域从“无条件开启”改为“仅在多行显示公式场景开启”：
+
+1. `hyphen == "y"`：仅处理可按行拆分的数学表格（多行公式结构信号）
+2. `mode == "math"`：仅在数学语义环境生效
+3. `math-display == "true"`：仅在陈列公式模式生效
+
+满足三条件时才 `local_begin ("defer-tags", "row")` 与 `local_begin ("the-tags", tuple)`；否则不进入 defer 逻辑。`exec_set_binding` 中已有的 `defer-tags=="row"` 判定逻辑保持不变，因此修复后既保留 align 场景的正确重绑，也避免 frame/solution 等环境误触发
+
 
 ## 2025/12/12
 ### What

--- a/src/Typeset/Table/table.cpp
+++ b/src/Typeset/Table/table.cpp
@@ -113,8 +113,13 @@ table_rep::typeset_row (int i, tree fm, tree t, path ip) {
   T[i]   = tm_new_array<cell> (nr_cols);
   STACK_NEW_ARRAY (subformat, tree, nr_cols);
   extract_format (fm, subformat, nr_cols);
-  tree old_defer= env->local_begin ("defer-tags", string ("row"));
-  tree old_tags = env->local_begin ("the-tags", tree (TUPLE));
+  bool can_make_tags= (hyphen == "y" && env->read (MODE) == "math" &&
+                       env->read (MATH_DISPLAY) == "true");
+  tree old_defer, old_tags;
+  if (can_make_tags) {
+    old_defer= env->local_begin ("defer-tags", string ("row"));
+    old_tags = env->local_begin ("the-tags", tree (TUPLE));
+  }
   for (j= 0; j < nr_cols; j++) {
     cell& C= T[i][j];
     C      = cell (env);
@@ -127,8 +132,10 @@ table_rep::typeset_row (int i, tree fm, tree t, path ip) {
     C->col_span= min (C->col_span, nr_cols - j);
     if (hyphen == "y") C->row_span= 1;
   }
-  env->local_end ("the-tags", old_tags);
-  env->local_end ("defer-tags", old_defer);
+  if (can_make_tags) {
+    env->local_end ("the-tags", old_tags);
+    env->local_end ("defer-tags", old_defer);
+  }
   STACK_DELETE_ARRAY (subformat);
 }
 


### PR DESCRIPTION
# [201_35] align环境编号后 smart-ref 以及 reference 失效

## 如何测试
打开 `TeXmacs\tests\tmu\201_35.tmu` ，查看 smart-ref 和 reference 的公式编号是否正确

- line1 的 label 编号应该都是1（这一次修改的修复样例）
- line2 的 label 编号应该都是2（这一次修改的修复样例）
- line3 的 label 编号应该都是3
- line4 的 label 编号应该都是4
- line5 的 label 编号应该都是5
- line6 的 label 编号应该都是6

## 2026/2/28
### What
修复在 frame、solution 等环境内的公式编号错位的问题

### Why
之前的实现把 `defer-tags=row` 放在 `table_rep::typeset_row` 行入口处，导致**所有**走 table row 的场景都可能触发延迟绑定

但 `defer-tags` 的设计初衷仅是服务多行公式（align/eqnarray/gather 等）中“`label` 先于 `eq-number`”的时序修正。像 frame、solution 这类外层环境内部也会进入 `typeset_row`，从而把本不该延迟重绑的 label 键加入 `the-tags`，最终在后续 `set-binding`（1参）时被错误覆盖，表现为编号错位

### How
将 `typeset_row` 中 `defer-tags/the-tags` 的行级作用域从“无条件开启”改为“仅在多行显示公式场景开启”：

1. `hyphen == "y"`：仅处理可按行拆分的数学表格（多行公式结构信号）
2. `mode == "math"`：仅在数学语义环境生效
3. `math-display == "true"`：仅在陈列公式模式生效

满足三条件时才 `local_begin ("defer-tags", "row")` 与 `local_begin ("the-tags", tuple)`；否则不进入 defer 逻辑。`exec_set_binding` 中已有的 `defer-tags=="row"` 判定逻辑保持不变，因此修复后既保留 align 场景的正确重绑，也避免 frame/solution 等环境误触发


## 2025/12/12
### What
之前的修改会导致 equation 环境中 label 被下一行覆盖绑定，导致编号出错

### Why
在 `table_rep::typeset_row` 只用 `local_begin/end the-tags` 的隔离设置在 equation 环境下不会进入 table 行，导致 `the-tags` 没被隔离好，因此会被下一个 equation 覆盖绑定

### How
在表格行入口打标记 `defer-tags=row`，并在 2 参 `set-binding(label, <value|the-label>)` 时判断只有存在 `defer-tags=="row"` 标记时才把键加入 `the-tags`
```cpp
if (is_func (t[1], VALUE, 1) && t[1][0] == THE_LABEL) {
  tree defer_tag= read ("defer-tags");
  tree old_tags = read ("the-tags");
  if (is_tuple (old_tags) && is_atomic (defer_tag) && defer_tag == "row") {
    tree new_tags= old_tags * tuple (key);
    assign (string ("the-tags"), new_tags);
    refined= true;
  }
}
```
这么做还能删除前一个实现中不必要的打补丁，因为列表环境的覆盖绑定也是因为 `the-tags` 没被隔离好：
```cpp
// if refined but new value is not atomic, skip (only for 1-arg set-binding)
if (N (t) == 1 && !is_atomic (value) && is_func (old_value, TUPLE) && N (old_value) >= 1 && is_atomic (old_value[0])) continue;
```

## 2025/11/30
### What
在 align 环境中，若 `<label|id>` 出现在 `<eq-number>` 之前，则 `<reference|id>` 或 `<smart-ref|id>` 会"错位"，即显示上一行的编号或“?”。

### Why
这是一个执行时序问题，排版器按从左到右的顺序处理公式/表格时：
- `<label|id>` 实际展开是 `<set-binding|id|<value|the-label>>`（二参形式），然后立即用当前`the-label` 值绑定
- `<eq-number>` 内部调用 `<next-equation>`，然后执行 `<set-binding|<the-equation>>`（一参形式），更新计数器并设置 `the-label`

当 `<label|id>` 出现在 `<eq-number>` 之前时，在执行 `<set-binding|id|<value|the-label>>` 时 `the-label` 尚未更新，所以就绑定了错误的值

### How
1. 在`edit_env_rep::exec_set_binding` 中，当处理到 `<label|id>` 的二参形式的 `set-binding` 时，若值来自 `<value|the-label>`，则**将这个键加入 `the-tags`**。这样当后续处理到 `<eq-number>` 的一参形式的 `set-binding` 时，`the-tags` 能读取**这些键**，就会用正确的编号值去覆盖绑定它们。如下：
```cpp
if (is_func (t[1], VALUE, 1) && t[1][0] == THE_LABEL) {
  tree old_tags= read ("the-tags");
  if (is_tuple (old_tags)) {
    tree new_tags= old_tags * tuple (key);
    assign (string ("the-tags"), new_tags);
  }
}
```

2. 在 `table_rep::typeset_row` 中，在每行开始时隔离 `the-tags`，这样确保行与行之间的 `the-tags` 互不干扰，避免 `<label|id>` 如果打在 `<eq-number>` 之后，会被下一行的 `<eq-number>` 错误覆盖。如下：
```cpp
tree old_tags= env->local_begin ("the-tags", tree (TUPLE));
// ...
env->local_end ("the-tags", old_tags);
```

### FIX
1. 以上修改实测会触发覆盖绑定的警告。故在处理一参和二参形式时，当涉及延迟绑定时都设置 `refined= true` ，在后面需要流入 redefined 时检测 refined 并跳过即可

2. 在列表等环境下，如果新值并不符合可读要求（不是atomic结构）则跳过覆盖绑定
```cpp
// if refined but new value is not atomic, skip (only for 1-arg set-binding)
if (N (t) == 1 && !is_atomic (value) && is_func (old_value, TUPLE) && N (old_value) >= 1 && is_atomic (old_value[0])) continue;
```