### PR TITLE
[202_108] Fix item-nr for enumerate variants created via new-list

### DIFF
--- a/TeXmacs/packages/standard/std-list.ts
+++ b/TeXmacs/packages/standard/std-list.ts
@@ -112,20 +112,22 @@
     </padded-normal>
   </macro>>
 
+  <assign|list-depth|0>
+
   <assign|list|<\macro|item-render|item-transform|body>
-    <\with|current-item|<arg|item-render>|transform-item|<arg|item-transform>|item-nr|<if|<equal|<value|enumerate-level>|1>|<value|item-nr>|0>>
+    <\with|current-item|<arg|item-render>|transform-item|<arg|item-transform>|list-depth|<plus|<value|list-depth>|1>|item-nr|<if|<equal|<value|list-depth>|0>|<value|item-nr>|0>>
       <render-list|<arg|body>>
     </with>
   </macro>>
 
   <assign|list*|<\macro|item-render|item-transform|body>
-    <\with|current-item|<arg|item-render>|transform-item|<quasiquote|<macro|name|<unquote|<value|last-item>>.<compound|<unquote|<arg|item-transform>>|<arg|name>>>>|item-nr|<value|item-nr>|last-item-nr|0>
+    <\with|current-item|<arg|item-render>|transform-item|<quasiquote|<macro|name|<unquote|<value|last-item>>.<compound|<unquote|<arg|item-transform>>|<arg|name>>>>|list-depth|<plus|<value|list-depth>|1>|item-nr|<value|item-nr>|last-item-nr|0>
       <render-list|<arg|body>>
     </with>
   </macro>> 
 
   <assign|list-continued|<\macro|item-render|item-transform|body>
-    <\with|current-item|<arg|item-render>|transform-item|<arg|item-transform>|item-nr|<value|last-item-nr>>
+    <\with|current-item|<arg|item-render>|transform-item|<arg|item-transform>|list-depth|<plus|<value|list-depth>|1>|item-nr|<value|last-item-nr>>
       <render-list|<arg|body>>
     </with>
   </macro>>

--- a/devel/202_108.md
+++ b/devel/202_108.md
@@ -1,0 +1,34 @@
+# #2776 Fix item-nr for enumerate variants created via new-list
+
+### How to test
+1. Clear cache
+   - macOS: delete `~/Library/Caches/MoganLab`
+   - Linux: delete `~/.cache/MoganLab`
+   - Windows: delete `%appdata%/AppData/Roaming/MoganLab` and `%appdata%/AppData/Local/MoganLab`
+2. Restart Mogan, open a new document
+3. Insert → Ordered list → "1, 2, 3, ..." (`enumerate-numeric`)
+4. Add 3 items (type text, press Enter for each)
+5. Inside item 3, delete the item marker (Backspace), then insert a nested ordered list via shortcut `1. Tab` (`enumerate`)
+6. Verify the nested list starts from 1 (not continuing from 4)
+
+## 2026/03/03
+### What
+The `list` macro condition used `enumerate-level` to decide whether to preserve or reset `item-nr`. This only worked for the `enumerate` macro (shortcut `1. Tab`) which increments `enumerate-level`. Variants created via `new-list` (e.g. `enumerate-numeric`, `enumerate-alpha`) do not go through `enumerate` and leave `enumerate-level` at 0, causing incorrect `item-nr` behavior.
+
+### Why
+The previous fix (202_65) checked `enumerate-level == 1` to identify top-level lists. But `new-list`-based variants never set `enumerate-level`, so the condition always fails for them — `item-nr` resets to 0 even at the top level, and nested lists inherit the parent's `item-nr` instead of resetting.
+
+Fixes: https://github.com/XmacsLabs/mogan/issues/2108
+
+### How
+In `TeXmacs/packages/standard/std-list.ts`:
+
+- Added a new variable `list-depth` (initialized to 0)
+- All three list macros (`list`, `list*`, `list-continued`) now increment `list-depth` via `<with>`
+- Changed the `item-nr` condition from `enumerate-level == 1` to `list-depth == 0`
+
+Since `list-depth` is incremented by all list macros (not just `enumerate`), the condition works uniformly for every list type.
+
+References from previous modifications:
+- https://gitee.com/MoganLab/mogan/pulls/893/files
+- https://gitee.com/MoganLab/mogan/pulls/996/files


### PR DESCRIPTION
closes #2776  and  #2929

### **How to test**
1. Clear cache : rm -rf ~/Library/Caches/MoganLab  
2. Restart Mogan, open a new document
3. Insert → Ordered list → "1, 2, 3, ..." (enumerate-numeric)
4. Add 3 items (type text, press Enter for each)
5. Inside item 3, delete the item marker (Backspace), then insert a nested ordered list via shortcut 1. Tab (enumerate)
6. Verify the nested list starts from 1 (not continuing from 4)

### **Fix:**
- Earlier item-nr reset was based on enumerate-level == 1 which only works for the enumerate macro path
- Now item-nr reset is based on list-depth == 0 which works for ALL list types (enumerate, enumerate-numeric, itemize, etc.)

### Before:

https://github.com/user-attachments/assets/3d241ee8-0d17-47b6-8d23-05052b91f97a

### After:

https://github.com/user-attachments/assets/7bfe6c2b-c1a6-44fb-959c-ec5c90e701ce
