### PR TITLE
[222_53] added chinese translation for 'Insert rectangles'

### DIFF
--- a/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
+++ b/TeXmacs/plugins/lang/dic/en_US/zh_CN.scm
@@ -1140,6 +1140,7 @@
 ("insert plain text" "插入纯文本")
 ("insert points" "插入点")
 ("insert polygons" "插入多边形")
+("insert rectangles" "插入矩形")
 ("insert right" "在右侧插入列")
 ("insert row above" "在上方插入行")
 ("insert row below" "在下方插入行")

--- a/devel/222_53.md
+++ b/devel/222_53.md
@@ -1,0 +1,20 @@
+# 222_51 Translate 'Insert rectangles' into chinese
+
+### What
+Translates the tooltip `Insert rectangles` found at `Insert -> Image -> Draw Image -> Hover over rectangle option in toolbar`
+
+### Why
+The option is in plain english and needs to be translated into chinese.
+
+### How
+In `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` added the translation:
+
+```diff
++  ("insert rectangles" "插入矩形")
+```
+
+## How to test
+1. Open Mogan and click on `插入` or `Insert`
+2. Go to `图片` or `Image`
+3. Click on `绘制图形` or `Draw Image`
+3. In the toolbar, hover over the rectangle option. Check `Insert rectangles` has been translated into `插入矩形`


### PR DESCRIPTION
Fixes #2797 
Add translation for 'Insert rectangles'

## Summary
Translates the tooltip `Insert rectangles` found at `Insert -> Image -> Draw Image -> Hover over rectangle option in toolbar`

**Developer document:** `devel/222_53.md`

## Issue Found
The option is in plain english and needs to be translated into chinese.

## Changes
In `TeXmacs/plugins/lang/dic/en_US/zh_CN.scm` added the translation:

```diff
+  ("insert rectangles" "插入矩形")
```

## How to test
1. Open Mogan and click on `插入` or `Insert`
2. Go to `图片` or `Image`
3. Click on `绘制图形` or `Draw Image`
3. In the toolbar, hover over the rectangle option. Check `Insert rectangles` has been translated into `插入矩形`

## Before
<img width="1226" height="379" alt="Screenshot 2026-03-07 113121" src="https://github.com/user-attachments/assets/02bab72c-b2a4-4d9d-b3dd-eee420835c05" />

## After
<img width="1269" height="298" alt="Screenshot 2026-03-07 113511" src="https://github.com/user-attachments/assets/7e9fd975-4bb1-4df6-8c8f-05d4345dbc94" />
