### PR TITLE
[222_48] : fix macOS shortcut issue 

### DIFF
--- a/devel/222_48.md
+++ b/devel/222_48.md
@@ -1,0 +1,16 @@
+# Fix macOS keyboard shortcuts in file chooser dialog
+
+## How to test
+1. Open Mogan on macOS
+2. Open the file dialog (File > Save or similar actions)
+3. The keyboard shortcuts should work properly:
+   - Command+V (paste)
+   - Command+C (copy)
+   - Other standard macOS shortcuts
+
+## Fix macOS file chooser dialog keyboard shortcuts
+### What
+Fixed issue #2894: keyboard shortcuts (Command+V, Command+C, etc.) not working in the file chooser dialog on macOS.
+
+### Why
+when Qt uses native file dialog on macOS, it has a keyboard shortcut issue that prevents users from using standard macOS shortcuts for copy/paste operations, negatively impacting user experience.

--- a/src/Plugins/Qt/qt_chooser_widget.cpp
+++ b/src/Plugins/Qt/qt_chooser_widget.cpp
@@ -287,7 +287,8 @@ qt_chooser_widget_rep::perform_dialog () {
   QFileDialog* dialog= new QFileDialog (this->as_qwidget (), caption, path);
 
 #ifdef OS_MACOS
-  // Use Qt's custom dialog on macOS to fix keyboard shortcuts (Command+V, Command+C, etc.)
+  // Use Qt's custom dialog on macOS to fix keyboard shortcuts
+  // (Command+V, Command+C, etc.)
   dialog->setOption (QFileDialog::DontUseNativeDialog, true);
 #endif
 


### PR DESCRIPTION
fixes #2894 

## How to test
1. Open Mogan on macOS
2. Open the file dialog (File > Save or similar actions)
3. The keyboard shortcuts should work properly:
   - Command+V (paste)
   - Command+C (copy)
   - Other standard macOS shortcuts

## Fix macOS file chooser dialog keyboard shortcuts
### What
Fixed issue #2894: keyboard shortcuts (Command+V, Command+C, etc.) not working in the file chooser dialog on macOS.

### Why
when Qt uses native file dialog on macOS, it has a keyboard shortcut issue that prevents users from using standard macOS shortcuts for copy/paste operations, negatively impacting user experience.

## SCreenshot
<img width="1179" height="930" alt="image" src="https://github.com/user-attachments/assets/96955942-5adb-4712-9fc7-d07ab91a38d1" />
