### PR TITLE
[201_95] Fix #2769: Enable keyboard navigation into bibliography sections

### DIFF
--- a/TeXmacs/progs/generic/generic-edit.scm
+++ b/TeXmacs/progs/generic/generic-edit.scm
@@ -29,6 +29,22 @@
   (and-with p (tree-outer t)
     (kbd-horizontal p forwards?)))
 
+(tm-define (kbd-horizontal t forwards?)
+  (:require (bibliography-context? t))
+  (cond
+    ;; When moving right and cursor is before the bibliography
+    ((and forwards? (tree-at-start? t))
+     (tree-go-to t :down :start))
+    
+    ;; When moving left and cursor is at the start inside bibliography
+    ((and (not forwards?) (tree-at-start? t :down))
+     (tree-go-to t :start))
+    
+    ;; Otherwise, use default navigation
+    (else
+     (and-with p (tree-outer t)
+       (kbd-horizontal p forwards?)))))
+
 (tm-define (kbd-vertical t downwards?)
   (and-with p (tree-outer t)
     (kbd-vertical p downwards?)))
@@ -514,6 +530,13 @@ TODO: 在文本模式中，可以自动识别剪贴板中的内容，并智能�
 
 (tm-define (focus-can-search? t) #f)
 (tm-define (focus-has-search-menu? t) #f)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Bibliography context predicate
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(tm-define (bibliography-context? t)
+  (tree-in? t '(bibliography bibliography* thebibliography bib-list)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tree traversal

--- a/devel/201_95.md
+++ b/devel/201_95.md
@@ -1,0 +1,54 @@
+# [201_95] 修复参考文献键盘导航问题
+
+## 如何测试
+1. 启动 Mogan，新建文档
+2. 插入参考文献：Insert → Automatic → Bibliography
+3. 将光标定位到参考文献前面
+4. 按右箭头键，光标应该能够进入参考文献内部
+5. 按左箭头键，光标应该能够退出参考文献
+
+## 2026/03/10 实现参考文献键盘导航功能
+
+### What
+修复 GitHub Issue #2769：无法使用右箭头键进入参考文献部分。用户在参考文献前按右箭头键时，光标无法进入参考文献内部进行编辑。
+
+### Why
+Mogan 编辑器使用特殊的导航系统处理复合结构，但参考文献部分（通过 `is_aux` 函数识别为辅助内容）被排除在水平键盘导航之外。这限制了用户使用键盘编辑包含参考文献内容的文档的能力。
+
+参考文献在 C++ 代码中被 `is_aux` 函数标识为辅助内容，导致标准的键盘导航被阻止。需要在 Scheme 层添加特殊的导航处理器来覆盖这种行为。
+
+### How
+在 `generic-edit.scm` 中添加参考文献的键盘导航支持：
+
+1. **添加参考文献上下文判断函数**：
+   ```scheme
+   (tm-define (bibliography-context? t)
+     (tree-in? t '(bibliography bibliography* thebibliography bib-list)))
+   ```
+
+2. **添加 kbd-horizontal 导航处理器**：
+   ```scheme
+   (tm-define (kbd-horizontal t forwards?)
+     (:require (bibliography-context? t))
+     (cond
+       ;; 向右移动且光标在参考文献前面时，进入参考文献
+       ((and forwards? (tree-at-start? t))
+        (tree-go-to t :down :start))
+       
+       ;; 向左移动且光标在参考文献内部开始位置时，退出参考文献
+       ((and (not forwards?) (tree-at-start? t :down))
+        (tree-go-to t :start))
+       
+       ;; 其他情况使用默认导航
+       (else
+        (and-with p (tree-outer t)
+          (kbd-horizontal p forwards?)))))
+   ```
+
+3. **支持多种参考文献标签**：
+   - `bibliography`：空参考文献占位符
+   - `bibliography*`：带星号的参考文献
+   - `thebibliography`：LaTeX 风格参考文献
+   - `bib-list`：渲染后的参考文献
+
+该实现遵循 `generic-edit.scm` 中其他复合结构的现有导航模式，确保与现有导航行为的一致性，同时不影响非参考文献内容的导航。


### PR DESCRIPTION
[201_95] Fix #2769: Enable keyboard navigation into bibliography sections

## Problem
Users cannot navigate into bibliography/reference sections using the right arrow key. When the cursor is positioned before a bibliography element and the user presses the right arrow key, the cursor remains stuck outside the bibliography instead of entering it, making it impossible to edit bibliographic content using keyboard navigation.

## Solution
Added keyboard navigation handler in the Scheme layer (`generic-edit.scm`) to enable horizontal navigation for bibliography sections.

## Changes
- **File**: `mogan/TeXmacs/progs/generic/generic-edit.scm`
- **Documentation**: `mogan/devel/201_94.md` (following Mogan contribution guidelines)
- Added `bibliography-context?` predicate function to identify bibliography sections
- Added `kbd-horizontal` handler with `:require (bibliography-context? t)` guard
- Supports tags: `bibliography`, `bibliography*`, `thebibliography`, `bib-list`

## Implementation Details
The fix follows the existing pattern used for other compound structures in `generic-edit.scm`:
- When cursor is before bibliography and user presses right arrow → enters the section
- When cursor is at start inside bibliography and user presses left arrow → exits the section
- Otherwise → delegates to parent navigation handler

### Code Added

```scheme
;; Bibliography context predicate
(tm-define (bibliography-context? t)
  (tree-in? t '(bibliography bibliography* thebibliography bib-list)))

;; Keyboard horizontal navigation for bibliography
(tm-define (kbd-horizontal t forwards?)
  (:require (bibliography-context? t))
  (cond
    ;; When moving right and cursor is before the bibliography
    ((and forwards? (tree-at-start? t))
     (tree-go-to t :down :start))
    
    ;; When moving left and cursor is at the start inside bibliography
    ((and (not forwards?) (tree-at-start? t :down))
     (tree-go-to t :start))
    
    ;; Otherwise, use default navigation
    (else
     (and-with p (tree-outer t)
       (kbd-horizontal p forwards?)))))
```

## Testing
-  Code builds successfully without errors
-  Syntax validated
-  Logic follows existing navigation patterns in `generic-edit.scm`
- Supports multiple bibliography tag types:
  - `bibliography` (empty placeholder)
  - `bibliography*` (starred variant)
  - `thebibliography` (LaTeX style)
  - `bib-list` (rendered bibliography)

### Test Steps
1. Create a new document
2. Insert → Automatic → Bibliography
3. Position cursor before the bibliography element
4. Press RIGHT ARROW → cursor should enter the bibliography
5. Press LEFT ARROW → cursor should exit back outside

## Documentation
Added `mogan/devel/201_95.md` following the official Mogan contribution guidelines:
## Related Issue
Fixes #2769