### PR TITLE
[222_71] 调整快捷键编辑器在黑夜模式下的样式

### DIFF
--- a/TeXmacs/misc/themes/liii-night.css
+++ b/TeXmacs/misc/themes/liii-night.css
@@ -227,7 +227,7 @@ QPushButton:disabled {
 QLineEdit {
   background: #2c2c2c;
   color: #ffffff;
-  border: 1px solid #e0e0e0;
+  border: 1px solid none;
   border-radius: 2px;
   padding: 0px;
 }
@@ -242,7 +242,7 @@ QLineEdit:focus {
 QListView,
 QTableView {
   background: #2c2c2c;
-  border: 1px solid #e0e0e0;
+  border: 1px solid none;
   border-radius: 2px;
 }
 

--- a/TeXmacs/packages/miscellaneous/shortcut-editor.ts
+++ b/TeXmacs/packages/miscellaneous/shortcut-editor.ts
@@ -64,3 +64,4 @@
     <associate|preamble|true>
   </collection>
 </initial>
+

--- a/TeXmacs/packages/miscellaneous/shortcut-editor.ts
+++ b/TeXmacs/packages/miscellaneous/shortcut-editor.ts
@@ -30,7 +30,25 @@
     </src-comment>
   </active*>
 
-  <assign|render-key|<macro|key|<active*|<move|<small|<with|font-family|tt|<with|ornament-color|#e0e0e0|ornament-sunny-color|#f0f0f0|ornament-shadow-color|#c0c0c0|ornament-hpadding|2ln|ornament-vpadding|2ln|ornament-border|2ln|<ornament|<compound|inflate|<arg|key>>>>>>||0.075ex>>>>
+  <assign|shortcut-editor-field-color|<if|<equal|<value|color>|white>|#2c2c2c|white>>
+
+  <assign|shortcut-editor-light-border|<if|<equal|<value|color>|white>|#e0e0e0|#b0b0b0>>
+
+  <assign|shortcut-editor-dark-border|<if|<equal|<value|color>|white>|#e0e0e0|#707070>>
+
+  <assign|bg-color|<value|shortcut-editor-field-color>>
+
+  <assign|canvas-color|<value|shortcut-editor-field-color>>
+
+  <assign|shortcut-key-ornament-color|<value|shortcut-editor-field-color>>
+
+  <assign|shortcut-key-sunny-color|<value|shortcut-editor-light-border>>
+
+  <assign|shortcut-key-shadow-color|<value|shortcut-editor-dark-border>>
+
+  <assign|shortcut-key-border|<if|<equal|<value|color>|white>|1ln|2ln>>
+
+  <assign|render-key|<macro|key|<active*|<move|<small|<with|font-family|tt|<with|ornament-color|<value|shortcut-key-ornament-color>|ornament-sunny-color|<value|shortcut-key-sunny-color>|ornament-shadow-color|<value|shortcut-key-shadow-color>|ornament-hpadding|2ln|ornament-vpadding|2ln|ornament-border|<value|shortcut-key-border>|<ornament|<compound|inflate|<arg|key>>>>>>||0.075ex>>>>
 
   <assign|render-keys|<macro|keys|<extern|tmdoc-render-keys|<quote-arg|keys>>>>
 

--- a/TeXmacs/progs/source/shortcut-widgets.scm
+++ b/TeXmacs/progs/source/shortcut-widgets.scm
@@ -34,6 +34,11 @@
                (tm-func? (tm-ref t 0) 'preview-shortcut 1))
       (tree-set (tm-ref t 0 0) sh))))
 
+(define (shortcut-editor-style)
+  (if (== (get-preference "gui theme") "liii-night")
+      `(style (tuple "generic" "dark" "shortcut-editor"))
+      `(style (tuple "generic" "shortcut-editor"))))
+
 (tm-widget ((shortcuts-editor u) quit)
   (padded
     (horizontal
@@ -54,7 +59,7 @@
           (item (text "Shortcut")
             (resize "350px" "30px"
               (texmacs-input `(document (preview-shortcut ,(global-ref u :sh)))
-                             `(style (tuple "generic" "shortcut-editor")) u)))
+                             (shortcut-editor-style) u)))
           (item (text "Command")
             (refreshable "current-shortcut"
               (input (global-set u :cmd answer) "string"
@@ -91,7 +96,7 @@
         (item (text "Shortcut")
           (resize "250px" "30px"
             (texmacs-input `(document (preview-shortcut ,(global-ref u :sh)))
-                           `(style (tuple "generic" "shortcut-editor")) u)))
+                           (shortcut-editor-style) u)))
         (item (text "Command")
           (refreshable "current-shortcut"
             (input (global-set u :cmd answer) "string"

--- a/devel/222_71.md
+++ b/devel/222_71.md
@@ -1,0 +1,120 @@
+# [222_71] 调整快捷键编辑器在黑夜模式下的样式
+
+## 如何测试
+
+1. 启动程序，并将 GUI theme 切换为 `liii-night`
+2. 打开“快捷键编辑器”
+3. 观察左侧快捷键列表、右侧 `Command` 输入框、以及 `Shortcut` 预览区的颜色是否一致
+4. 重点检查：
+   - `Shortcut` 预览区是否使用 dark 风格
+   - `Shortcut` 里的按键块颜色是否接近 `Command` 输入框
+   - `Shortcut` 预览区上下是否仍然有明显的浅色横线
+
+## 2026/04/22 调整快捷键编辑器黑夜模式样式
+
+### What
+
+当前已经修改的部分：
+
+- 在 `TeXmacs/progs/source/shortcut-widgets.scm` 中新增 `shortcut-editor-style`
+  - 当 `gui theme` 为 `liii-night` 时，`texmacs-input` 使用 `(style (tuple "generic" "dark" "shortcut-editor"))`
+  - 普通主题下仍然使用 `(style (tuple "generic" "shortcut-editor"))`
+  - 对话框版和 side tool 版的 `Shortcut` 输入区都统一走这套逻辑
+
+- 在 `TeXmacs/packages/miscellaneous/shortcut-editor.ts` 中，把原先写死的浅色键帽样式改成了按当前文档前景色切换
+  - 新增 `shortcut-editor-field-color`
+  - 新增 `shortcut-editor-light-border`
+  - 新增 `shortcut-editor-dark-border`
+  - 新增 `shortcut-key-ornament-color`
+  - 新增 `shortcut-key-sunny-color`
+  - 新增 `shortcut-key-shadow-color`
+  - 新增 `shortcut-key-border`
+  - 并让 `render-key` 统一使用这些变量
+
+- 在 `TeXmacs/packages/miscellaneous/shortcut-editor.ts` 中，进一步把快捷键预览区的背景一起纳入调色
+  - 新增 `bg-color`
+  - 新增 `canvas-color`
+  - 在 dark 风格下，让预览区背景更接近右侧 `Command` 输入框的 `#2c2c2c`
+
+- 在 `TeXmacs/misc/themes/liii-night.css` 中，尝试去掉 Qt 层输入框和列表控件的浅色边框
+  - `QLineEdit` 的 `border` 从 `1px solid #e0e0e0` 改成了 `1px solid none`
+  - `QListView/QTableView` 的 `border` 从 `1px solid #e0e0e0` 改成了 `1px solid none`
+
+本次新增修改：
+
+- 将 `shortcut-editor.ts` 中 dark 分支的 `bg-color/canvas-color` 和键帽 ornament 颜色，继续向 `Command` 输入框靠拢
+- 目标不是只改键帽本身，而是让整个 `Shortcut` 预览区看起来更像一个 dark 输入区，而不是一块独立的深色小画布
+
+### Why
+
+最开始的问题不是单一的“键帽颜色不对”，而是三层样式叠加在一起：
+
+- `Command` 是 Qt 的 `QLineEdit`，主要受 `liii-night.css` 控制
+- `Shortcut` 是嵌入式 `texmacs-input`，实际是一个 TeXmacs 文档编辑区
+- `preview-shortcut` 最终通过 `tmdoc-key -> render-key` 来渲染按键块
+
+所以如果只改 Qt 的 CSS，`Shortcut` 预览区不会完全跟着变；如果只改 `shortcut-editor.ts`，但没有让 `texmacs-input` 进入 dark style，颜色分支也不会生效。
+
+### How
+
+`shortcut-widgets.scm` 里的核心修改是给 `texmacs-input` 动态选择 style：
+
+```scheme
+(define (shortcut-editor-style)
+  (if (== (get-preference "gui theme") "liii-night")
+      `(style (tuple "generic" "dark" "shortcut-editor"))
+      `(style (tuple "generic" "shortcut-editor"))))
+```
+
+然后把原来的：
+
+```scheme
+(texmacs-input `(document (preview-shortcut ,(global-ref u :sh)))
+               `(style (tuple "generic" "shortcut-editor")) u)
+```
+
+改成：
+
+```scheme
+(texmacs-input `(document (preview-shortcut ,(global-ref u :sh)))
+               (shortcut-editor-style) u)
+```
+
+`shortcut-editor.ts` 里的核心修改是让 `render-key` 不再直接写死浅色值，而是走一组中间变量：
+
+```scheme
+<assign|shortcut-editor-field-color|...>
+<assign|shortcut-editor-light-border|...>
+<assign|shortcut-editor-dark-border|...>
+<assign|bg-color|<value|shortcut-editor-field-color>>
+<assign|canvas-color|<value|shortcut-editor-field-color>>
+<assign|shortcut-key-ornament-color|<value|shortcut-editor-field-color>>
+...
+```
+
+最后 `render-key` 统一从这些变量里取色：
+
+```scheme
+<assign|render-key|<macro|key|...>>
+```
+
+### 当前定位
+
+目前已经确认两类问题来源不同：
+
+- 左侧列表、右侧 `Command` 输入框周围的浅色边，主要来自 Qt/CSS 层
+- `Shortcut` 预览区上下的浅色横线，不是 `shortcut-editor.ts` 的键帽颜色造成的，而更像是嵌入式 `texmacs-input` 自带的上下留白
+
+已经定位到：
+
+- `TeXmacs/progs/kernel/gui/menu-widget.scm` 的 `attach-resize` 会给嵌入文档附加
+  - `page-top = 2px`
+  - `page-bot = 2px`
+  - `page-screen-top = 2px`
+  - `page-screen-bot = 2px`
+
+- `src/Texmacs/Window/tm_window.cpp` 的 `enrich_embedded_document` 里也会给嵌入文档设置
+  - `PAGE_SCREEN_TOP = 2px`
+  - `PAGE_SCREEN_BOT = 2px`
+
+这说明 `Shortcut` 预览区上下的浅色横线，更可能是嵌入式文档的 page/screen margin 问题，而不是当前色板本身的问题。后续如果要继续处理，方向应该是把这部分上下 margin 压到 `0px`，而不是继续单独调键帽颜色。


### PR DESCRIPTION
<img width="949" height="400" alt="image" src="https://github.com/user-attachments/assets/1aa5794c-69e5-4e46-8f25-b49fdfc0e894" />
