### PR TITLE
[201_95] Disable command mode autocomplete suggestions in macro editor

### DIFF
--- a/TeXmacs/progs/generic/generic-kbd.scm
+++ b/TeXmacs/progs/generic/generic-kbd.scm
@@ -25,12 +25,6 @@
         (texmacs texmacs tm-print)
         (doc help-funcs)))
 
-(tm-define (inside-macro-editor?)
-  (with u (url->string (current-buffer))
-  (or (== u "tmfs://aux/macro-editor")
-    (and (string-starts? u "tmfs://aux/edit-")
-      (not (== u "tmfs://aux/edit-shortcuts"))))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; General shortcuts for all modes
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -48,7 +42,7 @@
   ("]" (make-bracket-close "]" "["))
   ("{" (make-bracket-open "{" "}"))
   ("}" (make-bracket-close "}" "{"))
-  ("\\" (if (or (inside? 'hybrid) (in-prog?) (inside-macro-editor?)) (insert "\\") (make-hybrid)))
+  ("\\" (if (or (inside? 'hybrid) (in-prog?)) (insert "\\") (make-hybrid)))
   ("\\ var" "\\")
   ("\\ var var" "<setminus>")
   ("$" (make 'math))

--- a/devel/201_95.md
+++ b/devel/201_95.md
@@ -1,40 +1,35 @@
-# [201_95] Disable hybrid command mode in macro editor
+# [201_95] Disable autocomplete options in macro editor
 
 ### What
-Disabled the hybrid command mode (the `⟨\⟩` tag) in the macro editor. This prevents the `\` key from triggering command mode and its associated autocomplete suggestions.
+Disabled the autocomplete popup suggestions in the macro editor while keeping the `\` hybrid command mode functional.
 
 ### Why
-The macro editor is used for source editing of macros. In this context, the backslash character `\` should be treated as a literal character rather than a trigger for the hybrid command mode, which introduces distracting autocomplete suggestions and decorative brackets.
+The macro editor is used for source editing of macros. In this context, autocomplete suggestions for macros popup unexpectedly and interfere with typing command names. However, the `\` key itself should still trigger the hybrid command mode `⟨\⟩`. As the search/replace buffers and other auxiliary windows rely on standard autocomplete behavior, the fix must explicitly target only the macro editor buffers.
 
 ### How
-Modified `TeXmacs/progs/generic/generic-kbd.scm`:
+Modified `src/Edit/Interface/edit_source.cpp`:
 
-1. Defined a new helper function `(inside-macro-editor?)` that explicitly checks the URL of `(current-buffer)` to see if it matches the macro editor's auxiliary buffer paths (`tmfs://aux/macro-editor` or `tmfs://aux/edit-*` excluding `tmfs://aux/edit-shortcuts`). 
+Updated `source_complete_try()` to return early when the current buffer (`buf->buf->name`) is identified as a macro editor buffer. The check properly matches `tmfs://aux/macro-editor` or specific `tmfs://aux/edit-*` URLs while explicitly exempting `edit-shortcuts` and `edit-comment` to avoid unintentionally disabling their autocomplete.
 
-```scheme
-(tm-define (inside-macro-editor?)
-  (with u (url->string (current-buffer))
-    (or (== u "tmfs://aux/macro-editor")
-        (and (string-starts? u "tmfs://aux/edit-")
-             (not (== u "tmfs://aux/edit-shortcuts"))))))
-```
-
-2. Updated the backslash `\` key binding to use the new `(inside-macro-editor?)` predicate. If true, it inserts a literal backslash instead of calling `make-hybrid`.
-
-```scheme
-("\\" (if (or (inside? 'hybrid) (in-prog?) (inside-macro-editor?)) 
-         (insert "\\") (make-hybrid)))
+```cpp
+// Disable autocomplete options in the macro editor
+string buf_name= as_string (buf->buf->name);
+if ((starts (buf_name, "tmfs://aux/edit-") &&
+     buf_name != "tmfs://aux/edit-shortcuts" &&
+     !starts (buf_name, "tmfs://aux/edit-comment")) ||
+    buf_name == "tmfs://aux/macro-editor") {
+  return;
+}
 ```
 
 ### How to test
 1. Open Mogan Editor.
 2. Open the macro editor via **Tools → Macros → New macro or Edit macros**.
-4. Press the `\` key.
-5. **Verify**:
-   - A literal `\` is inserted.
-   - No `⟨\⟩` bracketed tag appears.
-   - No autocomplete suggestion popup appears.
-6. Test in a normal document:
-   - **Verify**: The `\` key still triggers the hybrid command mode completely.
-7. Test in search/replace window:
-   - **Verify**: The `\` key still triggers the hybrid command mode completely inside the search input buffer.
+3. Press the `\` key and begin typing.
+4. **Verify**:
+   - The `⟨\⟩` bracketed tag (hybrid command mode) appears correctly.
+   - *No* autocomplete suggestion popup appears while typing.
+5. Test in a normal document:
+   - **Verify**: The `\` key triggers the hybrid command mode completely, and autocomplete functions as normal.
+6. Test in search/replace window:
+   - **Verify**: The `\` key triggers the hybrid command mode completely, and autocomplete functions as normal.

--- a/src/Edit/Interface/edit_source.cpp
+++ b/src/Edit/Interface/edit_source.cpp
@@ -18,6 +18,7 @@
 #include "merge_sort.hpp"
 #include "observers.hpp"
 #include "preferences.hpp"
+#include "tm_buffer.hpp"
 #include "tree_observer.hpp"
 
 #include <moebius/data/scheme.hpp>
@@ -30,6 +31,15 @@ void
 edit_interface_rep::source_complete_try () {
   bool is_source     = (get_env_string ("mode") == "src");
   bool is_source_mode= (get_env_string ("preamble") == "true");
+
+  // Disable autocomplete options in the macro editor
+  string buf_name= as_string (buf->buf->name);
+  if ((starts (buf_name, "tmfs://aux/edit-") &&
+       buf_name != "tmfs://aux/edit-shortcuts" &&
+       !starts (buf_name, "tmfs://aux/edit-comment")) ||
+      buf_name == "tmfs://aux/macro-editor") {
+    return;
+  }
 
   if (is_source && (!is_source_mode)) {
     completion_style= get_preference ("completion style");


### PR DESCRIPTION
Fixes #2873 
In the macro editor, the autocomplete suggestions in command mode `⟨\⟩` should be disabled.

## Summary
Disabled the autocomplete popup suggestions in the macro editor while keeping the `\` hybrid command mode functional.

## Issue Found
When editing macros in the macro editor, typing `\` would trigger the command mode  `⟨\⟩` with a popup of autocomplete suggestions.

## Changes
Modified `src/Edit/Interface/edit_source.cpp`:

```cpp
// Disable autocomplete options in the macro editor
string buf_name= as_string (buf->buf->name);
if ((starts (buf_name, "tmfs://aux/edit-") &&
     buf_name != "tmfs://aux/edit-shortcuts" &&
     !starts (buf_name, "tmfs://aux/edit-comment")) ||
    buf_name == "tmfs://aux/macro-editor") {
  return;
}
```

### How to test
1. Open Mogan Editor.
2. Open the macro editor via **Tools → Macros → New macro or Edit macros**.
3. Press the `\` key and begin typing.
4. **Verify**:
   - The `⟨\⟩` bracketed tag (hybrid command mode) appears correctly.
   - *No* autocomplete suggestion popup appears while typing.
5. Test in a normal document:
   - **Verify**: The `\` key triggers the hybrid command mode completely, and autocomplete functions as normal.
6. Test in search/replace window:
   - **Verify**: The `\` key triggers the hybrid command mode completely, and autocomplete functions as normal.

https://github.com/user-attachments/assets/5ff49c4c-5734-40b6-b7a1-b3cea03d0507
