### PR TITLE
[201_94]: Fix slink bare URL redirect without HTTPS (#2324)

### DIFF
--- a/TeXmacs/progs/link/link-navigate.scm
+++ b/TeXmacs/progs/link/link-navigate.scm
@@ -497,12 +497,27 @@
   ; TODO: jump to anchors in HTML
   (noop))
 
+(define (url-looks-like-bare-domain? u)
+  "Check if a default-rooted URL looks like a bare domain (e.g. liiistem.cn)"
+  (let* ((s (url->system u)))
+    (and (not (string-null? s))
+         (not (string-starts? s "/"))
+         (not (string-starts? s "."))
+         (not (string-starts? s "~"))
+         (not (string-index s #\space))
+         (not (string-index s #\/))
+         (string-index s #\.)
+         (not (url-exists? (url-expand u))))))
+
 (define (default-root-handler u)
   (cond ((and (url-rooted-protocol? u "default")
               (url-rooted-web? (current-buffer)))
          (default-root-handler (url-relative (current-buffer) u)))
         ((url-or? (url-expand u))
          (default-root-disambiguator (url-expand u)))
+        ((url-looks-like-bare-domain? u)
+         (with web-url (system->url (string-append "https://" (url->system u)))
+           (http-root-handler web-url)))
         (else
          (with (base qry) (process-url u)
            (if (!= "" (url->system base))
@@ -546,33 +561,12 @@
         (and (resolve-id id)
              (delayed (:idle 25) (apply go-to-id (cons id opt-from)))))))
 
-(define (url-string-has-protocol? s)
-  "Check if a string already has a URL protocol prefix"
-  (or (string-starts? s "http://")
-      (string-starts? s "https://")
-      (string-starts? s "ftp://")
-      (string-starts? s "file://")
-      (string-starts? s "tmfs://")
-      (string-starts? s "blank://")))
-
-(define (url-string-looks-like-web? s)
-  "Check if a string looks like a bare web URL without protocol"
-  (and (not (url-string-has-protocol? s))
-       (not (string-starts? s "/"))
-       (not (string-starts? s "."))
-       (not (string-starts? s "~"))
-       (not (string-starts? s "#"))
-       (string-index s #\.)
-       (not (url-exists? (system->url s)))))
-
 (tm-define (go-to-url u . opt-from)
   (:synopsis "Jump to the url @u")
   (:argument opt-from "Optional path for the cursor history")
   (if (nnull? opt-from) (cursor-history-add (car opt-from)))
-  (when (and (string? u) (url-string-looks-like-web? u))
-    (set! u (string-append "https://" u)))
   (if (string? u) (set! u (system->url u)))
-  (with (action post) (url-handlers u) 
+  (with (action post) (url-handlers u)
     (action u) (post u))
   (if (nnull? opt-from) (cursor-history-add (cursor-path))))
 

--- a/devel/201_94.md
+++ b/devel/201_94.md
@@ -5,6 +5,18 @@
 1. Type `slink`, press Enter, enter URL `liiistem.cn`
 2. Ctrl+click the rendered link
 3. Expected: browser opens `https://liiistem.cn`
+4. Create a file `notes.pdf` next to the document, link to it via slink with `notes.pdf`
+5. Ctrl+click — expected: opens the local file, NOT `https://notes.pdf`
+
+## 2026/03/15 Move bare domain detection into default-root-handler
+### What
+Bare domains like `liiistem.cn` in slinks now open in the browser, while file links like `notes.pdf` still resolve correctly as local files.
+
+### Why
+The previous approach (prepending `https://` early in `go-to-url`) could misidentify file paths as web URLs because it checked file existence against the working directory, not relative to the current document. Moving the check into `default-root-handler` ensures file resolution (including relative paths) is attempted first.
+
+### How
+Added `url-looks-like-bare-domain?` check in `default-root-handler` (link-navigate.scm). The check runs only after relative path resolution has been attempted, and only matches strings that have no slashes, contain a dot, and don't resolve to an existing file via `url-expand`.
 
 ## 2026/03/07 Prepend https:// for bare domain URLs in slink
 ### What


### PR DESCRIPTION
## Problem
When typing `slink` and entering a bare domain like `liiistem.cn` (without `https://`), Ctrl+clicking the link does nothing. The URL is treated as a local file path because `go-to-url` routes it through `default-root-handler`, which fails to find any local file.

## Fix
Added detection of bare domain-like URLs in `go-to-url` (`TeXmacs/progs/link/link-navigate.scm`). When the input string:
- Has no protocol prefix (`http://`, `https://`, etc.)
- Is not a file path (doesn't start with `/`, `.`, `~`, `#`)
- Contains a dot (`.`)
- Does not exist as a local file

...then `https://` is automatically prepended before URL routing.

## How to test
1. Type `slink`, press Enter, enter `liiistem.cn`
2. Ctrl+click the rendered link
3. Browser should open `https://liiistem.cn`

Also verify these still work correctly:
- `https://liiistem.cn` — unchanged, opens normally
- `www.google.com` — opens as `https://www.google.com`
- `./local-file.tm` — not affected (relative path)

Closes #2324