### PR TITLE
[205_2009] Fix inconsistent document rendering when closing tabs

### DIFF
--- a/devel/205_2009.md
+++ b/devel/205_2009.md
@@ -1,0 +1,23 @@
+# 205_2009 Fix inconsistent document rendering when closing tabs
+
+## Problem
+Issue #2009: When using "Documents in separate windows" mode with Tab bar enabled, closing a tab causes the remaining document's rendering to become inconsistent (different font rendering for the same content).
+
+## Root Cause
+In `kill_window()` (`src/Texmacs/Data/new_window.cpp`), when the last tab in a window is closed, `set_current_view()` is called to switch to the surviving window's view. However, `set_current_view()` only updates the view pointer — it does not call `resume()` on the editor. Without `resume()`, `notify_change(THE_FOCUS + THE_EXTENTS)` is never triggered, so the font environment and layout are not recalculated, resulting in inconsistent rendering.
+
+## Fix
+Added `resume()` and `send_keyboard_focus()` calls after `set_current_view()` in `kill_window()`. This follows the same pattern used by `var_focus_on_buffer()` in `new_view.cpp`, ensuring the rendering pipeline is properly triggered when switching to the surviving window.
+
+## Steps to Reproduce
+1. Open Mogan
+2. Set Edit > Preferences > Buffer management > Documents in separate windows
+3. Set View > Tab bar
+4. Type Chinese text (e.g., `集合与映射`)
+5. Set Font to Microsoft YaHei, size 14pt
+6. Create a new document
+7. Close the new document in Tab bar
+8. Observe: the original document's rendering has changed
+
+## Files Changed
+- `src/Texmacs/Data/new_window.cpp`: Added `resume()` and `send_keyboard_focus()` in `kill_window()`

--- a/src/Texmacs/Data/new_window.cpp
+++ b/src/Texmacs/Data/new_window.cpp
@@ -350,7 +350,15 @@ kill_window (url wname) {
     url win= view_to_window (vs[i]);
     if (!is_none (win) && win != wname) {
       set_current_view (vs[i]);
-      // FIXME: make sure that win obtains the focus of the GUI too
+      // Ensure the editor is properly resumed so that rendering
+      // state (fonts, zoom, extents) is recalculated correctly
+      {
+        tm_view vw= concrete_view (vs[i]);
+        if (vw != NULL && vw->ed != NULL) {
+          vw->ed->resume ();
+          send_keyboard_focus (vw->ed);
+        }
+      }
       delete_window (wname);
       return;
     }


### PR DESCRIPTION
## Problem
Fixes #2009

When using "Documents in separate windows" mode with the Tab bar enabled, 
closing a newly created tab causes the original document's rendering to 
become inconsistent — the same text appears with different font metrics 
and spacing than before.

## Root Cause
In `kill_window()` inside `src/Texmacs/Data/new_window.cpp`, when the 
last tab in a window is closed, `set_current_view()` switches to the 
surviving window's view. But `set_current_view()` only updates the view 
pointer — it never calls `resume()` on the editor. 

Without `resume()`, `notify_change(THE_FOCUS + THE_EXTENTS)` is never 
triggered, so the font environment and page layout are not recalculated. 
This leaves the editor in a stale state, producing the visual mismatch.

There was already a FIXME comment at this location noting that GUI focus 
was not properly transferred.

## Fix
Added `resume()` and `send_keyboard_focus()` after `set_current_view()` 
in `kill_window()`, matching the pattern already used by 
`var_focus_on_buffer()` in `new_view.cpp`.

## Developer Doc
See `devel/205_2009.md`