### PR TITLE
[201_105] Fix unclear keyboard shortcut keys in dark mode

### DIFF
--- a/TeXmacs/packages/documentation/standard/tmdoc-gui.ts
+++ b/TeXmacs/packages/documentation/standard/tmdoc-gui.ts
@@ -28,7 +28,15 @@
     </src-comment>
   </active*>
 
-  <assign|render-key|<macro|key|<active*|<move|<small|<with|font-family|tt|<with|ornament-color|#e0e0e0|ornament-sunny-color|#f0f0f0|ornament-shadow-color|#c0c0c0|ornament-hpadding|2ln|ornament-vpadding|2ln|ornament-border|2ln|<ornament|<compound|inflate|<arg|key>>>>>>||0.075ex>>>>
+  <assign|render-key-color|black>
+
+  <assign|render-key-bg-color|#e0e0e0>
+
+  <assign|render-key-sunny-color|#f0f0f0>
+
+  <assign|render-key-shadow-color|#c0c0c0>
+
+  <assign|render-key|<macro|key|<active*|<move|<small|<with|font-family|tt|<with|color|<value|render-key-color>|ornament-color|<value|render-key-bg-color>|ornament-sunny-color|<value|render-key-sunny-color>|ornament-shadow-color|<value|render-key-shadow-color>|ornament-hpadding|2ln|ornament-vpadding|2ln|ornament-border|2ln|<ornament|<compound|inflate|<arg|key>>>>>>||0.075ex>>>>
 
   <assign|render-keys|<macro|keys|<extern|tmdoc-render-keys|<quote-arg|keys>>>>
 

--- a/TeXmacs/packages/miscellaneous/shortcut-editor.ts
+++ b/TeXmacs/packages/miscellaneous/shortcut-editor.ts
@@ -30,7 +30,15 @@
     </src-comment>
   </active*>
 
-  <assign|render-key|<macro|key|<active*|<move|<small|<with|font-family|tt|<with|ornament-color|#e0e0e0|ornament-sunny-color|#f0f0f0|ornament-shadow-color|#c0c0c0|ornament-hpadding|2ln|ornament-vpadding|2ln|ornament-border|2ln|<ornament|<compound|inflate|<arg|key>>>>>>||0.075ex>>>>
+  <assign|render-key-color|black>
+
+  <assign|render-key-bg-color|#e0e0e0>
+
+  <assign|render-key-sunny-color|#f0f0f0>
+
+  <assign|render-key-shadow-color|#c0c0c0>
+
+  <assign|render-key|<macro|key|<active*|<move|<small|<with|font-family|tt|<with|color|<value|render-key-color>|ornament-color|<value|render-key-bg-color>|ornament-sunny-color|<value|render-key-sunny-color>|ornament-shadow-color|<value|render-key-shadow-color>|ornament-hpadding|2ln|ornament-vpadding|2ln|ornament-border|2ln|<ornament|<compound|inflate|<arg|key>>>>>>||0.075ex>>>>
 
   <assign|render-keys|<macro|keys|<extern|tmdoc-render-keys|<quote-arg|keys>>>>
 

--- a/TeXmacs/packages/themes/dark/dark.ts
+++ b/TeXmacs/packages/themes/dark/dark.ts
@@ -72,6 +72,14 @@
 
   <assign|toggle-on-hover|<gui-contour*|<toggle-on>>>
 
+  <assign|render-key-color|white>
+
+  <assign|render-key-bg-color|#606060>
+
+  <assign|render-key-sunny-color|#808080>
+
+  <assign|render-key-shadow-color|#404040>
+
   <assign|pre-edit|<macro|body|<with|ornament-color|#707070|ornament-sunny-color|#808080|ornament-shadow-color|#606060|ornament-border|1px|ornament-hpadding|2px|ornament-vpadding|2px|<smash|<ornament|<with|color|white|<arg|body>>>>>>>
 
   <assign|focus-color|#ffffff0e>

--- a/devel/201_105.md
+++ b/devel/201_105.md
@@ -1,0 +1,37 @@
+# [201_105] Fix unclear keyboard shortcut keys in dark mode
+
+### What
+Made keyboard shortcut key caps (e.g. `Ctrl+V`, `Ctrl+Shift+V`) clearly visible in dark/night mode by introducing theme-overridable color variables for the `render-key` macro.
+
+### Why
+In night mode, the `render-key` macro used hardcoded light gray ornament colors (`#e0e0e0`, `#f0f0f0`, `#c0c0c0`) with no explicit text color. The dark theme sets the global text color to white, resulting in white text on a light gray background — making the shortcut keys nearly unreadable in the default startup document and all tmdoc documentation.
+
+### How
+Introduced four theme-overridable variables for the `render-key` macro and added dark mode overrides.
+
+Modified `TeXmacs/packages/documentation/standard/tmdoc-gui.ts` and `TeXmacs/packages/miscellaneous/shortcut-editor.ts`:
+
+Replaced hardcoded colors in `render-key` with variable references:
+- `render-key-color` — text color inside key caps (default: `black`)
+- `render-key-bg-color` — ornament background (default: `#e0e0e0`)
+- `render-key-sunny-color` — ornament highlight (default: `#f0f0f0`)
+- `render-key-shadow-color` — ornament shadow (default: `#c0c0c0`)
+
+Modified `TeXmacs/packages/themes/dark/dark.ts`:
+
+Added dark mode overrides for the key rendering variables:
+- `render-key-color` → `white`
+- `render-key-bg-color` → `#606060`
+- `render-key-sunny-color` → `#808080`
+- `render-key-shadow-color` → `#404040`
+
+### How to test
+1. Open Mogan Editor.
+2. Switch to night/dark mode via **Document → Theme → Dark**.
+3. Open the default startup document or any tmdoc document containing keyboard shortcuts (e.g. `<key|Ctrl+v>`).
+4. **Verify**:
+   - Keyboard shortcut key caps display white text on a medium-gray background.
+   - The key caps are clearly readable against the dark document background.
+5. Switch back to light mode.
+6. **Verify**:
+   - Keyboard shortcut key caps display black text on a light gray background, same as before.


### PR DESCRIPTION
Fixes #3114 

## What
Made keyboard shortcut key caps (e.g. `Ctrl+V`, `Ctrl+Shift+V`) clearly visible in dark/night mode by introducing theme-overridable color variables for the `render-key` macro.

**Developer Document:** `devel/201_105.md`

## Why
In night mode, the `render-key` macro used hardcoded light gray ornament colors (`#e0e0e0`, `#f0f0f0`, `#c0c0c0`) with no explicit text color. The dark theme sets the global text color to white, resulting in white text on a light gray background — making the shortcut keys nearly unreadable in the default startup document and all tmdoc documentation.

## How
Introduced four theme-overridable variables for the `render-key` macro and added dark mode overrides.

Modified `TeXmacs/packages/documentation/standard/tmdoc-gui.ts` and `TeXmacs/packages/miscellaneous/shortcut-editor.ts`:

Replaced hardcoded colors in `render-key` with variable references:
- `render-key-color` — text color inside key caps (default: `black`)
- `render-key-bg-color` — ornament background (default: `#e0e0e0`)
- `render-key-sunny-color` — ornament highlight (default: `#f0f0f0`)
- `render-key-shadow-color` — ornament shadow (default: `#c0c0c0`)

Modified `TeXmacs/packages/themes/dark/dark.ts`:

Added dark mode overrides for the key rendering variables:
- `render-key-color` → `white`
- `render-key-bg-color` → `#606060`
- `render-key-sunny-color` → `#808080`
- `render-key-shadow-color` → `#404040`

## How to test
1. Open Mogan Editor.
2. Switch to night/dark mode via **Document → Theme → Dark**.
3. Open the default startup document or any tmdoc document containing keyboard shortcuts (e.g. `<key|Ctrl+v>`).
4. **Verify**:
   - Keyboard shortcut key caps display white text on a medium-gray background.
   - The key caps are clearly readable against the dark document background.
5. Switch back to light mode.
6. **Verify**:
   - Keyboard shortcut key caps display black text on a light gray background, same as before.
   
## After the fix
   
<img width="1432" height="273" alt="Screenshot 2026-04-13 112226" src="https://github.com/user-attachments/assets/06474a7b-d0a5-40f2-a987-9e49fd601d6f" />

<img width="1431" height="273" alt="Screenshot 2026-04-13 112235" src="https://github.com/user-attachments/assets/642cf057-8870-4884-88ed-4271f0dbc568" />