### PR TITLE
[212_5]: Fix PDF export wait indicator not disappearing (#2621)

### DIFF
--- a/TeXmacs/progs/texmacs/texmacs/tm-print.scm
+++ b/TeXmacs/progs/texmacs/texmacs/tm-print.scm
@@ -95,6 +95,7 @@
         (switch-to-buffer cur)
         (buffer-close buf))
       (print-to-file fname))
+  (system-wait "" "")
   (user-confirm-open-pdf fname))
 
 (tm-define (wrapped-print-to-pdf-embeded-with-tm fname)
@@ -118,6 +119,7 @@
     (print-to-file fname)
     (unless (attach-doc-to-exported-pdf fname)
         (notify-now "Fail to attach tm to pdf"))))
+  (system-wait "" "")
   (user-confirm-open-pdf fname))
 
 (tm-define (wrapped-print-to-pdf-embeded-with-tmu fname)
@@ -141,6 +143,7 @@
     (print-to-file fname)
     (unless (attach-doc-to-exported-pdf fname)
         (notify-now "Fail to attach tmu to pdf"))))
+  (system-wait "" "")
   (user-confirm-open-pdf fname))
 
 (tm-define (attach-doc-to-exported-pdf fname)

--- a/devel/212_5.md
+++ b/devel/212_5.md
@@ -1,0 +1,24 @@
+# [212_5] Fix PDF export wait indicator not disappearing
+
+## Issue
+After exporting a PDF, the "导出中, 请稍后…" (Exporting, please wait) wait indicator dialog does not disappear. The user has to dismiss it manually, and it overlaps with the subsequent "Open PDF?" confirmation dialog. (Issue #2621)
+
+## How to test
+1. Open any document in Mogan
+2. Click `File -> Export -> Pdf...`, choose a path
+3. Verify the "Exporting, please wait" indicator disappears automatically once export completes
+4. Verify the "Open PDF?" confirmation dialog appears cleanly without the wait indicator behind it
+5. Repeat with `File -> Export -> Editable Pdf (tm)` and `File -> Export -> Editable Pdf (tmu)`
+
+## 2026/03/02
+
+### What
+Fixed the wait indicator not being dismissed after PDF export completes.
+
+### Why
+The `system-wait` mechanism uses a stack-based approach (in `qt_gui_rep::show_wait_indicator`). Calling `system-wait` with a non-empty message pushes a wait dialog onto the stack and displays it. Calling `system-wait` with an empty message pops the dialog and closes the window.
+
+All C++ callers (e.g. in `load_tex.cpp`, `make_file.cpp`) correctly call `system_wait("")` after their operations to dismiss the dialog. However, the three PDF export functions in `tm-print.scm` — `wrapped-print-to-file`, `wrapped-print-to-pdf-embeded-with-tm`, and `wrapped-print-to-pdf-embeded-with-tmu` — only called `system-wait` to show the indicator but never called it with empty strings to dismiss it.
+
+### How
+Added `(system-wait "" "")` after the export operation completes (before the `user-confirm-open-pdf` call) in all three PDF export functions in `TeXmacs/progs/texmacs/texmacs/tm-print.scm`.


### PR DESCRIPTION
## Issue
Fixes #2621 — The "导出中, 请稍后…" (Exporting, please wait) wait indicator does not disappear after PDF export completes, overlapping with the "Open PDF?" confirmation dialog.

## Root Cause
The `system-wait` mechanism uses a stack: a non-empty message pushes a dialog, an empty message pops it. All C++ callers correctly call `system_wait("")` to dismiss the dialog, but the three Scheme PDF export functions in `tm-print.scm` never popped it.

## Fix
Added `(system-wait "" "")` after export completes in:
- `wrapped-print-to-file`
- `wrapped-print-to-pdf-embeded-with-tm`
- `wrapped-print-to-pdf-embeded-with-tmu`

## How to test
1. Open any document, click `File -> Export -> Pdf...`
2. Verify the wait indicator disappears automatically after export
3. Verify the "Open PDF?" dialog appears cleanly
4. Repeat with `Editable Pdf (tm)` and `Editable Pdf (tmu)`