### PR TITLE
[203_26] Use standard LaTeX proof environment for semantic proof blocks

### DIFF
--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-define.scm
@@ -563,13 +563,9 @@
 
 (smart-table latex-texmacs-environment
   ("proof"
-   (!append (noindent) (textbf (!append (!translate "Proof") "\\ "))
-            ---
-            (hspace* (fill)) (!math (Box)) (medskip)))
+   ((!begin "proof") ---))
   ("proof*"
-   (!append (noindent) (textbf (!append 1 "\\ "))
-            ---
-            (hspace* (fill)) (!math (Box)) (medskip)))
+   ((!begin "proof" (!option 1)) ---))
   ("leftaligned"
    ((!begin "flushleft") ---))
   ("rightaligned"

--- a/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/plugins/latex/progs/convert/latex/latex-drd.scm
@@ -55,6 +55,7 @@
   (!verbatim "alltt")
   (!verbatim* "alltt")
   (begin-alltt "alltt")
+  (begin-proof "amsthm")
 
   (begin-tabularx "tabularx")
 

--- a/TeXmacs/progs/convert/latex/latex-define.scm
+++ b/TeXmacs/progs/convert/latex/latex-define.scm
@@ -563,13 +563,9 @@
 
 (smart-table latex-texmacs-environment
   ("proof"
-   (!append (noindent) (textbf (!append (!translate "Proof") "\\ "))
-            ---
-            (hspace* (fill)) (!math (Box)) (medskip)))
+   ((!begin "proof") ---))
   ("proof*"
-   (!append (noindent) (textbf (!append 1 "\\ "))
-            ---
-            (hspace* (fill)) (!math (Box)) (medskip)))
+   ((!begin "proof" (!option 1)) ---))
   ("leftaligned"
    ((!begin "flushleft") ---))
   ("rightaligned"

--- a/TeXmacs/progs/convert/latex/latex-drd.scm
+++ b/TeXmacs/progs/convert/latex/latex-drd.scm
@@ -55,6 +55,7 @@
   (!verbatim "alltt")
   (!verbatim* "alltt")
   (begin-alltt "alltt")
+  (begin-proof "amsthm")
 
   (begin-tabularx "tabularx")
 

--- a/devel/203_26.md
+++ b/devel/203_26.md
@@ -1,0 +1,16 @@
+# #2985 When proving semantic blocks to export PDF, use \begin{proof} \end{proof}
+
+## 2026/03/16 Update LaTeX export for semantic proof blocks
+
+### What
+Updated the LaTeX export logic for `proof` and `proof*` environments to use the standard LaTeX `proof` environment (from `amsthm`) instead of manual formatting.
+
+### Why
+- **Semantic Correctness**: Moves from visual imitation (`\noindent\textbf{...}`) to logical LaTeX environments.
+- **Improved Maintenance**: Uses standard structures that align with typical LaTeX theorem environments.
+- **Global Styling**: Follows the document class and global `amsthm` settings for QED box placement and labels.
+
+### How
+- Modified `latex-define.scm` (core and plugin) to map `proof` to `\begin{proof}` and `proof*` to `\begin{proof}[Title]`.
+- Added dependency on `amsthm` package in `latex-drd.scm` (core and plugin) to ensure it's automatically included in the preamble.
+


### PR DESCRIPTION
Fixes #2985 

### What
Updated the LaTeX export logic for `proof` and `proof*` environments to use the standard LaTeX `proof` environment (from `amsthm`) instead of manual formatting.

Before:
<img width="412" height="165" alt="Screenshot 2026-03-16 at 5 03 59 PM" src="https://github.com/user-attachments/assets/7ac35b2f-6498-4c0c-8096-d26f7633d61c" />

After:
<img width="337" height="178" alt="Screenshot 2026-03-16 at 5 02 45 PM" src="https://github.com/user-attachments/assets/1698cb31-7605-47a0-8f54-651a6d99d775" />

### How
- Modified `latex-define.scm` (core and plugin) to map `proof` to `\begin{proof}` and `proof*` to `\begin{proof}[Title]`.
- Added dependency on the `amsthm` package in `latex-drd.scm` (core and plugin) to ensure the proof environment is available in the exported document.
