### PR TITLE
[213_21] Fix typo and update outdated repository links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Mogan STEM is a professional scientific writing platform targeted at mathematics
 - Clear structure for different content types and well-organized document hierarchy
 - Click to insert environments; complex typesetting becomes simple
 
-![hesis-level Edits PRE](./public/images/Thesis-level-Edits.png)
+![Thesis-level Edits PRE](./public/images/Thesis-level-Edits.png)
 
 ### Scientific Document Creation
 - High-quality typesetting: professional document formatting with TeX quality output
@@ -58,14 +58,14 @@ Mogan STEM is a professional scientific writing platform targeted at mathematics
 ### Installation
 
 #### Option 1: Mogan STEM (Community Version)
-From Release: Download the latest release for your platform from [GitHub releases](https://github.com/XmacsLabs/mogan/releases).
+From Release: Download the latest release for your platform from [GitHub releases](https://github.com/MoganLab/mogan/releases).
 
 #### Option 2: Build from Source
 
 Clone the repository:
 
 ```bash
-git clone https://github.com/XmacsLabs/mogan.git
+git clone https://github.com/MoganLab/mogan.git
 cd mogan
 ```
 
@@ -82,7 +82,7 @@ For the commercial version with built-in AI features, please visit the [Liii STE
 
 ### Community Version Resources
 - Mogan website: [https://mogan.app](https://mogan.app)
-- GitHub repository: [github.com/XmacsLabs/mogan](https://github.com/XmacsLabs/mogan)
+- GitHub repository: [github.com/MoganLab/mogan](https://github.com/MoganLab/mogan)
 - User manual: comprehensive guide covering all features ([Liii/Mogan STEM docs](https://liiistem.cn/docs/welcome.html))
 - Video tutorials: step-by-step learning materials
 

--- a/devel/213_21.md
+++ b/devel/213_21.md
@@ -1,0 +1,16 @@
+# 213_21 Fix typo and update outdated repository links in README.md
+
+## 2025/02/27 Fix README.md typo and links
+
+### What
+Fixed a typo in the image alt text and updated all outdated GitHub repository links in `README.md`.
+
+### Why
+1. The image alt text `hesis-level Edits PRE` was missing the leading "T", it should be `Thesis-level Edits PRE`.
+2. Multiple links in `README.md` still pointed to the old repository `github.com/XmacsLabs/mogan` instead of the current `github.com/MoganLab/mogan`. This includes the releases link, clone URL, and repository reference in the documentation section.
+
+### How
+- Fixed typo: `hesis-level` → `Thesis-level` in image alt text
+- Updated GitHub releases link: `XmacsLabs/mogan` → `MoganLab/mogan`
+- Updated git clone URL: `XmacsLabs/mogan` → `MoganLab/mogan`
+- Updated repository reference link: `XmacsLabs/mogan` → `MoganLab/mogan`


### PR DESCRIPTION
Changes:
- Fix typo: "hesis-level" → "thesis-level"
- Update old XmacsLabs GitHub links to MoganLab
