### PR TITLE
Align TEXMACS_HOME_PATH Fallbacks With XDG/Platform Defaults (fixes #771 path inconsistency)

### DIFF
--- a/src/System/Boot/init_texmacs.cpp
+++ b/src/System/Boot/init_texmacs.cpp
@@ -300,14 +300,22 @@ init_main_paths () {
   url default_path;
 #if defined(OS_MINGW) || defined(OS_WIN)
   default_path= get_env ("APPDATA") * "/" * PREFIX_DIR;
+#elif defined(OS_MACOS)
+  default_path= get_env ("HOME") * "/Library/Application Support/" *
+                PREFIX_DIR;
+#elif defined(OS_WASM)
+  default_path= string ("/.") * PREFIX_DIR;
 #else
-  default_path= "~/.TeXmacs";
+  string xdg_data_home= get_env ("XDG_DATA_HOME");
+  if (is_empty (xdg_data_home)) xdg_data_home= get_env ("HOME") * "/.local/share";
+  default_path= xdg_data_home * "/" * PREFIX_DIR;
 #endif
   url home_path= get_env_path ("TEXMACS_HOME_PATH", default_path);
   if (is_none (home_path)) {
     boot_error << "\n";
     boot_error << "Installation problem: please send a bug report.\n";
-    boot_error << "'TEXMACS_HOME_PATH' could not be set to '~/.TeXmacs'.\n";
+    boot_error <<
+        "'TEXMACS_HOME_PATH' could not be set to the default user data path.\n";
     boot_error << "You may try to set this environment variable manually\n";
     boot_error << "\n";
     TM_FAILED ("installation problem");

--- a/src/System/Misc/data_cache.cpp
+++ b/src/System/Misc/data_cache.cpp
@@ -212,8 +212,20 @@ cache_refresh () {
 void
 cache_initialize () {
   texmacs_path= url_system ("$TEXMACS_PATH");
-  if (get_env ("TEXMACS_HOME_PATH") == "")
-    texmacs_home_path= url_system ("$HOME/.TeXmacs");
+  if (get_env ("TEXMACS_HOME_PATH") == "") {
+#if defined(OS_MINGW) || defined(OS_WIN)
+    texmacs_home_path= url_system (string ("$APPDATA/") * PREFIX_DIR);
+#elif defined(OS_MACOS)
+    texmacs_home_path= url_system (string ("$HOME/Library/Application Support/") *
+                                   PREFIX_DIR);
+#elif defined(OS_WASM)
+    texmacs_home_path= url_system (string ("/.") * PREFIX_DIR);
+#else
+    string xdg_data_home= get_env ("XDG_DATA_HOME");
+    if (is_empty (xdg_data_home)) xdg_data_home= "$HOME/.local/share";
+    texmacs_home_path= url_system (xdg_data_home * "/" * PREFIX_DIR);
+#endif
+  }
   else texmacs_home_path= url_system ("$TEXMACS_HOME_PATH");
   if (get_env ("TEXMACS_DOC_PATH") == "")
     texmacs_doc_path= url_system ("$TEXMACS_PATH/doc");

--- a/src/System/Misc/tm_sys_utils.cpp
+++ b/src/System/Misc/tm_sys_utils.cpp
@@ -108,7 +108,21 @@ url
 get_texmacs_home_path () {
   string path= get_env ("TEXMACS_HOME_PATH");
   if (is_empty (path)) {
-    path= "$HOME/.TeXmacs";
+    if (os_mingw () || os_win ()) {
+      path= get_env ("APPDATA") * "/" * PREFIX_DIR;
+    }
+    else if (os_macos ()) {
+      path= get_env ("HOME") * "/Library/Application Support/" * PREFIX_DIR;
+    }
+    else if (os_wasm ()) {
+      path= string ("/.") * PREFIX_DIR;
+    }
+    else {
+      string xdg_data_home= get_env ("XDG_DATA_HOME");
+      if (is_empty (xdg_data_home))
+        xdg_data_home= get_env ("HOME") * "/.local/share";
+      path= xdg_data_home * "/" * PREFIX_DIR;
+    }
   }
   return url_system (path);
 }


### PR DESCRIPTION
### Summary
This PR fixes an inconsistency in home-path fallback behavior that was still relevant to issue #771 (plugin/user data location policy).

Some startup and cache code paths still defaulted to `~/.TeXmacs`, while newer logic uses platform-specific/XDG-compliant locations. This caused mismatched behavior for plugin and user-data directories, especially on Linux.

---

### What changed
- Updated startup default path selection in `init_texmacs.cpp`.
- Updated `get_texmacs_home_path()` fallback in `tm_sys_utils.cpp`.
- Updated cache initialization fallback in `data_cache.cpp`.

---

### New fallback behavior

- **Windows:** `$APPDATA/<PREFIX_DIR>`
- **macOS:** `$HOME/Library/Application Support/<PREFIX_DIR>`
- **Linux/Unix:** `$XDG_DATA_HOME/<PREFIX_DIR>`  
  *(fallback: `$HOME/.local/share/<PREFIX_DIR>`)*

- **wasm:** `./<PREFIX_DIR>`

---

### Why this matters

- Keeps plugin and user-data paths consistent across startup/runtime/cache code.
- Removes legacy `~/.TeXmacs` fallback behavior that conflicts with XDG-based policy.
- Reduces cross-platform path surprises and aligns with the direction discussed in #771.

---

### Validation

- File diagnostics for modified files: **no errors**.
- `src/**` no longer contains `~/.TeXmacs` / `$HOME/.TeXmacs` fallbacks.