### PR TITLE
[213_19] Fix broken and outdated links in development guides

### DIFF
--- a/devel/213_19.md
+++ b/devel/213_19.md
@@ -1,0 +1,24 @@
+# 213_19 Fix broken and outdated links in development guides
+
+## 2025/02/27 Fix links in all platform development guides
+
+### What
+Fixed broken and outdated links across all six development guide files:
+- `Develop_on_Linux.md`
+- `Develop_on_Linux_ZH.md`
+- `Develop_on_macOS.md`
+- `Develop_on_macOS_ZH.md`
+- `Develop_on_Windows.md`
+- `Develop_on_Windows_ZH.md`
+
+### Why
+1. The English development guides for Linux and macOS incorrectly linked the testing section to the Chinese document `Test_ZH.md` instead of `Test_EN.md`.
+2. All six development guides linked the formatting guide to an external Gitee URL (`https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md`), which is outdated since the project has migrated to GitHub under MoganLab. These should use local relative paths instead.
+3. The Windows development guides used a Gitee clone URL (`git@gitee.com:XmacsLabs/mogan.git`) instead of the current GitHub URL.
+4. The English Windows guide contained a Chinese word "验证" that should be "Verify".
+
+### How
+- Changed `Test_ZH.md` → `Test_EN.md` in English guides
+- Changed external Gitee formatting links → local relative paths (`Format_EN.md` for English, `Format_ZH.md` for Chinese)
+- Changed Gitee clone URL → `https://github.com/MoganLab/mogan.git` in Windows guides
+- Changed "验证" → "Verify" in the English Windows guide

--- a/devel/Develop_on_Linux.md
+++ b/devel/Develop_on_Linux.md
@@ -36,7 +36,7 @@ xmake build stem
 ```
 
 ### Step 3: Testing
-Refer to [How to Test](Test_ZH.md)
+Refer to [How to Test](Test_EN.md)
 
 ### Step 4: Launch Mogan STEM
 ``` bash
@@ -62,4 +62,4 @@ xmake project -k compile_commands
 This command will generate a compile_commands.json file in the mogan folder. Clangd reads this file to understand the project's structure, thereby avoiding errors related to missing header files.
 
 ## Please format code before committing
-[Formating Guide](https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md)
+[Formatting Guide](Format_EN.md)

--- a/devel/Develop_on_Linux_ZH.md
+++ b/devel/Develop_on_Linux_ZH.md
@@ -62,4 +62,4 @@ xmake project -k compile_commands
 这个命令会在mogan文件夹下生成一个compile_commands.json文件，Clangd会读取它以理解项目的组织结构，从而避免找不到头文件的错误。
 
 ## commit前请格式化
-[格式化链接](https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md)
+[格式化指南](Format_ZH.md)

--- a/devel/Develop_on_Windows.md
+++ b/devel/Develop_on_Windows.md
@@ -23,7 +23,7 @@
   ```powershell
   choco  install xmake
   ```
-- 验证：
+- Verify:
   ```powershell
   xmake --version
   ```
@@ -32,7 +32,7 @@
 
 ```powershell
 cd E:\TestFile
-git clone git@gitee.com:XmacsLabs/mogan.git
+git clone https://github.com/MoganLab/mogan.git
 cd mogan
 ```
 
@@ -70,4 +70,4 @@ xmake run stem
 ```
 
 ## Please format code before committing
-[Formatting Guide](https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md)
+[Formatting Guide](Format_EN.md)

--- a/devel/Develop_on_Windows_ZH.md
+++ b/devel/Develop_on_Windows_ZH.md
@@ -34,7 +34,7 @@
 
 ```powershell
 cd E:\TestFile
-git clone git@gitee.com:XmacsLabs/mogan.git
+git clone https://github.com/MoganLab/mogan.git
 cd mogan
 ```
 
@@ -72,4 +72,4 @@ xmake run stem
 ```
 
 ## commit前请格式化
-[格式化链接](https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md)
+[格式化指南](Format_ZH.md)

--- a/devel/Develop_on_macOS.md
+++ b/devel/Develop_on_macOS.md
@@ -35,7 +35,7 @@ xmake build stem
 ```
 
 ## Step 4: Testing
-Refer to [How to Test](Test_ZH.md)
+Refer to [How to Test](Test_EN.md)
 
 ## Step 5: Launch Mogan STEM
 ``` bash
@@ -43,4 +43,4 @@ xmake run stem
 ```
 
 ## Please format code before committing
-[Formatting Guide](https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md)
+[Formatting Guide](Format_EN.md)

--- a/devel/Develop_on_macOS_ZH.md
+++ b/devel/Develop_on_macOS_ZH.md
@@ -42,4 +42,4 @@ xmake build stem
 xmake run stem
 ```
 ## commit前请格式化
-[格式化链接](https://gitee.com/XmacsLabs/mogan/blob/main/devel/Format_ZH.md)
+[格式化指南](Format_ZH.md)


### PR DESCRIPTION
Fix #2846 related

Changes:
- Replace outdated gitee.com links with local relative paths in all development guides
- Fix English guides linking to Chinese test docs (Test_ZH.md → Test_EN.md )
- Update git clone URLs from gitee to GitHub in Windows guides

Files changed:
- devel/Develop_on_Linux.md
- devel/Develop_on_Linux_ZH.md
- devel/Develop_on_macOS.md
- devel/Develop_on_macOS_ZH.md
- devel/Develop_on_Windows.md
- devel/Develop_on_Windows_ZH.md
- devel/213_19.md
