### PR TITLE
[200_27] Fix Proof Block Formatting issue in PDF export

### DIFF
--- a/TeXmacs/progs/convert/latex/tmtex.scm
+++ b/TeXmacs/progs/convert/latex/tmtex.scm
@@ -2642,7 +2642,7 @@
   (tex-concat (list (list 'item (list '!option (tmtex (car l)))) " ")))
 
 (define (tmtex-render-proof s l)
-  (list (list '!begin "proof*" (tmtex (car l))) (tmtex (cadr l))))
+  (list (list '!begin "proof") (tmtex (cadr l)) (list '!end "proof")))
 
 (define (tmtex-nbsp s l)
   '(!nbsp))


### PR DESCRIPTION
fixes #2985

- Change proof environment from custom LaTeX format to standard proof environment
- Use standard LaTeX proof environment instead of handwritten format
- Ensure compatibility with amsthm package, automatically handle QED symbol

Before fix: \noindent\textbf{Proof}\ \hspace*{\fill}$\Box$\medskip
After fix: \begin{proof}...\end{proof}