### PR TITLE
[213_21] Fix encoding issues and typo in Windows development guide

### DIFF
--- a/devel/Develop_on_Windows.md
+++ b/devel/Develop_on_Windows.md
@@ -21,14 +21,14 @@
 - **chocolatey**：
   
   ```powershell
-  choco  install xmake
+  choco install xmake
   ```
 - Verify:
   ```powershell
   xmake --version
   ```
 ## Step 2: Get Source Code, Compile and Run
-### Chose your working directory, for example E:\TestFile:
+### Choose your working directory, for example E:\TestFile:
 
 ```powershell
 cd E:\TestFile


### PR DESCRIPTION
>Fixed broken Chinese colon characters (：) to English colon (:) 
  In scoop and chocolatey installation instructions
>Fixed typo: "Chose" → "Choose"
>Fixed double space in `choco install` command

Improves readability of the Windows development guide for 
English-speaking contributors.