### PR TITLE
[204_30] fix(typeset): suppress ghost borders in vertically-spanned table cells

### DIFF
--- a/devel/204_30.md
+++ b/devel/204_30.md
@@ -1,0 +1,24 @@
+# 204_30 Suppress ghost borders in vertically-spanned table cells
+## How to test
+1. Create a new document
+2. Insert a 2x2 table
+3. Join cells vertically (row-span=2 on top-left cell)
+4. Verify ghost lines no longer appear in the merged region
+
+## 2026/03/03 Fix ghost borders in vertically-spanned table cells
+### What
+When a cell spans multiple rows via `cell-row-span > 1`, ghost lines
+appeared at interior positions of the merged region.
+
+### Why
+The consumed sub-cells retained their border values (`lborder`, `rborder`,
+`bborder`, `tborder`). During rendering, `cell_box_rep::pre_display()`
+drew these borders independently, producing ghost lines.
+
+### How
+- Zero borders on consumed cells in `table_rep::finish()` before boxes
+  are constructed
+- Guard each border side individually in `pre_display()` to prevent
+  any residual drawing
+
+Closes #861

--- a/src/Typeset/Boxes/Modifier/change_boxes.cpp
+++ b/src/Typeset/Boxes/Modifier/change_boxes.cpp
@@ -693,10 +693,10 @@ cell_box_rep::pre_display (renderer& ren) {
 
   if ((l > 0) || (r > 0) || (b > 0) || (t > 0)) {
     ren->set_pencil (fg);
-    ren->fill (lx1, by1, lx2, ty2);
-    ren->fill (rx1, by1, rx2, ty2);
-    ren->fill (lx1, by1, rx2, by2);
-    ren->fill (lx1, ty1, rx2, ty2);
+    if (l > 0) ren->fill (lx1, by1, lx2, ty2);
+    if (r > 0) ren->fill (rx1, by1, rx2, ty2);
+    if (b > 0) ren->fill (lx1, by1, rx2, by2);
+    if (t > 0) ren->fill (lx1, ty1, rx2, ty2);
   }
 }
 

--- a/src/Typeset/Table/table.cpp
+++ b/src/Typeset/Table/table.cpp
@@ -880,7 +880,29 @@ table_rep::finish () {
   array<string> ha;
   bool          ext_flag = true;
   bool          wide_flag= false;
-  for (i= 0; i < nr_rows; i++)
+// Fix #861: zero borders on cells consumed by row/col spans
+  for (int fi= 0; fi < nr_rows; fi++)
+    for (int fj= 0; fj < nr_cols; fj++)
+      if (!is_nil (T[fi][fj])) {
+        cell C= T[fi][fj];
+        if (C->row_span > 1)
+          for (int di= 1; di < C->row_span && (fi + di) < nr_rows; di++) {
+            cell& D= T[fi + di][fj];
+            if (!is_nil (D)) {
+              D->lborder= 0; D->rborder= 0;
+              D->bborder= 0; D->tborder= 0;
+            }
+          }
+        if (C->col_span > 1)
+          for (int dj= 1; dj < C->col_span && (fj + dj) < nr_cols; dj++) {
+            cell& D= T[fi][fj + dj];
+            if (!is_nil (D)) {
+              D->lborder= 0; D->rborder= 0;
+              D->bborder= 0; D->tborder= 0;
+            }
+          }
+      }
+  // End fix #861  for (i= 0; i < nr_rows; i++)
     for (j= 0; j < nr_cols; j++)
       if (!is_nil (T[i][j])) {
         cell C= T[i][j];


### PR DESCRIPTION
## Problem
Closes #861

When a cell spans multiple rows via `cell-row-span > 1`, the consumed
sub-cells retained their border values (`lborder`, `rborder`, `bborder`,
`tborder`). During rendering, `cell_box_rep::pre_display()` drew these
borders independently, producing ghost lines at interior positions of
the merged region.

## Fix
- Zero borders on consumed cells in `table_rep::finish()` before boxes
  are constructed
- Guard each border side individually in `pre_display()` to prevent
  any residual drawing

## Testing
Manually tested with a 2×2 table, row-span=2 on top-left cell.
Ghost line in merged cell is no longer visible.

## Files changed
- `src/Typeset/Table/table.cpp`
- `src/Typeset/Boxes/Modifier/change_boxes.cpp`