### PR TITLE
[201_93] fix \det input producing plain text instead of determinant matrix

### DIFF
--- a/TeXmacs/plugins/latex/progs/latex-kbd.scm
+++ b/TeXmacs/plugins/latex/progs/latex-kbd.scm
@@ -196,7 +196,7 @@
   ("coth" "Insert coth" (insert "coth"))
   ("csc" "Insert csc" (insert "csc"))
   ("deg" "Insert deg" (insert "deg"))
-  ("det" "Insert det" (insert "det"))
+  ("det" "Insert det" (make 'det))
   ("dim" "Insert dim" (insert "dim"))
   ("exp" "Insert exp" (insert "exp"))
   ("gcd" "Insert gcd" (insert "gcd"))

--- a/devel/201_93.md
+++ b/devel/201_93.md
@@ -1,0 +1,20 @@
+# [201_93] 修复 \det 输入为纯文本而非行列式矩阵的问题
+
+## 如何测试
+1. 启动 Mogan STEM，新建文档，进入数学模式
+2. 输入 `\det`，从自动补全弹窗中选择 `det`，按回车
+3. 应插入带竖线分隔符的行列式矩阵（而非纯文本 "det"）
+
+## 2026/03/06 修复 \det 输入行为
+
+### What
+修复 `\det` 在数学模式下输入时显示为纯文本 "det" 而非行列式矩阵的问题。
+
+### Why
+在 `TeXmacs/packages/standard/std-math.ts` 中，`det` 宏定义为带竖线分隔符的行列式矩阵。
+但 `TeXmacs/plugins/latex/progs/latex-kbd.scm` 中的 LaTeX 键盘绑定使用 `(insert "det")` 插入纯文本，
+导致用户通过 `\det` 输入时得到的是纯文本而非预期的行列式矩阵结构。
+
+### How
+将 `latex-kbd.scm` 中 `det` 的键盘命令从 `(insert "det")` 改为 `(make 'det)`，
+与菜单栏（table-menu.scm）和键盘快捷键（math-kbd.scm）中的行为保持一致。


### PR DESCRIPTION
## Summary
- Fix #2931
- `\det` in math mode now inserts a determinant matrix (with `|` delimiters) instead of plain text "det"
- Changed `(insert "det")` to `(make 'det)` in `latex-kbd.scm`, consistent with menu and keyboard shortcut behavior

## Test plan
- [ ] Open Mogan STEM, create new document, enter math mode
- [ ] Type `\det`, select from autocomplete, press Enter
- [ ] Verify a determinant matrix with vertical bar delimiters is inserted (not plain text)
