### PR TITLE
[201_96] fix: accent marks tooltip shows option key ⌥ on macOS

### DIFF
--- a/devel/201_96.md
+++ b/devel/201_96.md
@@ -1,0 +1,28 @@
+# [201_96] fix: accent marks tooltip shows option key ⌥ on macOS
+
+## How to Test
+
+1. Open Mogan on macOS.
+2. Enter math mode and open the accent insert popup (click the `~` accent button in the toolbar).
+3. Hover over any accent button (e.g., the tilde accent `tm_tilda.xpm`).
+4. The tooltip should display `等效快捷键: (⌥ ~)` — the Option key symbol ⌥ followed by `~`.
+5. Previously it showed a wrong symbol (⊙) instead of ⌥.
+
+## 2026/03/16 Fix macOS accent tooltip displaying ⊙ instead of ⌥
+
+### What
+Remove the `A-` → `escape` conversion in `kbd_system_prevails` in
+`src/Texmacs/Server/tm_config.cpp`.
+
+### Why
+On macOS, `kbd_system_prevails` was converting `"A-~"` (Option+~) to
+`"escape ~"` for tooltip display. The Escape key symbol (⎋, U+238B) was
+then shown instead of the Option key symbol (⌥, U+2325), appearing as ⊙
+in the apple-lucida font rendering at small size. Since Mogan on macOS
+uses the Option key (A-) as the accent modifier, the tooltip should show
+⌥ directly.
+
+### How
+Simplified `kbd_system_prevails` to return the input string unchanged.
+Now `"A-~"` is decoded by `system_kbd_initialize` as `"<#2325>"` (⌥),
+giving the correct tooltip `(⌥ ~)`.

--- a/src/Texmacs/Server/tm_config.cpp
+++ b/src/Texmacs/Server/tm_config.cpp
@@ -326,18 +326,7 @@ kbd_render (tree t) {
 }
 
 static string
-kbd_system_prevails (string s) {
-  string laf= get_preference ("look and feel");
-  bool   mac= os_macos () && (laf == "default" || laf == "macos");
-  if (mac && starts (s, "A-")) {
-    string ss= s (2, N (s));
-    string r = "escape " * ss;
-    if (starts (ss, "S-")) ss= ss (2, N (ss));
-    if (N (ss) == 1) return r;
-    else return s;
-  }
-  else return s;
-}
+kbd_system_prevails (string s) { return s; }
 
 tree
 tm_config_rep::kbd_system_rewrite (string s) {


### PR DESCRIPTION
## Summary

Fixes #2962

- On macOS, the keyboard shortcut tooltip for accent marks (e.g. the tilde accent `~`) was showing a wrong symbol (⊙) instead of the Option key symbol ⌥
- Root cause: `kbd_system_prevails` in `tm_config.cpp` was converting `"A-~"` (Option+~) to `"escape ~"` for display, causing the Escape key symbol to render as ⊙ in the apple-lucida font at small size
- Fix: simplified `kbd_system_prevails` to return the input unchanged, so `A-` is decoded as `⌥` (U+2325) via the existing macOS keyboard map

## Test plan

- [ ] Open Mogan on macOS
- [ ] Enter math mode and open the accent insert popup
- [ ] Hover over the tilde accent button
- [ ] Verify tooltip shows `等效快捷键: (⌥ ~)` with the correct Option key symbol ⌥ instead of ⊙
