### PR TITLE
[222_63] Remove unnecessary floating text toolbar label when selecting the text

### DIFF
--- a/devel/222_63.md
+++ b/devel/222_63.md
@@ -1,0 +1,14 @@
+
+# #3019 Remove Redundant Text Toolbar Label
+
+### 2026/03/20 Removed Redundant "Text Toolbar" Label
+
+### What
+Removed the hardcoded "文本工具栏" (Text Toolbar) label from the floating text toolbar.
+
+### Why
+The label is unnecessary since the toolbar is self-explanatory through icons and does not respect UI language settings.
+
+### How
+- Removed the QLabel creation in `QTMTextToolbar::rebuildButtonsFromScheme()`
+- Removed unused `#include <QLabel>`

--- a/src/Plugins/Qt/QTMTextToolbar.cpp
+++ b/src/Plugins/Qt/QTMTextToolbar.cpp
@@ -25,7 +25,6 @@
 #include <QGuiApplication>
 #include <QHelpEvent>
 #include <QIcon>
-#include <QLabel>
 #include <QLayoutItem>
 #include <QPainter>
 #include <QPen>
@@ -86,9 +85,6 @@ QTMTextToolbar::clearButtons () {
 void
 QTMTextToolbar::rebuildButtonsFromScheme () {
   clearButtons ();
-  QLabel* placeholder= new QLabel ("文本工具栏", this);
-  placeholder->setAlignment (Qt::AlignCenter);
-  layout->addWidget (placeholder);
   autoSize ();
 }
 


### PR DESCRIPTION
Fixes #3019 

### What
Removed the hardcoded "文本工具栏" (Text Toolbar) label from the floating text toolbar.
 
Before:
<img width="281" height="91" alt="Screenshot 2026-03-20 at 3 09 55 PM" src="https://github.com/user-attachments/assets/ec37e232-427f-44a9-a6f1-178392db50ea" />

After:
<img width="353" height="167" alt="Screenshot 2026-03-20 at 3 19 26 PM" src="https://github.com/user-attachments/assets/e7ae048c-e276-4d6f-9fb2-21e1f0e516fa" />

### Fix
1. Removed the QLabel creation in QTMTextToolbar::rebuildButtonsFromScheme()
2. Removed unused #include <QLabel>