### PR TITLE
[222_51] added chinese translation for 'Text for note'

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -2255,6 +2255,7 @@
 ("text box" "文本框")
 ("text corners" "文本角")
 ("text font" "文本字体")
+("Text for note" "用于笔记的文本")
 ("text height correction" "文本高度修正")
 ("text input" "文本输入")
 ("text mode" "文本模式")
@@ -2549,4 +2550,3 @@
 ("You are currently in guest mode, login to enable AI, MathOCR,and other features" "您当前处于访客状态，登录激活AI和公式识别等功能")
 ("Login Now" "立即登录")
 ("Use extensible brackets" "使用可伸缩括号")
-("Text for note" "用于笔记的文本")

--- a/devel/222_51.md
+++ b/devel/222_51.md
@@ -1,4 +1,4 @@
-# 202_111 Translate 'Text for Note' into chinese
+# 222_51 Translate 'Text for Note' into chinese
 
 ### What
 Translates the option `Text for note` found at `Insert -> Link -> Text for note`


### PR DESCRIPTION
Fixes #2906
Add translation for 'Text for note'

## Summary
Translates the option `Text for note` found at `Insert -> Link -> Text for note`

**Developer document:** `devel/222_51.md`

## Issue Found
The option is in plain english and needs to be translated into chinese.

## Changes
In `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` added the translation:

```diff
+  ("Text for note" "用于笔记的文本")
```

## How to Test
1. Open Mogan and click on `插入` or `Insert`
2. Go to `链接` or `Link`
3. In the options, `Text for note` has been translated into `用于笔记的文本`

<img width="1802" height="1765" alt="Screenshot 2026-03-02 125203" src="https://github.com/user-attachments/assets/7375d397-7d3a-4b84-9fb9-c9f937185978" />