### PR TITLE
[222_54] fix: override tooltip to Toggle cell alignment in tabular context only.

### DIFF
--- a/TeXmacs/progs/table/table-menu.scm
+++ b/TeXmacs/progs/table/table-menu.scm
@@ -668,3 +668,19 @@
 	((balloon (icon "tm_cell_join.xpm")
 		  "Join selected cells")
 	 (cell-set-span-selection)))))
+
+(tm-define (alternate-first-icon t)
+  (:require (table-markup-context? t))
+  "tm_cell_left.xpm")
+
+(tm-define (alternate-second-icon t)
+  (:require (table-markup-context? t))
+  "tm_cell_center.xpm")
+
+(tm-define (alternate-first-name t)
+  (:require (table-markup-context? t))
+  "Toggle cell alignment")
+
+(tm-define (alternate-second-name t)
+  (:require (table-markup-context? t))
+  "Toggle cell alignment")

--- a/devel/222_54.md
+++ b/devel/222_54.md
@@ -1,0 +1,14 @@
+# 222_54 fix: override tooltip to Toggle cell alignment in tabular context only
+
+## How to test
+Open a tabular table in Mogan. Place cursor inside a cell. Check the focus toolbar - the toggle button should now show the correct cell alignment icon (tm_cell_left or tm_cell_center) and tooltip "Toggle cell alignment" instead of the misleading "Toggle numbering".
+
+## 2026/03/12 fix: override alternate icons and names in tabular context
+### What
+Override `alternate-first-icon`, `alternate-second-icon`, `alternate-first-name` and `alternate-second-name` in `table-menu.scm` to show correct cell alignment icons and tooltip when inside a tabular context.
+
+### Why
+The button was using `tm_numbered.xpm` with tooltip "Toggle numbering" but it actually toggles cell alignment (tabular vs tabular*). This was misleading to users.
+
+### How
+Used `tm-define` with `(:require (table-markup-context? t))` to override the icon and name functions only inside tabular context in `table-menu.scm`.


### PR DESCRIPTION
Fixes #2852

The tooltip "Toggle numbering" was misleading - the button actually toggles cell alignment (tabular vs tabular*). Override alternate-first-icon, alternate-second-icon, alternate-first-name and alternate-second-name in table-menu.scm to show correct icons and tooltip only in tabular context using table-markup-context?.