### PR TITLE
[222_56] Fix missing macOS tiling menu options on zoom button

### DIFF
--- a/3rdparty/qwindowkitty/src/core/contexts/cocoawindowcontext.mm
+++ b/3rdparty/qwindowkitty/src/core/contexts/cocoawindowcontext.mm
@@ -332,6 +332,7 @@ namespace QWK {
         // System title bar
         void setSystemTitleBarVisible(const bool visible) {
             auto nswindow = [nsview window];
+            [nswindow setCollectionBehavior:[nswindow collectionBehavior] | NSWindowCollectionBehaviorFullScreenPrimary];
             if (!nswindow) {
                 return;
             }
@@ -348,8 +349,6 @@ namespace QWK {
             nswindow.hasShadow = YES;
             // nswindow.showsToolbarButton = NO;
             nswindow.movableByWindowBackground = NO;
-            nswindow.movable = NO; // This line causes the window in the wrong position when
-                                   // become fullscreen.
             [nswindow standardWindowButton:NSWindowCloseButton].hidden = NO;
             [nswindow standardWindowButton:NSWindowMiniaturizeButton].hidden = NO;
             [nswindow standardWindowButton:NSWindowZoomButton].hidden = NO;

--- a/devel/222_56.md
+++ b/devel/222_56.md
@@ -1,0 +1,13 @@
+# #2771 Fix missing macOS tiling menu options on zoom button
+
+### What
+Restores the native macOS tiling hover menu (including "Move & Resize", "Fill & Arrange", and "Enter Full Screen") when hovering over the window's green zoom button.
+
+### Why
+The window was explicitly marked as non-movable (`nswindow.movable = NO`), which caused macOS to disable part of the native window-management menu. In addition, the window was not explicitly marked as participating in Split View.
+
+### How
+Updated `3rdparty/qwindowkitty/src/core/contexts/cocoawindowcontext.mm`:
+
+1. Removed `nswindow.movable = NO`.
+2. Added `NSWindowCollectionBehaviorFullScreenPrimary` to the window's collection behavior so it participates in macOS Split View and tiling.


### PR DESCRIPTION
Fixes #2771

## What
Restores the native macOS tiling hover menu (including "Move & Resize", "Fill & Arrange", and "Enter Full Screen") when hovering over the window's green zoom button.

Before:
<img width="350" height="220" alt="Screenshot 2026-03-16 at 4 28 10 AM" src="https://github.com/user-attachments/assets/e0a76600-3b74-4ad7-b332-914fc38426ff" />

After:
<img width="488" height="298" alt="Screenshot 2026-03-16 at 4 27 31 AM" src="https://github.com/user-attachments/assets/e97b57f6-5722-4a09-a311-60e0c4a45e7e" />



### How
Updated `3rdparty/qwindowkitty/src/core/contexts/cocoawindowcontext.mm`:

1. Removed `nswindow.movable = NO`.
2. Added `NSWindowCollectionBehaviorFullScreenPrimary` so the window participates in macOS Split View and tiling.